### PR TITLE
Implement Stage 1: parsers, data models, and pre-processor via TDD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 requires-python = ">=3.13, < 3.14"
 dependencies = [
     "defusedxml >= 0.7.1, < 1",
+    "httpx[trio] >= 0.28, < 1",
     "trio >= 0.33.0, < 1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "defusedxml >= 0.7.1, < 1",
     "httpx[trio] >= 0.28, < 1",
     "trio >= 0.33.0, < 1",
+    "yt-dlp >= 2024.1.0",
 ]
 
 [project.scripts]

--- a/src/auto_lorebook/llm/__init__.py
+++ b/src/auto_lorebook/llm/__init__.py
@@ -1,0 +1,1 @@
+"""LLM client and pipeline stage implementations."""

--- a/src/auto_lorebook/llm/client.py
+++ b/src/auto_lorebook/llm/client.py
@@ -1,0 +1,97 @@
+"""Async HTTP client for the OpenRouter /chat/completions API."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+
+class OpenRouterError(RuntimeError):
+    """Raised when the OpenRouter API returns an error response."""
+
+
+class OpenRouterClient:
+    """Async HTTP client for the OpenRouter /chat/completions API.
+
+    Uses httpx with an optional injected transport for testing.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str = "https://openrouter.ai/api/v1",
+        _transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        """Initialise the client.
+
+        :param api_key: OpenRouter API key for the Authorization header.
+        :param base_url: Base URL for the OpenRouter API.
+        :param _transport: Optional custom transport (for testing only).
+        """
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._transport = _transport
+
+    async def chat(
+        self,
+        model: str,
+        messages: list[dict[str, str]],
+        *,
+        temperature: float = 0.2,
+        max_tokens: int | None = None,
+        response_format: dict[str, str] | None = None,
+    ) -> str:
+        """Send a chat completion request and return the response text.
+
+        :param model: Model identifier string.
+        :param messages: List of role/content message dicts.
+        :param temperature: Sampling temperature.
+        :param max_tokens: Optional token limit for the response.
+        :param response_format: Optional response format dict (e.g. JSON mode).
+        :return: Assistant message content string.
+        :raises OpenRouterError: If the API returns a non-2xx response.
+        """
+        payload: dict[str, object] = {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+        }
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if response_format is not None:
+            payload["response_format"] = response_format
+
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        url = f"{self._base_url}/chat/completions"
+
+        async with httpx.AsyncClient(transport=self._transport) as http:
+            response = await http.post(url, json=payload, headers=headers)
+
+        if response.status_code >= 400:
+            msg = f"OpenRouter API error {response.status_code}: {response.text}"
+            raise OpenRouterError(msg)
+
+        data = response.json()
+        return str(data["choices"][0]["message"]["content"])
+
+
+def openrouter_client_from_env(
+    *,
+    base_url: str = "https://openrouter.ai/api/v1",
+) -> OpenRouterClient:
+    """Create an OpenRouterClient using the OPENROUTER_API_KEY env variable.
+
+    :param base_url: Base URL for the OpenRouter API.
+    :return: Configured OpenRouterClient.
+    :raises RuntimeError: If OPENROUTER_API_KEY is not set in the environment.
+    """
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if api_key is None:
+        msg = "OPENROUTER_API_KEY environment variable is not set"
+        raise RuntimeError(msg)
+    return OpenRouterClient(api_key, base_url=base_url)

--- a/src/auto_lorebook/llm/preprocessor.py
+++ b/src/auto_lorebook/llm/preprocessor.py
@@ -1,0 +1,157 @@
+"""Stage 1 pre-processor: maps transcript chunks to existing wiki entities."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from typing import TYPE_CHECKING
+
+from auto_lorebook.models import (
+    PreprocessorOutput,
+    SectionMapping,
+    SourceMetadata,
+    TranscriptChunk,
+    WikiExcerpt,
+)
+
+if TYPE_CHECKING:
+    from auto_lorebook.llm.client import OpenRouterClient
+
+DEFAULT_PREPROCESSOR_MODEL = "anthropic/claude-3.5-haiku"
+
+_SYSTEM_PROMPT = textwrap.dedent("""\
+    You are a lore analysis assistant. You will receive numbered transcript sections
+    and a set of existing wiki pages. Your job is to:
+
+    1. For each transcript section, identify which wiki entities it relates to and
+       provide a brief relevant excerpt from that wiki page.
+    2. Identify any entity names in the transcript that do not appear in any wiki page
+       — these are potentially new entities worth creating pages for.
+
+    Respond ONLY with valid JSON matching this exact schema:
+    {
+      "section_mappings": [
+        {
+          "chunk_index": <int>,
+          "relevant_entities": [
+            {"entity_name": <str>, "category": <str>, "excerpt": <str>}
+          ]
+        }
+      ],
+      "new_entity_mentions": [<str>, ...]
+    }
+""")
+
+
+def _build_user_message(
+    chunks: list[TranscriptChunk], wiki_pages: dict[str, str]
+) -> str:
+    """Format the user message with transcript sections and wiki page content.
+
+    :param chunks: Transcript chunks to analyse.
+    :param wiki_pages: Mapping of wiki page title → markdown content.
+    :return: Formatted user message string.
+    """
+    lines: list[str] = ["## Transcript Sections"]
+    for i, chunk in enumerate(chunks):
+        lines.append(f"[{i}] {chunk.text}")
+
+    if wiki_pages:
+        lines.append("\n## Wiki Pages")
+        for title, content in wiki_pages.items():
+            lines.extend((f"\n### {title}", content))
+    else:
+        lines.append("\n## Wiki Pages\n(none — this is a fresh wiki)")
+
+    return "\n".join(lines)
+
+
+def _parse_response(raw: str) -> PreprocessorOutput:
+    """Parse the LLM JSON response into a PreprocessorOutput.
+
+    :param raw: Raw JSON string from the LLM.
+    :return: Parsed PreprocessorOutput.
+    :raises ValueError: If the JSON is malformed or missing required fields.
+    """
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        msg = f"pre-processor response is not valid JSON: {exc}"
+        raise ValueError(msg) from exc
+
+    if "section_mappings" not in data or "new_entity_mentions" not in data:
+        msg = (
+            "pre-processor response missing required keys:"
+            " 'section_mappings' and/or 'new_entity_mentions'"
+        )
+        raise ValueError(msg)
+
+    dummy_source = SourceMetadata(filename="<preprocessor>")
+    section_mappings: list[SectionMapping] = []
+
+    for entry in data["section_mappings"]:
+        chunk_index = int(entry["chunk_index"])
+        excerpts = [
+            WikiExcerpt(
+                entity_name=e["entity_name"],
+                category=e["category"],
+                content=e["excerpt"],
+            )
+            for e in entry.get("relevant_entities", [])
+        ]
+        # Placeholder chunk — replaced with real chunk by index after parsing.
+        placeholder_chunk = TranscriptChunk(
+            text=f"<chunk {chunk_index}>",
+            source=dummy_source,
+        )
+        section_mappings.append(
+            SectionMapping(chunk=placeholder_chunk, relevant_wiki_excerpts=excerpts)
+        )
+
+    return PreprocessorOutput(
+        section_mappings=section_mappings,
+        new_entity_mentions=list(data["new_entity_mentions"]),
+    )
+
+
+async def run_preprocessor(
+    *,
+    client: OpenRouterClient,
+    chunks: list[TranscriptChunk],
+    wiki_pages: dict[str, str],
+    model: str = DEFAULT_PREPROCESSOR_MODEL,
+) -> PreprocessorOutput:
+    """Run the Stage 1 pre-processor against the transcript chunks.
+
+    Sends the full transcript and all wiki pages to the LLM in a single call,
+    asking it to map sections to existing wiki entities and flag new ones.
+
+    :param client: OpenRouterClient to use for the LLM call.
+    :param chunks: Parsed transcript chunks to analyse.
+    :param wiki_pages: Mapping of wiki page title → markdown content.
+    :param model: Model identifier to use for the pre-processor stage.
+    :return: PreprocessorOutput with section mappings and new entity mentions.
+    :raises ValueError: If the LLM response cannot be parsed as valid JSON.
+    """
+    user_message = _build_user_message(chunks, wiki_pages)
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": user_message},
+    ]
+    raw = await client.chat(
+        model,
+        messages,
+        temperature=0.1,
+        response_format={"type": "json_object"},
+    )
+    output = _parse_response(raw)
+
+    # Replace placeholder chunks with the actual input chunks by index.
+    for i, mapping in enumerate(output.section_mappings):
+        if i < len(chunks):
+            output.section_mappings[i] = SectionMapping(
+                chunk=chunks[i],
+                relevant_wiki_excerpts=mapping.relevant_wiki_excerpts,
+            )
+
+    return output

--- a/src/auto_lorebook/models.py
+++ b/src/auto_lorebook/models.py
@@ -1,0 +1,89 @@
+"""Core data models for the Auto-Lorebook pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SourceMetadata:
+    """Metadata about the source of ingested lore content.
+
+    :param filename: Original filename of the source.
+    :param source_url: Optional URL (YouTube video or web page) for citations.
+    """
+
+    filename: str
+    source_url: str | None = None
+
+
+@dataclass
+class SrtBlock:
+    """A single subtitle block parsed from an SRT file.
+
+    :param index: Sequential block number (1-based).
+    :param start_seconds: Start time in seconds.
+    :param end_seconds: End time in seconds.
+    :param text: Dialogue/narration text, whitespace-stripped.
+    """
+
+    index: int
+    start_seconds: float
+    end_seconds: float
+    text: str
+
+
+@dataclass
+class TranscriptChunk:
+    """A logical chunk of transcript text, with optional timestamps.
+
+    Timestamps are present for SRT-sourced chunks; None for plain text.
+
+    :param text: The chunk's lore text.
+    :param source: Metadata about where this chunk came from.
+    :param start_seconds: Optional start timestamp (SRT only).
+    :param end_seconds: Optional end timestamp (SRT only).
+    """
+
+    text: str
+    source: SourceMetadata
+    start_seconds: float | None = None
+    end_seconds: float | None = None
+
+
+@dataclass
+class WikiExcerpt:
+    """A relevant excerpt from an existing wiki page.
+
+    :param entity_name: Name of the wiki entity (e.g. "Aldara").
+    :param category: Entity category (e.g. "locations", "characters").
+    :param content: The relevant excerpt text from the wiki page.
+    """
+
+    entity_name: str
+    category: str
+    content: str
+
+
+@dataclass
+class SectionMapping:
+    """Maps a transcript chunk to relevant existing wiki excerpts.
+
+    :param chunk: The transcript chunk being mapped.
+    :param relevant_wiki_excerpts: Wiki excerpts relevant to this chunk.
+    """
+
+    chunk: TranscriptChunk
+    relevant_wiki_excerpts: list[WikiExcerpt] = field(default_factory=list)
+
+
+@dataclass
+class PreprocessorOutput:
+    """Output from the Stage 1 pre-processor LLM call.
+
+    :param section_mappings: Each chunk mapped to relevant wiki excerpts.
+    :param new_entity_mentions: Entity names not found in the existing wiki.
+    """
+
+    section_mappings: list[SectionMapping]
+    new_entity_mentions: list[str]

--- a/src/auto_lorebook/parsers/__init__.py
+++ b/src/auto_lorebook/parsers/__init__.py
@@ -1,0 +1,1 @@
+"""Source file parsers for the Auto-Lorebook ingestion pipeline."""

--- a/src/auto_lorebook/parsers/srt.py
+++ b/src/auto_lorebook/parsers/srt.py
@@ -1,0 +1,161 @@
+"""SRT subtitle file parser."""
+
+from __future__ import annotations
+
+import html
+import re
+from typing import TYPE_CHECKING
+
+from auto_lorebook.models import SrtBlock, TranscriptChunk
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from auto_lorebook.models import SourceMetadata
+
+_TIMESTAMP_RE = re.compile(
+    r"(\d{2}):(\d{2}):(\d{2}),(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2}),(\d{3})"
+)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_MIN_LINES_PER_BLOCK = 2
+
+
+class SrtParseError(ValueError):
+    """Raised when an SRT file cannot be parsed."""
+
+
+def srt_timestamp_to_seconds(ts: str) -> float:
+    """Convert an SRT timestamp string to total seconds.
+
+    :param ts: Timestamp string in HH:MM:SS,mmm format.
+    :return: Total seconds as a float.
+    :raises SrtParseError: If the timestamp format is invalid.
+    """
+    m = re.fullmatch(r"(\d{2}):(\d{2}):(\d{2}),(\d{3})", ts.strip())
+    if m is None:
+        msg = f"Invalid SRT timestamp: {ts!r}"
+        raise SrtParseError(msg)
+    hours, minutes, seconds, millis = (int(g) for g in m.groups())
+    return hours * 3600.0 + minutes * 60.0 + seconds + millis / 1000.0
+
+
+def _clean_text(raw: str) -> str:
+    """Strip HTML tags and decode HTML entities from subtitle text.
+
+    :param raw: Raw text from an SRT block.
+    :return: Cleaned plain-text string.
+    """
+    stripped = _HTML_TAG_RE.sub("", raw)
+    # Two passes to handle double-encoded entities like &amp;amp; → &amp; → &
+    once = html.unescape(stripped)
+    return html.unescape(once)
+
+
+def parse_srt(content: str) -> list[SrtBlock]:
+    """Parse SRT content string into a list of SrtBlocks.
+
+    :param content: Raw SRT file content.
+    :return: List of parsed SrtBlock instances.
+    :raises SrtParseError: If a timestamp line cannot be parsed.
+    """
+    # Normalize: strip BOM, normalize line endings
+    content = content.lstrip("\ufeff").replace("\r\n", "\n").replace("\r", "\n")
+
+    blocks: list[SrtBlock] = []
+    segments = re.split(r"\n{2,}", content.strip())
+
+    for segment in segments:
+        segment = segment.strip()  # noqa: PLW2901
+        if not segment:
+            continue
+        lines = segment.splitlines()
+        if len(lines) < _MIN_LINES_PER_BLOCK:
+            continue
+
+        # Line 0: sequence index
+        try:
+            index = int(lines[0].strip())
+        except ValueError:
+            continue  # skip malformed segment
+
+        # Line 1: timestamps
+        ts_line = lines[1].strip()
+        m = _TIMESTAMP_RE.fullmatch(ts_line)
+        if m is None:
+            msg = f"Invalid SRT timestamp line: {ts_line!r}"
+            raise SrtParseError(msg)
+        h1, m1, s1, ms1, h2, m2, s2, ms2 = (int(g) for g in m.groups())
+        start = h1 * 3600.0 + m1 * 60.0 + s1 + ms1 / 1000.0
+        end = h2 * 3600.0 + m2 * 60.0 + s2 + ms2 / 1000.0
+
+        # Remaining lines: text
+        raw_text = " ".join(lines[2:])
+        text = _clean_text(raw_text).strip()
+        if not text:
+            continue
+
+        blocks.append(
+            SrtBlock(index=index, start_seconds=start, end_seconds=end, text=text)
+        )
+
+    return blocks
+
+
+def parse_srt_file(path: Path) -> list[SrtBlock]:
+    """Read and parse an SRT file from disk.
+
+    :param path: Path to the .srt file.
+    :return: List of parsed SrtBlock instances.
+    :raises SrtParseError: If the file content cannot be parsed.
+    """
+    return parse_srt(path.read_text(encoding="utf-8"))
+
+
+def chunk_srt_blocks(
+    blocks: list[SrtBlock],
+    source: SourceMetadata,
+    *,
+    max_gap_seconds: float = 3.0,
+) -> list[TranscriptChunk]:
+    """Group SRT blocks into logical transcript chunks.
+
+    Consecutive blocks whose gap is within ``max_gap_seconds`` are merged into
+    one chunk. A large silence gap starts a new chunk.
+
+    :param blocks: Parsed SRT blocks.
+    :param source: Source metadata to attach to each chunk.
+    :param max_gap_seconds: Max silence gap before starting a new chunk.
+    :return: List of TranscriptChunk instances.
+    """
+    if not blocks:
+        return []
+
+    chunks: list[TranscriptChunk] = []
+    group: list[SrtBlock] = [blocks[0]]
+
+    for block in blocks[1:]:
+        gap = block.start_seconds - group[-1].end_seconds
+        if gap <= max_gap_seconds:
+            group.append(block)
+        else:
+            chunks.append(_group_to_chunk(group, source))
+            group = [block]
+
+    chunks.append(_group_to_chunk(group, source))
+    return chunks
+
+
+def _group_to_chunk(group: list[SrtBlock], source: SourceMetadata) -> TranscriptChunk:
+    """Convert a list of SRT blocks into a single TranscriptChunk.
+
+    :param group: Non-empty list of consecutive SRT blocks.
+    :param source: Source metadata for the chunk.
+    :return: TranscriptChunk spanning the group's time range.
+    """
+    text = " ".join(b.text for b in group)
+    return TranscriptChunk(
+        text=text,
+        source=source,
+        start_seconds=group[0].start_seconds,
+        end_seconds=group[-1].end_seconds,
+    )

--- a/src/auto_lorebook/parsers/text.py
+++ b/src/auto_lorebook/parsers/text.py
@@ -1,0 +1,47 @@
+"""Plain text and markdown parser."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from auto_lorebook.models import SourceMetadata, TranscriptChunk
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def parse_text(content: str, source: SourceMetadata) -> list[TranscriptChunk]:
+    """Parse plain-text or markdown content into transcript chunks.
+
+    Splits on blank lines (double newlines). Single newlines within a paragraph
+    are kept as spaces. Empty paragraphs are skipped.
+
+    :param content: Raw text content.
+    :param source: Source metadata to attach to each chunk.
+    :return: List of TranscriptChunk instances (no timestamps).
+    """
+    if not content.strip():
+        return []
+
+    raw_paragraphs = re.split(r"\n{2,}", content)
+    chunks: list[TranscriptChunk] = []
+
+    for raw in raw_paragraphs:
+        # Join internal single newlines with a space, then strip
+        text = " ".join(raw.splitlines()).strip()
+        if not text:
+            continue
+        chunks.append(TranscriptChunk(text=text, source=source))
+
+    return chunks
+
+
+def parse_text_file(path: Path, source: SourceMetadata) -> list[TranscriptChunk]:
+    """Read and parse a plain-text or markdown file from disk.
+
+    :param path: Path to the text file.
+    :param source: Source metadata to attach to each chunk.
+    :return: List of TranscriptChunk instances.
+    """
+    return parse_text(path.read_text(encoding="utf-8"), source)

--- a/src/auto_lorebook/parsers/youtube.py
+++ b/src/auto_lorebook/parsers/youtube.py
@@ -1,0 +1,99 @@
+"""YouTube subtitle downloader via yt-dlp."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yt_dlp
+
+from auto_lorebook.models import SourceMetadata
+
+_YOUTUBE_HOSTS = frozenset({
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "youtu.be",
+})
+
+
+class YouTubeSubtitleError(RuntimeError):
+    """Raised when YouTube subtitles cannot be downloaded or found."""
+
+
+def _validate_youtube_url(url: str) -> None:
+    """Raise ValueError if url is not a recognised YouTube URL.
+
+    :param url: URL string to validate.
+    :raises ValueError: If url is not a YouTube URL.
+    """
+    try:
+        parsed = urlparse(url)
+        host = parsed.netloc.lower()
+    except Exception:  # noqa: BLE001
+        host = ""
+    if host not in _YOUTUBE_HOSTS:
+        msg = f"Not a YouTube URL: {url!r}"
+        raise ValueError(msg)
+
+
+def _yt_dlp_download(url: str, out_dir: Path, lang: str) -> None:
+    """Invoke yt-dlp to download subtitles into out_dir.
+
+    Downloads both manual and auto-generated subtitles in SRT format.
+
+    :param url: YouTube URL.
+    :param out_dir: Directory to write subtitle files into.
+    :param lang: Subtitle language code.
+    """
+    ydl_opts = {
+        "writesubtitles": True,
+        "writeautomaticsub": True,
+        "subtitleslangs": [lang],
+        "subtitlesformat": "srt",
+        "skip_download": True,
+        "outtmpl": str(out_dir / "%(id)s.%(ext)s"),
+        "quiet": True,
+        "no_warnings": True,
+    }
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        ydl.download([url])
+
+
+def fetch_youtube_transcript(
+    url: str,
+    *,
+    lang: str = "en",
+) -> tuple[str, SourceMetadata]:
+    """Download YouTube subtitles and return SRT content with source metadata.
+
+    Downloads manual subtitles if available, falling back to auto-generated
+    captions. The returned SRT content can be passed directly to
+    ``parse_srt()`` for further processing.
+
+    :param url: YouTube video URL (youtube.com or youtu.be).
+    :param lang: Subtitle language code (default: ``"en"``).
+    :return: Tuple of ``(srt_content, SourceMetadata)``.
+    :raises ValueError: If the URL is not a recognised YouTube URL.
+    :raises YouTubeSubtitleError: If no subtitles are found or download fails.
+    """
+    _validate_youtube_url(url)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = Path(tmp)
+        _yt_dlp_download(url, out_dir, lang)
+
+        # yt-dlp names subtitle files as VIDEO_ID.LANG.srt
+        srt_files = sorted(out_dir.glob(f"*.{lang}.srt"))
+        if not srt_files:
+            # Fallback: any .srt file in the directory
+            srt_files = sorted(out_dir.glob("*.srt"))
+        if not srt_files:
+            msg = f"No {lang!r} subtitles found for {url!r}"
+            raise YouTubeSubtitleError(msg)
+
+        content = srt_files[0].read_text(encoding="utf-8")
+        filename = srt_files[0].name
+
+    return content, SourceMetadata(filename=filename, source_url=url)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,197 @@
+"""Tests for the OpenRouter async HTTP client."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from auto_lorebook.llm.client import (
+    OpenRouterClient,
+    OpenRouterError,
+    openrouter_client_from_env,
+)
+
+FAKE_API_KEY = "test-key-123"
+BASE_URL = "https://openrouter.ai/api/v1"
+_USER_HI = [{"role": "user", "content": "Hi"}]
+
+
+def _make_response(
+    content: str, model: str = "test-model", status: int = 200
+) -> httpx.Response:
+    """Build a mock httpx.Response for the chat completions endpoint."""
+    body = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "model": model,
+        "choices": [{"message": {"role": "assistant", "content": content}}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    return httpx.Response(status_code=status, json=body)
+
+
+def _make_error_response(
+    status: int, message: str = "Rate limit exceeded"
+) -> httpx.Response:
+    """Build a mock error httpx.Response."""
+    body = {"error": {"message": message, "type": "rate_limit_error"}}
+    return httpx.Response(status_code=status, json=body)
+
+
+def _make_client(handler: httpx.MockTransport) -> OpenRouterClient:
+    """Return an OpenRouterClient backed by a mock transport."""
+    return OpenRouterClient(FAKE_API_KEY, base_url=BASE_URL, _transport=handler)
+
+
+@pytest.mark.trio
+async def test_chat_success_returns_content() -> None:
+    """Successful response returns the assistant message content string."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return _make_response("Hello from the LLM!")
+
+    client = _make_client(httpx.MockTransport(handler))
+    result = await client.chat("test-model", _USER_HI)
+    assert result == "Hello from the LLM!"
+
+
+@pytest.mark.trio
+async def test_chat_non_2xx_raises_error() -> None:
+    """Non-2xx responses raise OpenRouterError."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return _make_error_response(429)
+
+    client = _make_client(httpx.MockTransport(handler))
+    with pytest.raises(OpenRouterError):
+        await client.chat("test-model", _USER_HI)
+
+
+@pytest.mark.trio
+async def test_chat_sends_authorization_header() -> None:
+    """Request includes the Authorization: Bearer header."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return _make_response("ok")
+
+    client = _make_client(httpx.MockTransport(handler))
+    await client.chat("test-model", _USER_HI)
+    assert captured[0].headers["authorization"] == f"Bearer {FAKE_API_KEY}"
+
+
+@pytest.mark.trio
+async def test_chat_sends_model_in_body() -> None:
+    """Request body includes the requested model."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return _make_response("ok")
+
+    client = _make_client(httpx.MockTransport(handler))
+    await client.chat("my-model", _USER_HI)
+    body = json.loads(captured[0].content)
+    assert body["model"] == "my-model"
+
+
+@pytest.mark.trio
+async def test_chat_sends_messages_in_body() -> None:
+    """Request body includes the messages list."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return _make_response("ok")
+
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Tell me lore."},
+    ]
+    client = _make_client(httpx.MockTransport(handler))
+    await client.chat("test-model", messages)
+    body = json.loads(captured[0].content)
+    assert body["messages"] == messages
+
+
+@pytest.mark.trio
+async def test_chat_sends_temperature() -> None:
+    """Request body includes the temperature parameter."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return _make_response("ok")
+
+    client = _make_client(httpx.MockTransport(handler))
+    await client.chat("test-model", _USER_HI, temperature=0.5)
+    body = json.loads(captured[0].content)
+    assert body["temperature"] == pytest.approx(0.5)
+
+
+@pytest.mark.trio
+async def test_chat_sends_max_tokens_when_set() -> None:
+    """max_tokens is included in the request body when provided."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return _make_response("ok")
+
+    client = _make_client(httpx.MockTransport(handler))
+    await client.chat("test-model", _USER_HI, max_tokens=512)
+    body = json.loads(captured[0].content)
+    assert body["max_tokens"] == 512
+
+
+@pytest.mark.trio
+async def test_chat_omits_max_tokens_when_none() -> None:
+    """max_tokens is NOT in the request body when None."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return _make_response("ok")
+
+    client = _make_client(httpx.MockTransport(handler))
+    await client.chat("test-model", _USER_HI)
+    body = json.loads(captured[0].content)
+    assert "max_tokens" not in body
+
+
+@pytest.mark.trio
+async def test_chat_sends_response_format_when_provided() -> None:
+    """response_format is included in the body when given."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return _make_response("{}")
+
+    fmt = {"type": "json_object"}
+    client = _make_client(httpx.MockTransport(handler))
+    await client.chat("test-model", _USER_HI, response_format=fmt)
+    body = json.loads(captured[0].content)
+    assert body["response_format"] == fmt
+
+
+def test_openrouter_client_from_env_reads_key() -> None:
+    """openrouter_client_from_env creates a client from the env variable."""
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "env-key-456"}):
+        client = openrouter_client_from_env()
+    assert isinstance(client, OpenRouterClient)
+
+
+def test_openrouter_client_from_env_missing_key() -> None:
+    """openrouter_client_from_env raises RuntimeError if key is not set."""
+    env = {k: v for k, v in os.environ.items() if k != "OPENROUTER_API_KEY"}
+    with (
+        patch.dict(os.environ, env, clear=True),
+        pytest.raises(RuntimeError, match="OPENROUTER_API_KEY"),
+    ):
+        openrouter_client_from_env()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,113 @@
+"""Tests for core data models."""
+
+import pytest
+
+from auto_lorebook.models import (
+    PreprocessorOutput,
+    SectionMapping,
+    SourceMetadata,
+    SrtBlock,
+    TranscriptChunk,
+    WikiExcerpt,
+)
+
+
+def test_source_metadata_required_fields() -> None:
+    """SourceMetadata requires filename; source_url defaults to None."""
+    source = SourceMetadata(filename="notes.txt")
+    assert source.filename == "notes.txt"
+    assert source.source_url is None
+
+
+def test_source_metadata_with_url() -> None:
+    """SourceMetadata accepts an optional source_url."""
+    source = SourceMetadata(
+        filename="subs.en.srt",
+        source_url="https://youtube.com/watch?v=abc123",
+    )
+    assert source.source_url == "https://youtube.com/watch?v=abc123"
+
+
+def test_srt_block_fields() -> None:
+    """SrtBlock stores index, start/end seconds, and text."""
+    block = SrtBlock(index=1, start_seconds=0.0, end_seconds=1.5, text="Hello world")
+    assert block.index == 1
+    assert block.start_seconds == pytest.approx(0.0)
+    assert block.end_seconds == pytest.approx(1.5)
+    assert block.text == "Hello world"
+
+
+def test_transcript_chunk_minimal() -> None:
+    """TranscriptChunk requires text and source; timestamps default to None."""
+    source = SourceMetadata(filename="notes.txt")
+    chunk = TranscriptChunk(text="Some lore text.", source=source)
+    assert chunk.text == "Some lore text."
+    assert chunk.source is source
+    assert chunk.start_seconds is None
+    assert chunk.end_seconds is None
+
+
+def test_transcript_chunk_with_timestamps() -> None:
+    """TranscriptChunk accepts optional timestamps."""
+    source = SourceMetadata(filename="subs.srt")
+    chunk = TranscriptChunk(
+        text="The kingdom fell.",
+        source=source,
+        start_seconds=10.0,
+        end_seconds=12.5,
+    )
+    assert chunk.start_seconds == pytest.approx(10.0)
+    assert chunk.end_seconds == pytest.approx(12.5)
+
+
+def test_wiki_excerpt_fields() -> None:
+    """WikiExcerpt stores entity_name, category, and content."""
+    excerpt = WikiExcerpt(
+        entity_name="Aldara",
+        category="locations",
+        content="Aldara is a city in the north.",
+    )
+    assert excerpt.entity_name == "Aldara"
+    assert excerpt.category == "locations"
+    assert excerpt.content == "Aldara is a city in the north."
+
+
+def test_section_mapping_fields() -> None:
+    """SectionMapping stores chunk and list of wiki excerpts."""
+    source = SourceMetadata(filename="notes.txt")
+    chunk = TranscriptChunk(text="The city of Aldara burned.", source=source)
+    excerpt = WikiExcerpt(
+        entity_name="Aldara", category="locations", content="Aldara is a city."
+    )
+    mapping = SectionMapping(chunk=chunk, relevant_wiki_excerpts=[excerpt])
+    assert mapping.chunk is chunk
+    assert len(mapping.relevant_wiki_excerpts) == 1
+    assert mapping.relevant_wiki_excerpts[0] is excerpt
+
+
+def test_section_mapping_empty_excerpts() -> None:
+    """SectionMapping allows empty wiki excerpt list."""
+    source = SourceMetadata(filename="notes.txt")
+    chunk = TranscriptChunk(text="An unknown entity appeared.", source=source)
+    mapping = SectionMapping(chunk=chunk, relevant_wiki_excerpts=[])
+    assert mapping.relevant_wiki_excerpts == []
+
+
+def test_preprocessor_output_fields() -> None:
+    """PreprocessorOutput stores section_mappings and new_entity_mentions."""
+    source = SourceMetadata(filename="subs.srt")
+    chunk = TranscriptChunk(text="The Dragon Vex attacked.", source=source)
+    mapping = SectionMapping(chunk=chunk, relevant_wiki_excerpts=[])
+    output = PreprocessorOutput(
+        section_mappings=[mapping],
+        new_entity_mentions=["Dragon Vex"],
+    )
+    assert len(output.section_mappings) == 1
+    assert output.new_entity_mentions == ["Dragon Vex"]
+
+
+def test_preprocessor_output_empty() -> None:
+    """PreprocessorOutput can be constructed with empty lists."""
+    output = PreprocessorOutput(section_mappings=[], new_entity_mentions=[])
+    assert output.section_mappings == []
+    assert output.new_entity_mentions == []

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -1,0 +1,159 @@
+"""Tests for the Stage 1 pre-processor."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from auto_lorebook.llm.preprocessor import DEFAULT_PREPROCESSOR_MODEL, run_preprocessor
+from auto_lorebook.models import PreprocessorOutput, SourceMetadata, TranscriptChunk
+
+
+def _make_chunk(text: str, index: int = 0) -> TranscriptChunk:
+    source = SourceMetadata(filename="test.srt")
+    return TranscriptChunk(
+        text=text,
+        source=source,
+        start_seconds=float(index),
+        end_seconds=float(index + 1),
+    )
+
+
+def _make_client(response_json: dict) -> AsyncMock:  # type: ignore[type-arg]
+    """Return a mock OpenRouterClient whose chat() returns the given JSON."""
+    client = AsyncMock()
+    client.chat = AsyncMock(return_value=json.dumps(response_json))
+    return client
+
+
+def _valid_response(
+    chunks: list[TranscriptChunk],
+    *,
+    new_entities: list[str] | None = None,
+) -> dict:  # type: ignore[type-arg]
+    """Build a valid pre-processor JSON response for the given chunks."""
+    mappings = [
+        {"chunk_index": i, "relevant_entities": []}
+        for i in range(len(chunks))
+    ]
+    return {
+        "section_mappings": mappings,
+        "new_entity_mentions": new_entities or [],
+    }
+
+
+@pytest.mark.trio
+async def test_run_preprocessor_returns_output() -> None:
+    """Happy path: returns a PreprocessorOutput from a valid LLM response."""
+    chunks = [_make_chunk("The kingdom of Aldara.", 0)]
+    client = _make_client(_valid_response(chunks))
+    result = await run_preprocessor(client=client, chunks=chunks, wiki_pages={})
+    assert isinstance(result, PreprocessorOutput)
+
+
+@pytest.mark.trio
+async def test_run_preprocessor_empty_chunks() -> None:
+    """Empty chunk list returns PreprocessorOutput with empty mappings."""
+    client = _make_client({"section_mappings": [], "new_entity_mentions": []})
+    result = await run_preprocessor(client=client, chunks=[], wiki_pages={})
+    assert result.section_mappings == []
+    assert result.new_entity_mentions == []
+
+
+@pytest.mark.trio
+async def test_run_preprocessor_all_chunks_in_mappings() -> None:
+    """Every input chunk has a corresponding entry in section_mappings."""
+    chunks = [_make_chunk("Chunk one.", 0), _make_chunk("Chunk two.", 1)]
+    client = _make_client(_valid_response(chunks))
+    result = await run_preprocessor(client=client, chunks=chunks, wiki_pages={})
+    assert len(result.section_mappings) == len(chunks)
+
+
+@pytest.mark.trio
+async def test_run_preprocessor_new_entity_mentions() -> None:
+    """New entity mentions from the LLM response are included in output."""
+    chunks = [_make_chunk("The Dragon Vex attacked.", 0)]
+    client = _make_client(
+        _valid_response(chunks, new_entities=["Dragon Vex", "The North Keep"])
+    )
+    result = await run_preprocessor(client=client, chunks=chunks, wiki_pages={})
+    assert "Dragon Vex" in result.new_entity_mentions
+    assert "The North Keep" in result.new_entity_mentions
+
+
+@pytest.mark.trio
+async def test_run_preprocessor_wiki_excerpts_populated() -> None:
+    """Relevant wiki excerpts are parsed into SectionMapping objects."""
+    chunks = [_make_chunk("Aldara stands tall.", 0)]
+    response = {
+        "section_mappings": [
+            {
+                "chunk_index": 0,
+                "relevant_entities": [
+                    {
+                        "entity_name": "Aldara",
+                        "category": "locations",
+                        "excerpt": "Aldara is a city.",
+                    },
+                ],
+            }
+        ],
+        "new_entity_mentions": [],
+    }
+    client = _make_client(response)
+    result = await run_preprocessor(
+        client=client,
+        chunks=chunks,
+        wiki_pages={"Aldara": "# Aldara\nAldara is a city."},
+    )
+    assert len(result.section_mappings[0].relevant_wiki_excerpts) == 1
+    exc = result.section_mappings[0].relevant_wiki_excerpts[0]
+    assert exc.entity_name == "Aldara"
+    assert exc.category == "locations"
+
+
+@pytest.mark.trio
+async def test_run_preprocessor_uses_default_model() -> None:
+    """run_preprocessor uses DEFAULT_PREPROCESSOR_MODEL when model is not specified."""
+    chunks = [_make_chunk("Some text.", 0)]
+    client = _make_client(_valid_response(chunks))
+    await run_preprocessor(client=client, chunks=chunks, wiki_pages={})
+    client.chat.assert_called_once()
+    called_model = client.chat.call_args[0][0]
+    assert called_model == DEFAULT_PREPROCESSOR_MODEL
+
+
+@pytest.mark.trio
+async def test_run_preprocessor_respects_custom_model() -> None:
+    """run_preprocessor passes the custom model to the client."""
+    chunks = [_make_chunk("Some text.", 0)]
+    client = _make_client(_valid_response(chunks))
+    await run_preprocessor(
+        client=client,
+        chunks=chunks,
+        wiki_pages={},
+        model="google/gemini-2.0-flash",
+    )
+    called_model = client.chat.call_args[0][0]
+    assert called_model == "google/gemini-2.0-flash"
+
+
+@pytest.mark.trio
+async def test_run_preprocessor_malformed_json_raises() -> None:
+    """Malformed LLM JSON response raises ValueError."""
+    chunks = [_make_chunk("Text.", 0)]
+    client = AsyncMock()
+    client.chat = AsyncMock(return_value="not valid json {{{")
+    with pytest.raises(ValueError, match="pre-processor"):
+        await run_preprocessor(client=client, chunks=chunks, wiki_pages={})
+
+
+@pytest.mark.trio
+async def test_run_preprocessor_missing_key_raises() -> None:
+    """Response JSON missing required keys raises ValueError."""
+    chunks = [_make_chunk("Text.", 0)]
+    client = _make_client({"section_mappings": []})  # missing new_entity_mentions
+    with pytest.raises(ValueError, match="pre-processor"):
+        await run_preprocessor(client=client, chunks=chunks, wiki_pages={})

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -34,10 +34,7 @@ def _valid_response(
     new_entities: list[str] | None = None,
 ) -> dict:  # type: ignore[type-arg]
     """Build a valid pre-processor JSON response for the given chunks."""
-    mappings = [
-        {"chunk_index": i, "relevant_entities": []}
-        for i in range(len(chunks))
-    ]
+    mappings = [{"chunk_index": i, "relevant_entities": []} for i in range(len(chunks))]
     return {
         "section_mappings": mappings,
         "new_entity_mentions": new_entities or [],

--- a/tests/test_srt_parser.py
+++ b/tests/test_srt_parser.py
@@ -1,0 +1,218 @@
+"""Tests for the SRT subtitle file parser."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from auto_lorebook.models import SourceMetadata, SrtBlock
+from auto_lorebook.parsers.srt import (
+    SrtParseError,
+    chunk_srt_blocks,
+    parse_srt,
+    parse_srt_file,
+    srt_timestamp_to_seconds,
+)
+
+SIMPLE_SRT = textwrap.dedent("""\
+    1
+    00:00:00,000 --> 00:00:01,500
+    Hello world
+
+    2
+    00:00:02,000 --> 00:00:03,500
+    The kingdom of Aldara was founded long ago.
+""")
+
+MULTILINE_SRT = textwrap.dedent("""\
+    1
+    00:00:00,000 --> 00:00:02,000
+    The dragon flew
+    over the mountains.
+""")
+
+HTML_TAGS_SRT = textwrap.dedent("""\
+    1
+    00:00:00,000 --> 00:00:02,000
+    <i>The narrator spoke</i> about <b>the kingdom</b>.
+""")
+
+HTML_ENTITIES_SRT = textwrap.dedent("""\
+    1
+    00:00:00,000 --> 00:00:02,000
+    It&#39;s a &amp; b &amp;amp; c.
+""")
+
+WINDOWS_ENDINGS_SRT = "1\r\n00:00:00,000 --> 00:00:01,000\r\nHello.\r\n\r\n"
+
+BOM_SRT = "\ufeff" + SIMPLE_SRT
+
+MALFORMED_TIMESTAMP_SRT = textwrap.dedent("""\
+    1
+    00:00:00.000 -> 00:00:01.500
+    Bad timestamp format.
+""")
+
+
+# --- srt_timestamp_to_seconds ---
+
+
+def test_timestamp_to_seconds_basic() -> None:
+    """Convert HH:MM:SS,mmm to total seconds."""
+    assert srt_timestamp_to_seconds("00:00:01,000") == pytest.approx(1.0)
+
+
+def test_timestamp_to_seconds_minutes() -> None:
+    """Handles minutes correctly."""
+    assert srt_timestamp_to_seconds("00:01:00,000") == pytest.approx(60.0)
+
+
+def test_timestamp_to_seconds_hours() -> None:
+    """Handles hours correctly."""
+    assert srt_timestamp_to_seconds("01:00:00,000") == pytest.approx(3600.0)
+
+
+def test_timestamp_to_seconds_fractional() -> None:
+    """Milliseconds contribute fractional seconds."""
+    assert srt_timestamp_to_seconds("00:04:32,500") == pytest.approx(272.5)
+
+
+def test_timestamp_to_seconds_youtube_example() -> None:
+    """Matches YouTube &t= link format: 4m32s = 272s."""
+    assert srt_timestamp_to_seconds("00:04:32,000") == pytest.approx(272.0)
+
+
+# --- parse_srt ---
+
+
+def test_parse_srt_empty_string() -> None:
+    """Empty string returns empty list."""
+    assert parse_srt("") == []
+
+
+def test_parse_srt_single_block() -> None:
+    """Parses a single SRT block correctly."""
+    blocks = parse_srt(SIMPLE_SRT)
+    assert len(blocks) == 2
+    b = blocks[0]
+    assert b.index == 1
+    assert b.start_seconds == pytest.approx(0.0)
+    assert b.end_seconds == pytest.approx(1.5)
+    assert b.text == "Hello world"
+
+
+def test_parse_srt_multiple_blocks() -> None:
+    """Parses all blocks and preserves order."""
+    blocks = parse_srt(SIMPLE_SRT)
+    assert len(blocks) == 2
+    assert blocks[1].index == 2
+    assert blocks[1].text == "The kingdom of Aldara was founded long ago."
+
+
+def test_parse_srt_multiline_text() -> None:
+    """Multi-line dialogue is joined with a space."""
+    blocks = parse_srt(MULTILINE_SRT)
+    assert len(blocks) == 1
+    assert blocks[0].text == "The dragon flew over the mountains."
+
+
+def test_parse_srt_strips_html_tags() -> None:
+    """HTML tags like <i> and <b> are removed from text."""
+    blocks = parse_srt(HTML_TAGS_SRT)
+    assert blocks[0].text == "The narrator spoke about the kingdom."
+
+
+def test_parse_srt_html_entities() -> None:
+    """HTML entities like &#39; and &amp; are decoded."""
+    blocks = parse_srt(HTML_ENTITIES_SRT)
+    assert blocks[0].text == "It's a & b & c."
+
+
+def test_parse_srt_windows_line_endings() -> None:
+    """CRLF line endings are normalized before parsing."""
+    blocks = parse_srt(WINDOWS_ENDINGS_SRT)
+    assert len(blocks) == 1
+    assert blocks[0].text == "Hello."
+
+
+def test_parse_srt_bom() -> None:
+    """BOM character at file start is stripped."""
+    blocks = parse_srt(BOM_SRT)
+    assert len(blocks) == 2
+    assert blocks[0].index == 1
+
+
+def test_parse_srt_malformed_timestamp() -> None:
+    """Malformed timestamp raises SrtParseError."""
+    with pytest.raises(SrtParseError):
+        parse_srt(MALFORMED_TIMESTAMP_SRT)
+
+
+# --- parse_srt_file ---
+
+
+def test_parse_srt_file_reads_utf8(tmp_path: Path) -> None:
+    """parse_srt_file reads a UTF-8 .srt file from disk."""
+    srt_file = tmp_path / "test.srt"
+    srt_file.write_text(SIMPLE_SRT, encoding="utf-8")
+    blocks = parse_srt_file(srt_file)
+    assert len(blocks) == 2
+    assert blocks[0].text == "Hello world"
+
+
+# --- chunk_srt_blocks ---
+
+
+def test_chunk_srt_blocks_empty() -> None:
+    """Empty block list returns empty chunk list."""
+    source = SourceMetadata(filename="test.srt")
+    assert chunk_srt_blocks([], source) == []
+
+
+def test_chunk_srt_blocks_small_gap_merged() -> None:
+    """Blocks with a small gap are kept in one chunk."""
+    source = SourceMetadata(filename="test.srt")
+    blocks = [
+        SrtBlock(index=1, start_seconds=0.0, end_seconds=1.0, text="First."),
+        SrtBlock(index=2, start_seconds=1.5, end_seconds=2.5, text="Second."),
+    ]
+    chunks = chunk_srt_blocks(blocks, source, max_gap_seconds=3.0)
+    assert len(chunks) == 1
+    assert "First." in chunks[0].text
+    assert "Second." in chunks[0].text
+
+
+def test_chunk_srt_blocks_large_gap_splits() -> None:
+    """Blocks with a large gap produce separate chunks."""
+    source = SourceMetadata(filename="test.srt")
+    blocks = [
+        SrtBlock(index=1, start_seconds=0.0, end_seconds=1.0, text="First."),
+        SrtBlock(index=2, start_seconds=20.0, end_seconds=21.0, text="Second."),
+    ]
+    chunks = chunk_srt_blocks(blocks, source, max_gap_seconds=3.0)
+    assert len(chunks) == 2
+    assert chunks[0].text == "First."
+    assert chunks[1].text == "Second."
+
+
+def test_chunk_srt_blocks_timestamps() -> None:
+    """Chunk timestamps come from the first and last block in each group."""
+    source = SourceMetadata(filename="test.srt")
+    blocks = [
+        SrtBlock(index=1, start_seconds=5.0, end_seconds=6.0, text="A."),
+        SrtBlock(index=2, start_seconds=6.5, end_seconds=7.5, text="B."),
+    ]
+    chunks = chunk_srt_blocks(blocks, source, max_gap_seconds=3.0)
+    assert len(chunks) == 1
+    assert chunks[0].start_seconds == pytest.approx(5.0)
+    assert chunks[0].end_seconds == pytest.approx(7.5)
+
+
+def test_chunk_srt_blocks_source_propagated() -> None:
+    """Source metadata is propagated to each chunk."""
+    source = SourceMetadata(
+        filename="vid.srt", source_url="https://youtube.com/watch?v=abc"
+    )
+    blocks = [SrtBlock(index=1, start_seconds=0.0, end_seconds=1.0, text="Hi.")]
+    chunks = chunk_srt_blocks(blocks, source)
+    assert chunks[0].source is source

--- a/tests/test_text_parser.py
+++ b/tests/test_text_parser.py
@@ -1,0 +1,81 @@
+"""Tests for the plain text / markdown parser."""
+
+from pathlib import Path
+
+from auto_lorebook.models import SourceMetadata
+from auto_lorebook.parsers.text import parse_text, parse_text_file
+
+
+def _source(filename: str = "notes.txt") -> SourceMetadata:
+    return SourceMetadata(filename=filename)
+
+
+def test_parse_text_empty_string() -> None:
+    """Empty content returns an empty list."""
+    assert parse_text("", _source()) == []
+
+
+def test_parse_text_single_paragraph() -> None:
+    """A single paragraph becomes a single chunk."""
+    chunks = parse_text("The kingdom was founded long ago.", _source())
+    assert len(chunks) == 1
+    assert chunks[0].text == "The kingdom was founded long ago."
+
+
+def test_parse_text_multiple_paragraphs() -> None:
+    """Double newlines split text into multiple chunks."""
+    content = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
+    chunks = parse_text(content, _source())
+    assert len(chunks) == 3
+    assert chunks[0].text == "First paragraph."
+    assert chunks[1].text == "Second paragraph."
+    assert chunks[2].text == "Third paragraph."
+
+
+def test_parse_text_no_timestamps() -> None:
+    """Plain text chunks have no timestamps."""
+    chunks = parse_text("Some lore.", _source())
+    assert chunks[0].start_seconds is None
+    assert chunks[0].end_seconds is None
+
+
+def test_parse_text_source_propagated() -> None:
+    """Source metadata is attached to every chunk."""
+    source = SourceMetadata(filename="lore.md", source_url="https://example.com/lore")
+    chunks = parse_text("Paragraph one.\n\nParagraph two.", source)
+    assert all(c.source is source for c in chunks)
+
+
+def test_parse_text_strips_surrounding_whitespace() -> None:
+    """Leading/trailing whitespace on each paragraph is stripped."""
+    content = "  Hello world.  \n\n  Second.  "
+    chunks = parse_text(content, _source())
+    assert chunks[0].text == "Hello world."
+    assert chunks[1].text == "Second."
+
+
+def test_parse_text_ignores_blank_only_paragraphs() -> None:
+    """Paragraphs that are blank after stripping are skipped."""
+    content = "First.\n\n   \n\nSecond."
+    chunks = parse_text(content, _source())
+    assert len(chunks) == 2
+
+
+def test_parse_text_single_newline_not_split() -> None:
+    """Single newlines within a paragraph are preserved as spaces."""
+    content = "Line one.\nLine two."
+    chunks = parse_text(content, _source())
+    assert len(chunks) == 1
+    assert "Line one." in chunks[0].text
+    assert "Line two." in chunks[0].text
+
+
+def test_parse_text_file_reads_utf8(tmp_path: Path) -> None:
+    """parse_text_file reads a UTF-8 text file from disk."""
+    text_file = tmp_path / "notes.txt"
+    text_file.write_text("Magic exists here.\n\nDragons are real.", encoding="utf-8")
+    source = SourceMetadata(filename="notes.txt")
+    chunks = parse_text_file(text_file, source)
+    assert len(chunks) == 2
+    assert chunks[0].text == "Magic exists here."
+    assert chunks[1].text == "Dragons are real."

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -1,0 +1,162 @@
+"""Tests for the YouTube subtitle downloader."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from auto_lorebook.parsers.srt import parse_srt
+from auto_lorebook.parsers.youtube import (
+    YouTubeSubtitleError,
+    fetch_youtube_transcript,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# --- URL validation (tested via the public API) ---
+
+
+def test_fetch_accepts_standard_youtube_url() -> None:
+    """Standard youtube.com/watch URL is accepted without download error."""
+
+    def fake_download(_url: str, out_dir: Path, lang: str) -> None:
+        (out_dir / f"vid.{lang}.srt").write_text(SAMPLE_SRT, encoding="utf-8")
+
+    with patch("auto_lorebook.parsers.youtube._yt_dlp_download", fake_download):
+        fetch_youtube_transcript("https://www.youtube.com/watch?v=abc123")
+
+
+def test_fetch_accepts_short_youtu_be_url() -> None:
+    """Short youtu.be URL is accepted without error."""
+
+    def fake_download(_url: str, out_dir: Path, lang: str) -> None:
+        (out_dir / f"vid.{lang}.srt").write_text(SAMPLE_SRT, encoding="utf-8")
+
+    with patch("auto_lorebook.parsers.youtube._yt_dlp_download", fake_download):
+        fetch_youtube_transcript("https://youtu.be/abc123")
+
+
+def test_fetch_accepts_mobile_youtube_url() -> None:
+    """Mobile m.youtube.com URL is accepted without error."""
+
+    def fake_download(_url: str, out_dir: Path, lang: str) -> None:
+        (out_dir / f"vid.{lang}.srt").write_text(SAMPLE_SRT, encoding="utf-8")
+
+    with patch("auto_lorebook.parsers.youtube._yt_dlp_download", fake_download):
+        fetch_youtube_transcript("https://m.youtube.com/watch?v=abc123")
+
+
+def test_fetch_rejects_non_youtube_url() -> None:
+    """Non-YouTube URL raises ValueError before any download."""
+    with pytest.raises(ValueError, match="YouTube"):
+        fetch_youtube_transcript("https://vimeo.com/123456")
+
+
+def test_fetch_rejects_plain_text() -> None:
+    """Arbitrary string raises ValueError."""
+    with pytest.raises(ValueError, match="YouTube"):
+        fetch_youtube_transcript("not a url at all")
+
+
+def test_fetch_rejects_empty_string() -> None:
+    """Empty string raises ValueError."""
+    with pytest.raises(ValueError, match="YouTube"):
+        fetch_youtube_transcript("")
+
+
+# --- fetch_youtube_transcript ---
+
+SAMPLE_SRT = """\
+1
+00:00:00,000 --> 00:00:02,000
+Hello from YouTube.
+
+2
+00:00:02,500 --> 00:00:04,000
+This is a test subtitle.
+"""
+
+
+def _fake_srt_download(_url: str, out_dir: Path, lang: str) -> None:
+    """Write a fake SRT file simulating yt-dlp output."""
+    (out_dir / f"testvideo.{lang}.srt").write_text(SAMPLE_SRT, encoding="utf-8")
+
+
+def test_fetch_youtube_transcript_returns_srt_content() -> None:
+    """Returns the SRT content string when subtitles are found."""
+    with patch("auto_lorebook.parsers.youtube._yt_dlp_download", _fake_srt_download):
+        srt_content, _ = fetch_youtube_transcript(
+            "https://www.youtube.com/watch?v=testvideo"
+        )
+    assert "Hello from YouTube." in srt_content
+
+
+def test_fetch_youtube_transcript_source_metadata_url() -> None:
+    """Returned SourceMetadata carries the original YouTube URL."""
+    target_url = "https://www.youtube.com/watch?v=testvideo"
+    with patch("auto_lorebook.parsers.youtube._yt_dlp_download", _fake_srt_download):
+        _, source = fetch_youtube_transcript(target_url)
+    assert source.source_url == target_url
+
+
+def test_fetch_youtube_transcript_source_metadata_filename() -> None:
+    """Returned SourceMetadata filename matches the downloaded SRT filename."""
+    with patch("auto_lorebook.parsers.youtube._yt_dlp_download", _fake_srt_download):
+        _, source = fetch_youtube_transcript(
+            "https://www.youtube.com/watch?v=testvideo"
+        )
+    assert source.filename.endswith(".srt")
+
+
+def test_fetch_youtube_transcript_no_subtitles_raises() -> None:
+    """Raises YouTubeSubtitleError when yt-dlp writes no SRT files."""
+
+    def no_files(_url: str, _out_dir: Path, _lang: str) -> None:
+        pass  # writes nothing
+
+    with (
+        patch("auto_lorebook.parsers.youtube._yt_dlp_download", no_files),
+        pytest.raises(YouTubeSubtitleError),
+    ):
+        fetch_youtube_transcript("https://www.youtube.com/watch?v=nosubs")
+
+
+def test_fetch_youtube_transcript_passes_lang_to_downloader() -> None:
+    """The lang parameter is forwarded to _yt_dlp_download."""
+    received: list[str] = []
+
+    def capture_lang(_url: str, out_dir: Path, lang: str) -> None:
+        received.append(lang)
+        (out_dir / f"testvideo.{lang}.srt").write_text(SAMPLE_SRT, encoding="utf-8")
+
+    with patch("auto_lorebook.parsers.youtube._yt_dlp_download", capture_lang):
+        fetch_youtube_transcript("https://www.youtube.com/watch?v=testvideo", lang="fr")
+    assert received == ["fr"]
+
+
+def test_fetch_youtube_transcript_calls_downloader_with_url() -> None:
+    """The original URL is forwarded to _yt_dlp_download."""
+    received: list[str] = []
+
+    def capture_url(url: str, out_dir: Path, lang: str) -> None:
+        received.append(url)
+        (out_dir / f"testvideo.{lang}.srt").write_text(SAMPLE_SRT, encoding="utf-8")
+
+    target = "https://www.youtube.com/watch?v=testvideo"
+    with patch("auto_lorebook.parsers.youtube._yt_dlp_download", capture_url):
+        fetch_youtube_transcript(target)
+    assert received == [target]
+
+
+def test_fetch_youtube_transcript_integrates_with_srt_parser() -> None:
+    """The returned SRT content can be parsed by parse_srt."""
+    with patch("auto_lorebook.parsers.youtube._yt_dlp_download", _fake_srt_download):
+        srt_content, _ = fetch_youtube_transcript(
+            "https://www.youtube.com/watch?v=testvideo"
+        )
+    blocks = parse_srt(srt_content)
+    assert len(blocks) == 2
+    assert blocks[0].text == "Hello from YouTube."

--- a/uv.lock
+++ b/uv.lock
@@ -3,13 +3,25 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-03-31T19:09:45.105728066Z"
+exclude-newer = "2026-03-31T20:07:01.707326224Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-defusedxml = { timestamp = "2026-04-06T19:09:45.105740833Z", span = "P1D" }
-ruff = { timestamp = "2026-04-05T19:09:45.105750165Z", span = "P2D" }
-ty = { timestamp = "2026-04-06T19:09:45.105750652Z", span = "P1D" }
+defusedxml = { timestamp = "2026-04-06T20:07:01.707342471Z", span = "P1D" }
+ruff = { timestamp = "2026-04-05T20:07:01.707350925Z", span = "P2D" }
+ty = { timestamp = "2026-04-06T20:07:01.707351373Z", span = "P1D" }
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
 
 [[package]]
 name = "attrs"
@@ -25,6 +37,7 @@ name = "auto-lorebook"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },
+    { name = "httpx" },
     { name = "trio" },
 ]
 
@@ -44,6 +57,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1,<1" },
+    { name = "httpx", extras = ["trio"], specifier = ">=0.28,<1" },
     { name = "trio", specifier = ">=0.33.0,<1" },
 ]
 
@@ -247,6 +261,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/37/b4a87dff166dc0a5002e9d03fcb6ca8eeff048247b011b67f047e31122c9/gcovr-8.6.tar.gz", hash = "sha256:b2e7042abca9321cadbab8a06eb34d19f801b831557b28cdc30a029313de8b9e", size = 199997, upload-time = "2026-01-13T20:04:30.019Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/be/f722c843e7875c7cf92cf0e0c1604cddda55a70278c768c6327a78fdba79/gcovr-8.6-py3-none-any.whl", hash = "sha256:dbf9d87c38042752ad6f530aa8210427e22b526611bb7b7bfed0e81977d1f1ef", size = 254618, upload-time = "2026-01-13T20:04:28.15Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3,13 +3,13 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-03-31T20:07:01.707326224Z"
+exclude-newer = "2026-03-31T20:21:24.802906717Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-defusedxml = { timestamp = "2026-04-06T20:07:01.707342471Z", span = "P1D" }
-ruff = { timestamp = "2026-04-05T20:07:01.707350925Z", span = "P2D" }
-ty = { timestamp = "2026-04-06T20:07:01.707351373Z", span = "P1D" }
+defusedxml = { timestamp = "2026-04-06T20:21:24.802919488Z", span = "P1D" }
+ruff = { timestamp = "2026-04-05T20:21:24.802928822Z", span = "P2D" }
+ty = { timestamp = "2026-04-06T20:21:24.802929272Z", span = "P1D" }
 
 [[package]]
 name = "anyio"
@@ -39,6 +39,7 @@ dependencies = [
     { name = "defusedxml" },
     { name = "httpx" },
     { name = "trio" },
+    { name = "yt-dlp" },
 ]
 
 [package.dev-dependencies]
@@ -59,6 +60,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1,<1" },
     { name = "httpx", extras = ["trio"], specifier = ">=0.28,<1" },
     { name = "trio", specifier = ">=0.33.0,<1" },
+    { name = "yt-dlp", specifier = ">=2024.1.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -808,4 +810,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2026.3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/34/7c6b4e3f89cb6416d2cd7ab6dab141a1df97ab0fb22d15816db2c92148c9/yt_dlp-2026.3.17.tar.gz", hash = "sha256:ba7aa31d533f1ffccfe70e421596d7ca8ff0bf1398dc6bb658b7d9dec057d2c9", size = 3119221, upload-time = "2026-03-17T23:43:00.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/13/5093bcb954878e50f7217fd2ab94282b53934022e4e4a03265582da83bf5/yt_dlp-2026.3.17-py3-none-any.whl", hash = "sha256:32992db94303a8a5d211a183f2174834fe7f8c29d83ed2e7a324eae97a8f26d8", size = 3315134, upload-time = "2026-03-17T23:42:57.863Z" },
 ]


### PR DESCRIPTION
Adds the foundational components for the lore ingestion pipeline using
red/green TDD cycles:

- models.py: core dataclasses (SourceMetadata, SrtBlock, TranscriptChunk,
  WikiExcerpt, SectionMapping, PreprocessorOutput)
- parsers/srt.py: SRT subtitle parser with HTML/entity cleanup and
  block-to-chunk grouping
- parsers/text.py: plain-text/markdown paragraph splitter
- llm/client.py: async OpenRouter HTTP client (httpx + trio)
- llm/preprocessor.py: Stage 1 pre-processor prompt + JSON output parser

91 tests passing, ruff clean, ty clean.

https://claude.ai/code/session_01UgXbq9MVXDfPtSJudumi49