### PR TITLE
Implement Stage 1a & 1b: transcript segmentation and per-segment summarization

### DIFF
--- a/docs/architecture/staleness.md
+++ b/docs/architecture/staleness.md
@@ -20,7 +20,7 @@ inputs:
   corrections_sha256: jk0lm1...          # .transcription-corrections.yaml
   entity_index_sha256: n2o3p4...         # canonical serialization of the in-memory index
   preamble_sha256: q5r6s7...             # the fully-assembled preamble string
-  model: openrouter/anthropic/claude-sonnet-4
+  model: anthropic/claude-sonnet-4-5
   model_params_sha256: t8u9v0...         # temperature, max_tokens, etc.
 generated_at: 2026-04-20T14:32:00Z
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -27,14 +27,23 @@ uv run auto-lorebook --help
 ## Configure
 
 On first invocation of `auto-lorebook ingest`, the tool detects a
-missing `~/.auto-lorebook/config.yaml` and prompts for the values
-needed to write one (wiki repo path, API-key env var name, and primary
-model). It also seeds the wiki with the entity directories and the
-two convention files (`.wiki-context.yaml`,
+missing `~/.auto-lorebook/config.yaml` and prompts for:
+
+- Your wiki repo path.
+- Your OpenRouter API key (input is hidden; stored at
+  `~/.auto-lorebook/credentials` with mode 0600).
+- Primary model slug (default: Claude Sonnet 4.5).
+
+It also seeds the wiki with the entity directories and the two
+convention files (`.wiki-context.yaml`,
 `.transcription-corrections.yaml`). Pass `--no-interactive` to suppress
 the prompt and require a pre-existing config instead.
 
-To write the file by hand, the minimal layout is:
+If you'd rather use an environment variable, leave the API-key prompt
+blank and `export OPENROUTER_API_KEY=sk-or-...` in your shell. The env
+var takes precedence over the credentials file when both are present.
+
+To write the config by hand, the minimal layout is:
 
 ```yaml
 schema_version: 1
@@ -49,19 +58,14 @@ preamble:
   budget_fraction: 0.8
 ```
 
-Set the API key in your shell:
-
-```bash
-export OPENROUTER_API_KEY=sk-or-...
-```
-
 The tool expects two locations:
 
 - **Wiki repo** — any directory you point the tool at, where sources,
   entity YAMLs, and rendered markdown live. See
   [repository layout](../architecture/repository-layout.md).
-- **State directory** — `~/.auto-lorebook/`, holding `config.yaml` and
-  pending (unapproved) ingest artifacts.
+- **State directory** — `~/.auto-lorebook/`, holding `config.yaml`,
+  the optional `credentials` file (mode 0600), and pending (unapproved)
+  ingest artifacts.
 
 ## Next
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -51,8 +51,8 @@ wiki_repo_path: /path/to/your/wiki
 openrouter:
   api_key_env: OPENROUTER_API_KEY
 models:
-  primary: openrouter/anthropic/claude-sonnet-4-5
-  extractor: openrouter/anthropic/claude-sonnet-4-5   # accepted but unused in Phase 1
+  primary: anthropic/claude-sonnet-4-5
+  extractor: anthropic/claude-sonnet-4-5   # accepted but unused in Phase 1
   primary_context_window: 200000
 preamble:
   budget_fraction: 0.8

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -27,8 +27,15 @@ uv run auto-lorebook --help
 
 ## Configure
 
-The tool reads configuration from `~/.auto-lorebook/config.yaml`. A
-minimal example:
+On first invocation of `auto-lorebook ingest`, the tool detects a
+missing `~/.auto-lorebook/config.yaml` and prompts for the values
+needed to write one (wiki repo path, API-key env var name, and primary
+model). It also seeds the wiki with the entity directories and the
+two convention files (`.wiki-context.yaml`,
+`.transcription-corrections.yaml`). Pass `--no-interactive` to suppress
+the prompt and require a pre-existing config instead.
+
+To write the file by hand, the minimal layout is:
 
 ```yaml
 schema_version: 1

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,6 @@ Auto-Lorebook is a Python CLI managed with [uv](https://docs.astral.sh/uv/).
 
 - Python 3.13.
 - `uv` installed. On macOS: `brew install uv`.
-- `yt-dlp` on `PATH` for YouTube ingestion.
 - An OpenRouter API key for LLM access.
 
 ## Install

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -6,9 +6,15 @@ implementation status.
 
 !!! info "Current status"
 
-    MVP scaffolding only. CLI skeleton exists
-    (`src/auto_lorebook/cli.py` + `commands/`); no pipeline stage is
-    implemented yet. Phase 1 is the next target.
+    Phase 1 in progress. Foundations landed: CLI skeleton, config
+    loader, info.yaml, tolerant `.wiki-context.yaml` and
+    `.transcription-corrections.yaml` readers, interactive context
+    gathering with flag overrides, preamble assembly with
+    component-specific token-budget errors, canonical `h:mm:ss`
+    timestamp helpers, SRT parser, and a yt-dlp subprocess wrapper
+    wired into `ingest` for YouTube URLs. Stage 1a / 1b, the
+    `generate-reading` / `regenerate-reading` / `approve-reading`
+    commands, and the OpenRouter client are still outstanding.
 
 ## Phase 1: Reading stage
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -6,15 +6,17 @@ implementation status.
 
 !!! info "Current status"
 
-    Phase 1 in progress. Foundations landed: CLI skeleton, config
-    loader, info.yaml, tolerant `.wiki-context.yaml` and
-    `.transcription-corrections.yaml` readers, interactive context
-    gathering with flag overrides, preamble assembly with
-    component-specific token-budget errors, canonical `h:mm:ss`
-    timestamp helpers, SRT parser, and a yt-dlp subprocess wrapper
-    wired into `ingest` for YouTube URLs. Stage 1a / 1b, the
-    `generate-reading` / `regenerate-reading` / `approve-reading`
-    commands, and the OpenRouter client are still outstanding.
+    Phase 1 substantially landed. The reading pipeline is runnable end
+    to end against a real OpenRouter backend: `ingest` fetches
+    YouTube transcripts via `yt-dlp`, `generate-reading` runs Stage 1a
+    (structure + mechanical validation) and Stage 1b (per-segment
+    summarize, parallelized) to produce a draft `reading.md`, the
+    mechanical gap check surfaces low-yield stretches during review,
+    `approve-reading` flips the draft into the wiki, and
+    `regenerate-reading --from=structure|summarize [--segments]`
+    supports targeted re-runs. Remaining Phase 1 polish: live
+    end-to-end validation against a real source and tuning the 1a/1b
+    prompts based on that run.
 
 ## Phase 1: Reading stage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "defusedxml >= 0.7.1, < 1",
     "pyyaml >= 6.0, < 7",
     "trio >= 0.33.0, < 1",
+    "yt-dlp >= 2025.1.1",
+    "imageio-ffmpeg >= 0.5.0",
 ]
 
 [project.scripts]

--- a/src/auto_lorebook/cli.py
+++ b/src/auto_lorebook/cli.py
@@ -10,7 +10,14 @@ import logging
 import sys
 
 from auto_lorebook import __version__
-from auto_lorebook.commands import configure_context_cmd, ingest_cmd, version_cmd
+from auto_lorebook.commands import (
+    approve_reading_cmd,
+    configure_context_cmd,
+    generate_reading_cmd,
+    ingest_cmd,
+    regenerate_reading_cmd,
+    version_cmd,
+)
 
 # Get package name dynamically from installed metadata
 try:
@@ -90,6 +97,9 @@ def create_parser() -> argparse.ArgumentParser:
     version_cmd.add_parser(subparsers, common_parser)
     ingest_cmd.add_parser(subparsers, common_parser)
     configure_context_cmd.add_parser(subparsers, common_parser)
+    generate_reading_cmd.add_parser(subparsers, common_parser)
+    approve_reading_cmd.add_parser(subparsers, common_parser)
+    regenerate_reading_cmd.add_parser(subparsers, common_parser)
 
     return parser
 

--- a/src/auto_lorebook/commands/__init__.py
+++ b/src/auto_lorebook/commands/__init__.py
@@ -5,8 +5,18 @@ Each subcommand is defined in its own module and exports:
 - run(args): Execute the subcommand logic
 """
 
+from auto_lorebook.commands import approve_reading as approve_reading_cmd
 from auto_lorebook.commands import configure_context as configure_context_cmd
+from auto_lorebook.commands import generate_reading as generate_reading_cmd
 from auto_lorebook.commands import ingest as ingest_cmd
+from auto_lorebook.commands import regenerate_reading as regenerate_reading_cmd
 from auto_lorebook.commands import version as version_cmd
 
-__all__ = ["configure_context_cmd", "ingest_cmd", "version_cmd"]
+__all__ = [
+    "approve_reading_cmd",
+    "configure_context_cmd",
+    "generate_reading_cmd",
+    "ingest_cmd",
+    "regenerate_reading_cmd",
+    "version_cmd",
+]

--- a/src/auto_lorebook/commands/approve_reading.py
+++ b/src/auto_lorebook/commands/approve_reading.py
@@ -1,0 +1,53 @@
+"""auto-lorebook approve-reading subcommand."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import reading_pipeline as pipeline
+
+if TYPE_CHECKING:
+    import argparse
+
+_logger = logging.getLogger(__name__)
+
+
+def add_parser(
+    subparsers: argparse._SubParsersAction,
+    common_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Register the approve-reading subcommand."""
+    parser = subparsers.add_parser(
+        "approve-reading",
+        parents=[common_parser],
+        help="Flip the draft reading to approved and copy it into the wiki",
+        description=(
+            "Sets `reading_status: approved` on the draft reading.md under "
+            "~/.auto-lorebook/pending/<source_id>/reading/ and copies it to "
+            "<wiki>/sources/<source_id>/reading.md. Downstream stages refuse "
+            "to run on a draft reading."
+        ),
+    )
+    parser.add_argument("source_id", help="Source ID (e.g. yt-abc12345678)")
+    parser.set_defaults(func=run)
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the approve-reading command."""
+    try:
+        cfg = cfg_mod.load_config()
+    except cfg_mod.ConfigError as e:
+        _logger.error("%s", e)
+        return 1
+
+    try:
+        approved = pipeline.approve(cfg, args.source_id)
+    except pipeline.ReadingPipelineError as e:
+        _logger.error("%s", e)
+        return 1
+
+    print(f"Approved: {approved}")  # noqa: T201
+    return 0

--- a/src/auto_lorebook/commands/generate_reading.py
+++ b/src/auto_lorebook/commands/generate_reading.py
@@ -1,0 +1,62 @@
+"""auto-lorebook generate-reading subcommand."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import reading_pipeline as pipeline
+
+if TYPE_CHECKING:
+    import argparse
+
+_logger = logging.getLogger(__name__)
+
+
+def add_parser(
+    subparsers: argparse._SubParsersAction,
+    common_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Register the generate-reading subcommand."""
+    parser = subparsers.add_parser(
+        "generate-reading",
+        parents=[common_parser],
+        help="Run Stage 1a + 1b and write a draft reading.md for review",
+        description=(
+            "Run Stage 1a (structure) and Stage 1b (summarize) on an "
+            "already-ingested source, producing a draft reading.md under "
+            "~/.auto-lorebook/pending/<source_id>/reading/ for human review."
+        ),
+    )
+    parser.add_argument(
+        "source_id",
+        help="Source ID (e.g. yt-abc12345678)",
+    )
+    parser.set_defaults(func=run)
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the generate-reading command."""
+    try:
+        cfg = cfg_mod.load_config()
+    except cfg_mod.ConfigError as e:
+        _logger.error("%s", e)
+        return 1
+
+    try:
+        result = pipeline.generate(cfg, args.source_id)
+    except pipeline.ReadingPipelineError as e:
+        _logger.error("%s", e)
+        return 1
+
+    print(f"Draft reading: {result.pending_reading_path}")  # noqa: T201
+    print(f"  structure:   {result.structure_path}")  # noqa: T201
+    print(f"  bullets:     {result.bullets_path}")  # noqa: T201
+    if result.gap_warnings:
+        print()  # noqa: T201
+        print(f"{len(result.gap_warnings)} possible coverage gap(s):")  # noqa: T201
+        for w in result.gap_warnings:
+            print(f"  ⚠ {w.format_warning()}")  # noqa: T201
+    return 0

--- a/src/auto_lorebook/commands/ingest.py
+++ b/src/auto_lorebook/commands/ingest.py
@@ -92,6 +92,17 @@ def add_parser(
         default=False,
         help="Skip all interactive prompts; use flags only",
     )
+    parser.add_argument(
+        "--cookies-from-browser",
+        dest="cookies_from_browser",
+        default=None,
+        metavar="BROWSER",
+        help=(
+            "Load cookies from this browser for YouTube fetches "
+            "(e.g. chrome, firefox, safari, edge, brave). Helps avoid "
+            "HTTP 429 rate limits."
+        ),
+    )
     parser.set_defaults(func=run)
     return parser
 
@@ -175,7 +186,11 @@ def _run_from_url(
 
     with tempfile.TemporaryDirectory(prefix="auto-lorebook-yt-") as tmp:
         try:
-            fetched = ytdlp.fetch(args.url_or_path, Path(tmp))
+            fetched = ytdlp.fetch(
+                args.url_or_path,
+                Path(tmp),
+                cookies_from_browser=args.cookies_from_browser,
+            )
         except ytdlp.YtDlpError as e:
             _logger.error("%s", e)
             return 1

--- a/src/auto_lorebook/commands/ingest.py
+++ b/src/auto_lorebook/commands/ingest.py
@@ -99,16 +99,27 @@ def add_parser(
 def run(args: argparse.Namespace) -> int:
     """Execute the ingest command."""
     try:
-        cfg = cfg_mod.load_config()
+        cfg = _load_or_create_config(no_interactive=args.no_interactive)
     except cfg_mod.ConfigError as e:
         _logger.error("%s", e)
         return 1
+    except KeyboardInterrupt:
+        return 130
 
     wiki_repo = cfg.wiki_repo_path
 
     if args.url_or_path.startswith(("http://", "https://")):
         return _run_from_url(args, cfg, wiki_repo)
     return _run_from_local(args, cfg, wiki_repo)
+
+
+def _load_or_create_config(*, no_interactive: bool) -> cfg_mod.Config:
+    try:
+        return cfg_mod.load_config()
+    except cfg_mod.MissingConfigError:
+        if no_interactive:
+            raise
+        return cfg_mod.interactive_setup()
 
 
 @dataclass

--- a/src/auto_lorebook/commands/ingest.py
+++ b/src/auto_lorebook/commands/ingest.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import datetime
 import logging
 import tempfile
 from dataclasses import dataclass
@@ -13,6 +12,7 @@ from auto_lorebook import config as cfg_mod
 from auto_lorebook import info_yaml, source_store, ytdlp
 from auto_lorebook import source_id as sid_mod
 from auto_lorebook.commands._shared import finalize_context
+from auto_lorebook.timestamps import format_iso_now
 
 if TYPE_CHECKING:
     import argparse
@@ -234,7 +234,7 @@ def _new_info(
     args: argparse.Namespace,
     transcript_filename: str,
 ) -> info_yaml.Info:
-    fetched_at = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    fetched_at = format_iso_now()
     title = resolved.fetched_title or Path(args.url_or_path).stem
     duration = (
         int(resolved.fetched_duration)

--- a/src/auto_lorebook/commands/ingest.py
+++ b/src/auto_lorebook/commands/ingest.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import datetime
 import logging
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from auto_lorebook import config as cfg_mod
-from auto_lorebook import info_yaml, source_store
+from auto_lorebook import info_yaml, source_store, ytdlp
 from auto_lorebook import source_id as sid_mod
 from auto_lorebook.commands._shared import finalize_context
 
@@ -30,7 +32,7 @@ def add_parser(
         description=(
             "Fetch a source, gather context, and store it in the wiki. "
             "Local files (.srt, .txt, .md) are supported. "
-            "YouTube URLs require yt-dlp (fetch not yet implemented)."
+            "YouTube URLs are fetched via yt-dlp (must be on PATH)."
         ),
     )
     parser.add_argument(
@@ -105,12 +107,27 @@ def run(args: argparse.Namespace) -> int:
     wiki_repo = cfg.wiki_repo_path
 
     if args.url_or_path.startswith(("http://", "https://")):
-        _logger.error(
-            "Fetching transcripts from URLs is not yet implemented. "
-            "Download the transcript manually and pass the local file."
-        )
-        return 1
+        return _run_from_url(args, cfg, wiki_repo)
+    return _run_from_local(args, cfg, wiki_repo)
 
+
+@dataclass
+class _ResolvedSource:
+    """Local file + initial metadata produced by resolving the positional arg."""
+
+    local_path: Path
+    source_url: str | None
+    source_type: str
+    fetched_title: str | None = None
+    fetched_duration: float | None = None
+    caption_type: str | None = None
+
+
+def _run_from_local(
+    args: argparse.Namespace,
+    cfg: cfg_mod.Config,
+    wiki_repo: Path,
+) -> int:
     try:
         source_id = sid_mod.derive(args.url_or_path, args.source_id, args.source_url)
     except sid_mod.SourceIdError as e:
@@ -122,11 +139,58 @@ def run(args: argparse.Namespace) -> int:
         _logger.error("File not found: %s", local_path)
         return 1
 
-    source_type = _derive_source_type(local_path, args.source_url)
+    resolved = _ResolvedSource(
+        local_path=local_path,
+        source_url=args.source_url,
+        source_type=_derive_source_type(local_path, args.source_url),
+    )
+    return _store_and_finalize(args, cfg, wiki_repo, source_id, resolved)
 
+
+def _run_from_url(
+    args: argparse.Namespace,
+    cfg: cfg_mod.Config,
+    wiki_repo: Path,
+) -> int:
+    video_id = sid_mod.extract_video_id(args.url_or_path)
+    if not video_id:
+        _logger.error(
+            "Only YouTube URLs are supported for remote ingest. "
+            "Download non-YouTube sources manually and pass the local file."
+        )
+        return 1
+
+    source_id = args.source_id or f"yt-{video_id}"
+
+    with tempfile.TemporaryDirectory(prefix="auto-lorebook-yt-") as tmp:
+        try:
+            fetched = ytdlp.fetch(args.url_or_path, Path(tmp))
+        except ytdlp.YtDlpError as e:
+            _logger.error("%s", e)
+            return 1
+
+        caption_type = "auto" if ".auto." in fetched.srt_path.name else "manual"
+        resolved = _ResolvedSource(
+            local_path=fetched.srt_path,
+            source_url=args.url_or_path,
+            source_type="youtube",
+            fetched_title=fetched.title,
+            fetched_duration=fetched.duration,
+            caption_type=caption_type,
+        )
+        return _store_and_finalize(args, cfg, wiki_repo, source_id, resolved)
+
+
+def _store_and_finalize(
+    args: argparse.Namespace,
+    cfg: cfg_mod.Config,
+    wiki_repo: Path,
+    source_id: str,
+    resolved: _ResolvedSource,
+) -> int:
     try:
         dest, transcript_filename = source_store.copy_transcript(
-            local_path, source_id, source_type, wiki_repo
+            resolved.local_path, source_id, resolved.source_type, wiki_repo
         )
     except (source_store.DuplicateSourceError, source_store.CollisionError) as e:
         _logger.error("%s", e)
@@ -146,7 +210,7 @@ def run(args: argparse.Namespace) -> int:
             )
             return 1
     else:
-        info = _new_info(source_id, source_type, args, transcript_filename)
+        info = _new_info(source_id, resolved, args, transcript_filename)
 
     info.transcript_filename = transcript_filename
 
@@ -166,17 +230,25 @@ def _derive_source_type(local_path: Path, source_url: str | None) -> str:
 
 def _new_info(
     source_id: str,
-    source_type: str,
+    resolved: _ResolvedSource,
     args: argparse.Namespace,
     transcript_filename: str,
 ) -> info_yaml.Info:
     fetched_at = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    title = resolved.fetched_title or Path(args.url_or_path).stem
+    duration = (
+        int(resolved.fetched_duration)
+        if resolved.fetched_duration is not None
+        else None
+    )
     return info_yaml.Info(
         source_id=source_id,
-        source_type=source_type,
+        source_type=resolved.source_type,
         fetched_at=fetched_at,
-        source_url=args.source_url,
-        title=Path(args.url_or_path).stem,
+        source_url=resolved.source_url,
+        title=title,
+        duration_seconds=duration,
+        caption_type=resolved.caption_type,
         transcript_filename=transcript_filename,
         context=info_yaml.SourceContext(),
     )

--- a/src/auto_lorebook/commands/ingest.py
+++ b/src/auto_lorebook/commands/ingest.py
@@ -32,7 +32,7 @@ def add_parser(
         description=(
             "Fetch a source, gather context, and store it in the wiki. "
             "Local files (.srt, .txt, .md) are supported. "
-            "YouTube URLs are fetched via yt-dlp (must be on PATH)."
+            "YouTube URLs are fetched via yt-dlp (bundled)."
         ),
     )
     parser.add_argument(

--- a/src/auto_lorebook/commands/regenerate_reading.py
+++ b/src/auto_lorebook/commands/regenerate_reading.py
@@ -1,0 +1,81 @@
+"""auto-lorebook regenerate-reading subcommand."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import reading_pipeline as pipeline
+
+if TYPE_CHECKING:
+    import argparse
+
+_logger = logging.getLogger(__name__)
+
+
+def add_parser(
+    subparsers: argparse._SubParsersAction,
+    common_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Register the regenerate-reading subcommand."""
+    parser = subparsers.add_parser(
+        "regenerate-reading",
+        parents=[common_parser],
+        help="Re-run Stage 1a or 1b for an existing draft reading",
+        description=(
+            "Re-runs from a given substage. `--from=structure` reruns 1a "
+            "then 1b (discarding any existing bullets). `--from=summarize` "
+            "reruns only 1b, preserving structure.yaml. With `--segments`, "
+            "only the listed segments are re-summarized; other segments "
+            "keep their existing bullets."
+        ),
+    )
+    parser.add_argument("source_id", help="Source ID (e.g. yt-abc12345678)")
+    parser.add_argument(
+        "--from",
+        dest="from_stage",
+        required=True,
+        choices=["structure", "summarize"],
+        help="Substage to start from",
+    )
+    parser.add_argument(
+        "--segments",
+        dest="segments",
+        default=None,
+        help=("Comma-separated segment IDs (valid only with --from=summarize)"),
+    )
+    parser.set_defaults(func=run)
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the regenerate-reading command."""
+    try:
+        cfg = cfg_mod.load_config()
+    except cfg_mod.ConfigError as e:
+        _logger.error("%s", e)
+        return 1
+
+    segment_ids: list[str] | None = None
+    if args.segments:
+        segment_ids = [s.strip() for s in args.segments.split(",") if s.strip()]
+
+    try:
+        result = pipeline.regenerate(
+            cfg,
+            args.source_id,
+            from_stage=args.from_stage,
+            segment_ids=segment_ids,
+        )
+    except pipeline.ReadingPipelineError as e:
+        _logger.error("%s", e)
+        return 1
+
+    print(f"Draft reading: {result.pending_reading_path}")  # noqa: T201
+    if result.gap_warnings:
+        print()  # noqa: T201
+        print(f"{len(result.gap_warnings)} possible coverage gap(s):")  # noqa: T201
+        for w in result.gap_warnings:
+            print(f"  ⚠ {w.format_warning()}")  # noqa: T201
+    return 0

--- a/src/auto_lorebook/config.py
+++ b/src/auto_lorebook/config.py
@@ -31,7 +31,7 @@ class OpenRouterConfig:
 class ModelsConfig:
     """Models section of config.yaml."""
 
-    primary: str = "openrouter/anthropic/claude-sonnet-4-5"
+    primary: str = "anthropic/claude-sonnet-4-5"
     primary_context_window: int = 200_000
     extractor: str | None = None
 
@@ -122,7 +122,7 @@ def load_config(home: Path | None = None) -> Config:
         api_key_env=or_raw.get("api_key_env", "OPENROUTER_API_KEY"),
     )
     models = ModelsConfig(
-        primary=models_raw.get("primary", "openrouter/anthropic/claude-sonnet-4-5"),
+        primary=models_raw.get("primary", "anthropic/claude-sonnet-4-5"),
         primary_context_window=int(models_raw.get("primary_context_window", 200_000)),
         extractor=models_raw.get("extractor"),
     )
@@ -170,7 +170,7 @@ def save_last_context(last: LastContext, home: Path | None = None) -> None:
 
 
 _DEFAULT_API_KEY_ENV = "OPENROUTER_API_KEY"
-_DEFAULT_MODEL = "openrouter/anthropic/claude-sonnet-4-5"
+_DEFAULT_MODEL = "anthropic/claude-sonnet-4-5"
 _WIKI_SUBDIRS = ("characters", "locations", "factions", "events", "items", "concepts")
 _CREDENTIALS_FILE = "credentials"
 

--- a/src/auto_lorebook/config.py
+++ b/src/auto_lorebook/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import getpass
 import logging
 import os
 from dataclasses import dataclass, field
@@ -52,8 +53,11 @@ class Config:
     preamble: PreambleConfig = field(default_factory=PreambleConfig)
 
     def get_api_key(self) -> str | None:
-        """Read API key from environment variable named in config."""
-        return os.environ.get(self.openrouter.api_key_env)
+        """Resolve API key. Env var wins; falls back to credentials file."""
+        env_value = os.environ.get(self.openrouter.api_key_env)
+        if env_value:
+            return env_value
+        return _read_credentials()
 
 
 @dataclass
@@ -168,6 +172,7 @@ def save_last_context(last: LastContext, home: Path | None = None) -> None:
 _DEFAULT_API_KEY_ENV = "OPENROUTER_API_KEY"
 _DEFAULT_MODEL = "openrouter/anthropic/claude-sonnet-4-5"
 _WIKI_SUBDIRS = ("characters", "locations", "factions", "events", "items", "concepts")
+_CREDENTIALS_FILE = "credentials"
 
 
 def _prompt(prompt_text: str, default: str | None = None) -> str:
@@ -182,8 +187,42 @@ def _prompt(prompt_text: str, default: str | None = None) -> str:
         print("(required)")  # noqa: T201
 
 
+def _credentials_path(home: Path | None = None) -> Path:
+    return config_dir(home) / _CREDENTIALS_FILE
+
+
+def _read_credentials(home: Path | None = None) -> str | None:
+    """Read API key from `<config_dir>/credentials`; missing/empty → None."""
+    path = _credentials_path(home)
+    if not path.exists():
+        return None
+    try:
+        return path.read_text(encoding="utf-8").strip() or None
+    except OSError:
+        _logger.warning("Could not read %s", path)
+        return None
+
+
+def _write_credentials(api_key: str, home: Path | None = None) -> Path:
+    """Write API key to credentials file with mode 0600."""
+    cfg_dir = config_dir(home)
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    path = _credentials_path(home)
+    atomic_write_text(path, api_key + "\n")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        # Windows / unusual filesystems may not support POSIX modes.
+        _logger.warning("Could not chmod %s to 0600", path)
+    return path
+
+
 def interactive_setup(home: Path | None = None) -> Config:
     """Prompt the user for first-run config and write `config.yaml`.
+
+    The API key is read with `getpass` (input hidden) and stored in
+    `<config_dir>/credentials` (mode 0600). Blank skips the file and
+    falls back to the `OPENROUTER_API_KEY` env var at runtime.
 
     Creates the wiki repo skeleton (entity dirs + `.wiki-context.yaml` /
     `.transcription-corrections.yaml` schema stubs) if it doesn't exist.
@@ -198,10 +237,10 @@ def interactive_setup(home: Path | None = None) -> Config:
 
     wiki_raw = _prompt("Wiki repository directory")
     wiki = Path(wiki_raw).expanduser().resolve()
-    api_key_env = _prompt(
-        "Environment variable holding your OpenRouter API key",
-        default=_DEFAULT_API_KEY_ENV,
-    )
+    api_key = getpass.getpass(
+        "OpenRouter API key (input hidden; leave blank to use "
+        f"${_DEFAULT_API_KEY_ENV}): "
+    ).strip()
     model = _prompt(
         "Primary model slug (used for both reading substages)",
         default=_DEFAULT_MODEL,
@@ -210,7 +249,7 @@ def interactive_setup(home: Path | None = None) -> Config:
     data: dict[str, Any] = {
         "schema_version": 1,
         "wiki_repo_path": str(wiki),
-        "openrouter": {"api_key_env": api_key_env},
+        "openrouter": {"api_key_env": _DEFAULT_API_KEY_ENV},
         "models": {"primary": model},
     }
     cfg_dir.mkdir(parents=True, exist_ok=True)
@@ -219,14 +258,20 @@ def interactive_setup(home: Path | None = None) -> Config:
         yaml.safe_dump(data, allow_unicode=True, sort_keys=False),
     )
 
+    cred_path: Path | None = None
+    if api_key:
+        cred_path = _write_credentials(api_key, home=home)
+
     _bootstrap_wiki(wiki)
 
     print()  # noqa: T201
     print(f"Wrote {cfg_path}")  # noqa: T201
-    if not os.environ.get(api_key_env):
+    if cred_path is not None:
+        print(f"Wrote API key to {cred_path} (mode 0600)")  # noqa: T201
+    elif not os.environ.get(_DEFAULT_API_KEY_ENV):
         print(  # noqa: T201
-            f"Reminder: export {api_key_env}=<your OpenRouter key> before running "
-            "`generate-reading`."
+            f"Reminder: export {_DEFAULT_API_KEY_ENV}=<your OpenRouter key> "
+            "before running `generate-reading`."
         )
 
     return load_config(home=home)

--- a/src/auto_lorebook/config.py
+++ b/src/auto_lorebook/config.py
@@ -68,7 +68,8 @@ class ConfigError(ValueError):
     """Raised when config.yaml is missing or malformed."""
 
 
-def _config_dir(home: Path | None = None) -> Path:
+def config_dir(home: Path | None = None) -> Path:
+    """Resolve ~/.auto-lorebook, respecting AUTO_LOREBOOK_HOME override."""
     if home is not None:
         return home
     env = os.environ.get(_CONFIG_DIR_ENV)
@@ -83,7 +84,7 @@ def load_config(home: Path | None = None) -> Config:
     :param home: override for the config directory (for tests)
     :raises ConfigError: if file is missing or malformed
     """
-    cfg_path = _config_dir(home) / "config.yaml"
+    cfg_path = config_dir(home) / "config.yaml"
     if not cfg_path.exists():
         msg = (
             f"Config file not found: {cfg_path}\n"
@@ -136,7 +137,7 @@ def load_config(home: Path | None = None) -> Config:
 
 def load_last_context(home: Path | None = None) -> LastContext:
     """Load ~/.auto-lorebook/last-context.yaml; missing/corrupt → empty."""
-    path = _config_dir(home) / "last-context.yaml"
+    path = config_dir(home) / "last-context.yaml"
     if not path.exists():
         return LastContext()
     try:
@@ -154,7 +155,7 @@ def load_last_context(home: Path | None = None) -> LastContext:
 
 def save_last_context(last: LastContext, home: Path | None = None) -> None:
     """Atomically write perspective and source_nature to last-context.yaml."""
-    cfg_dir = _config_dir(home)
+    cfg_dir = config_dir(home)
     cfg_dir.mkdir(parents=True, exist_ok=True)
     path = cfg_dir / "last-context.yaml"
     data: dict[str, Any] = {}

--- a/src/auto_lorebook/config.py
+++ b/src/auto_lorebook/config.py
@@ -68,6 +68,10 @@ class ConfigError(ValueError):
     """Raised when config.yaml is missing or malformed."""
 
 
+class MissingConfigError(ConfigError):
+    """Raised specifically when config.yaml does not exist (first run)."""
+
+
 def config_dir(home: Path | None = None) -> Path:
     """Resolve ~/.auto-lorebook, respecting AUTO_LOREBOOK_HOME override."""
     if home is not None:
@@ -88,15 +92,10 @@ def load_config(home: Path | None = None) -> Config:
     if not cfg_path.exists():
         msg = (
             f"Config file not found: {cfg_path}\n"
-            "Create it with at minimum:\n"
-            "  schema_version: 1\n"
-            "  wiki_repo_path: /path/to/your/wiki\n"
-            "  openrouter:\n"
-            "    api_key_env: OPENROUTER_API_KEY\n"
-            "  models:\n"
-            "    primary: openrouter/anthropic/claude-sonnet-4-5\n"
+            "Run an interactive command (e.g. `auto-lorebook ingest ...`) "
+            "to create one, or write it by hand."
         )
-        raise ConfigError(msg)
+        raise MissingConfigError(msg)
     raw = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
         msg = f"{cfg_path}: expected a YAML mapping, got {type(raw).__name__}"
@@ -164,3 +163,81 @@ def save_last_context(last: LastContext, home: Path | None = None) -> None:
     if last.source_nature is not None:
         data["source_nature"] = last.source_nature
     atomic_write_text(path, yaml.safe_dump(data, allow_unicode=True, sort_keys=False))
+
+
+_DEFAULT_API_KEY_ENV = "OPENROUTER_API_KEY"
+_DEFAULT_MODEL = "openrouter/anthropic/claude-sonnet-4-5"
+_WIKI_SUBDIRS = ("characters", "locations", "factions", "events", "items", "concepts")
+
+
+def _prompt(prompt_text: str, default: str | None = None) -> str:
+    """Prompt for a value; blank → default. Re-prompt if no default + blank."""
+    while True:
+        suffix = f" [{default}]" if default else ""
+        value = input(f"{prompt_text}{suffix}: ").strip()
+        if value:
+            return value
+        if default is not None:
+            return default
+        print("(required)")  # noqa: T201
+
+
+def interactive_setup(home: Path | None = None) -> Config:
+    """Prompt the user for first-run config and write `config.yaml`.
+
+    Creates the wiki repo skeleton (entity dirs + `.wiki-context.yaml` /
+    `.transcription-corrections.yaml` schema stubs) if it doesn't exist.
+
+    :raises KeyboardInterrupt: user pressed Ctrl-C
+    """
+    cfg_dir = config_dir(home)
+    cfg_path = cfg_dir / "config.yaml"
+
+    print("First run: setting up ~/.auto-lorebook/config.yaml.")  # noqa: T201
+    print()  # noqa: T201
+
+    wiki_raw = _prompt("Wiki repository directory")
+    wiki = Path(wiki_raw).expanduser().resolve()
+    api_key_env = _prompt(
+        "Environment variable holding your OpenRouter API key",
+        default=_DEFAULT_API_KEY_ENV,
+    )
+    model = _prompt(
+        "Primary model slug (used for both reading substages)",
+        default=_DEFAULT_MODEL,
+    )
+
+    data: dict[str, Any] = {
+        "schema_version": 1,
+        "wiki_repo_path": str(wiki),
+        "openrouter": {"api_key_env": api_key_env},
+        "models": {"primary": model},
+    }
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(
+        cfg_path,
+        yaml.safe_dump(data, allow_unicode=True, sort_keys=False),
+    )
+
+    _bootstrap_wiki(wiki)
+
+    print()  # noqa: T201
+    print(f"Wrote {cfg_path}")  # noqa: T201
+    if not os.environ.get(api_key_env):
+        print(  # noqa: T201
+            f"Reminder: export {api_key_env}=<your OpenRouter key> before running "
+            "`generate-reading`."
+        )
+
+    return load_config(home=home)
+
+
+def _bootstrap_wiki(wiki: Path) -> None:
+    """Create the wiki entity dirs and tolerant-yaml stubs if absent."""
+    wiki.mkdir(parents=True, exist_ok=True)
+    for sub in _WIKI_SUBDIRS:
+        (wiki / sub).mkdir(exist_ok=True)
+    for fname in (".wiki-context.yaml", ".transcription-corrections.yaml"):
+        path = wiki / fname
+        if not path.exists():
+            atomic_write_text(path, "schema_version: 1\n")

--- a/src/auto_lorebook/gap_check.py
+++ b/src/auto_lorebook/gap_check.py
@@ -1,0 +1,98 @@
+"""Mechanical gap-check heuristic over a Structure.
+
+Surfaces contiguous stretches of low-yield segments longer than a
+threshold. No LLM involvement; purely deterministic pattern matching
+over segment titles and notes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from auto_lorebook.timestamps import format_timestamp
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from auto_lorebook.structure import Segment, Structure
+
+DEFAULT_THRESHOLD_SECONDS = 300.0
+
+DEFAULT_LOW_YIELD_PATTERNS: tuple[str, ...] = (
+    "rules",
+    "break",
+    "off-topic",
+    "off topic",
+    "silence",
+    "inaudible",
+    "pizza",
+    "snack",
+    "tangent",
+    "aside",
+)
+
+
+@dataclass(frozen=True)
+class GapWarning:
+    """One contiguous low-yield stretch over threshold."""
+
+    start: float
+    end: float
+    segment_ids: tuple[str, ...]
+    segment_titles: tuple[str, ...]
+
+    @property
+    def duration(self) -> float:
+        return self.end - self.start
+
+    def format_warning(self) -> str:
+        """Human-readable one-liner for reading review."""
+        titles = ", ".join(f'"{t}"' for t in self.segment_titles)
+        return (
+            f"Possible coverage gap: {format_timestamp(self.start)}-"
+            f"{format_timestamp(self.end)} covered only by segments "
+            f"titled {titles}."
+        )
+
+
+def check(
+    structure: Structure,
+    *,
+    threshold_seconds: float = DEFAULT_THRESHOLD_SECONDS,
+    low_yield_patterns: Iterable[str] | None = None,
+) -> list[GapWarning]:
+    """Scan segments for maximal low-yield runs longer than threshold."""
+    patterns = tuple(
+        p.lower() for p in (low_yield_patterns or DEFAULT_LOW_YIELD_PATTERNS)
+    )
+    warnings: list[GapWarning] = []
+    run: list[Segment] = []
+
+    def flush() -> None:
+        if not run:
+            return
+        duration = run[-1].end - run[0].start
+        if duration > threshold_seconds:
+            warnings.append(
+                GapWarning(
+                    start=run[0].start,
+                    end=run[-1].end,
+                    segment_ids=tuple(s.id for s in run),
+                    segment_titles=tuple(s.title for s in run),
+                )
+            )
+
+    for seg in structure.segments:
+        if _is_low_yield(seg, patterns):
+            run.append(seg)
+        else:
+            flush()
+            run = []
+    flush()
+    return warnings
+
+
+def _is_low_yield(seg: Segment, patterns: tuple[str, ...]) -> bool:
+    haystack = (seg.title + " " + (seg.notes or "")).lower()
+    return any(p in haystack for p in patterns)

--- a/src/auto_lorebook/llm_helpers.py
+++ b/src/auto_lorebook/llm_helpers.py
@@ -1,0 +1,41 @@
+"""Shared helpers for LLM stage modules.
+
+Holds the bits each stage re-uses: code-fence-tolerant JSON parsing and
+preamble-plus-task-instructions system-prompt assembly.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+CODE_FENCE_RE = re.compile(r"^```(?:json)?\s*\n(?P<body>.*?)\n```\s*$", re.DOTALL)
+
+
+def parse_json_object(text: str, context: str) -> dict[str, Any]:
+    """Parse an LLM response into a JSON object, tolerating ```json fences.
+
+    :raises ValueError: body is not valid JSON or not an object.
+    """
+    raw = text.strip()
+    m = CODE_FENCE_RE.match(raw)
+    if m:
+        raw = m.group("body").strip()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        msg = f"{context}: response was not valid JSON: {e}"
+        raise ValueError(msg) from e
+    if not isinstance(parsed, dict):
+        # ValueError (not TypeError) so callers catch one class for bad payloads
+        msg = f"{context}: response must be a JSON object, got {type(parsed).__name__}"
+        raise ValueError(msg)  # noqa: TRY004
+    return parsed
+
+
+def build_system_prompt(preamble_text: str, task_instructions: str) -> str:
+    """Concat preamble (if non-empty) and task instructions with a separator."""
+    if preamble_text.strip():
+        return f"{preamble_text}\n\n---\n\n{task_instructions}"
+    return task_instructions

--- a/src/auto_lorebook/openrouter.py
+++ b/src/auto_lorebook/openrouter.py
@@ -1,0 +1,162 @@
+"""OpenRouter HTTP client.
+
+Thin wrapper over OpenRouter's OpenAI-compatible `/chat/completions`
+endpoint. Uses stdlib `urllib` to avoid a runtime HTTP dep.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_TIMEOUT = 120.0
+
+
+class OpenRouterError(RuntimeError):
+    """Base for OpenRouter client errors."""
+
+
+class OpenRouterAuthError(OpenRouterError):
+    """401: bad or missing API key."""
+
+
+class OpenRouterRateLimitError(OpenRouterError):
+    """429: upstream throttling."""
+
+
+class OpenRouterAPIError(OpenRouterError):
+    """Non-2xx response or malformed body."""
+
+
+class OpenRouterTransportError(OpenRouterError):
+    """DNS / connection / TLS failure before a response was received."""
+
+
+@dataclass(frozen=True)
+class OpenRouterResponse:
+    """Parsed completion response."""
+
+    text: str
+    model: str
+    tokens_in: int | None
+    tokens_out: int | None
+
+
+class OpenRouterClient:
+    """Synchronous OpenRouter chat-completions client."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        default_model: str,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = DEFAULT_TIMEOUT,
+        referer: str | None = None,
+        app_title: str | None = None,
+    ) -> None:
+        if not api_key:
+            msg = "OpenRouterClient: api_key is required (set it in the config or env)"
+            raise OpenRouterError(msg)
+        self._api_key = api_key
+        self._default_model = default_model
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._referer = referer
+        self._app_title = app_title
+
+    def complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        response_format: dict[str, Any] | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> OpenRouterResponse:
+        """Call `/chat/completions` and return the first choice's text."""
+        body: dict[str, Any] = {
+            "model": model or self._default_model,
+            "messages": messages,
+        }
+        if temperature is not None:
+            body["temperature"] = temperature
+        if response_format is not None:
+            body["response_format"] = response_format
+        if extra:
+            body.update(extra)
+
+        raw = self._post_json("/chat/completions", body)
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as e:
+            msg = f"OpenRouter returned non-JSON body: {raw[:200]!r}"
+            raise OpenRouterAPIError(msg) from e
+
+        choices = parsed.get("choices") or []
+        if not choices:
+            msg = f"OpenRouter returned no choices: {parsed!r}"
+            raise OpenRouterAPIError(msg)
+        first = choices[0]
+        message = first.get("message") or {}
+        text = message.get("content") or ""
+        usage = parsed.get("usage") or {}
+        return OpenRouterResponse(
+            text=text,
+            model=parsed.get("model") or body["model"],
+            tokens_in=usage.get("prompt_tokens"),
+            tokens_out=usage.get("completion_tokens"),
+        )
+
+    def _post_json(self, path: str, body: dict[str, Any]) -> bytes:
+        url = self._base_url + path
+        data = json.dumps(body).encode("utf-8")
+        req = Request(url, data=data, method="POST")  # noqa: S310
+        req.add_header("Authorization", f"Bearer {self._api_key}")
+        req.add_header("Content-Type", "application/json")
+        if self._referer:
+            req.add_header("HTTP-Referer", self._referer)
+        if self._app_title:
+            req.add_header("X-Title", self._app_title)
+        try:
+            with urlopen(req, timeout=self._timeout) as resp:  # noqa: S310
+                return resp.read()
+        except HTTPError as e:
+            self._raise_from_http_error(e)
+        except URLError as e:
+            msg = f"OpenRouter transport error: {e.reason}"
+            raise OpenRouterTransportError(msg) from e
+        # unreachable: _raise_from_http_error always raises
+        msg = "unreachable"
+        raise RuntimeError(msg)
+
+    @staticmethod
+    def _raise_from_http_error(e: HTTPError) -> None:
+        body_bytes = b""
+        with contextlib.suppress(Exception):
+            body_bytes = e.read() or b""
+        detail = ""
+        if body_bytes:
+            try:
+                parsed = json.loads(body_bytes.decode("utf-8", errors="replace"))
+                detail = (
+                    parsed.get("error", {}).get("message")
+                    if isinstance(parsed, dict)
+                    else ""
+                ) or body_bytes.decode("utf-8", errors="replace")[:200]
+            except json.JSONDecodeError:
+                detail = body_bytes.decode("utf-8", errors="replace")[:200]
+        msg = f"OpenRouter {e.code}: {detail or e.reason}"
+        if e.code == 401:
+            raise OpenRouterAuthError(msg) from e
+        if e.code == 429:
+            raise OpenRouterRateLimitError(msg) from e
+        raise OpenRouterAPIError(msg) from e

--- a/src/auto_lorebook/openrouter.py
+++ b/src/auto_lorebook/openrouter.py
@@ -6,7 +6,6 @@ endpoint. Uses stdlib `urllib` to avoid a runtime HTTP dep.
 
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
 from dataclasses import dataclass
@@ -140,9 +139,10 @@ class OpenRouterClient:
 
     @staticmethod
     def _raise_from_http_error(e: HTTPError) -> None:
-        body_bytes = b""
-        with contextlib.suppress(Exception):
+        try:
             body_bytes = e.read() or b""
+        except (OSError, AttributeError):
+            body_bytes = b""
         detail = ""
         if body_bytes:
             try:

--- a/src/auto_lorebook/reading.py
+++ b/src/auto_lorebook/reading.py
@@ -116,8 +116,12 @@ def read_frontmatter(path: Path) -> dict[str, Any]:
     return parsed
 
 
-def set_status(path: Path, status: str) -> None:
-    """Rewrite the `reading_status` field in place."""
+def with_status(path: Path, status: str) -> str:
+    """Return the reading.md text with `reading_status` set to `status`.
+
+    :raises FileNotFoundError: path doesn't exist
+    :raises ReadingError: invalid status, missing/malformed frontmatter
+    """
     if status not in VALID_STATUSES:
         msg = (
             f"invalid reading_status {status!r}; "
@@ -129,9 +133,7 @@ def set_status(path: Path, status: str) -> None:
     if not m:
         msg = f"{path}: no frontmatter block"
         raise ReadingError(msg)
-    body = m.group("body")
-    rest = m.group("rest")
-    parsed = yaml.safe_load(body) or {}
+    parsed = yaml.safe_load(m.group("body")) or {}
     if not isinstance(parsed, dict):
         msg = f"{path}: frontmatter is not a mapping"
         raise ReadingError(msg)
@@ -139,7 +141,12 @@ def set_status(path: Path, status: str) -> None:
     new_fm = yaml.safe_dump(
         parsed, allow_unicode=True, sort_keys=False, default_flow_style=False
     ).rstrip("\n")
-    atomic_write_text(path, f"---\n{new_fm}\n---\n{rest}")
+    return f"---\n{new_fm}\n---\n{m.group('rest')}"
+
+
+def set_status(path: Path, status: str) -> None:
+    """Rewrite the `reading_status` field in place."""
+    atomic_write_text(path, with_status(path, status))
 
 
 def _render_frontmatter(

--- a/src/auto_lorebook/reading.py
+++ b/src/auto_lorebook/reading.py
@@ -1,0 +1,214 @@
+"""Reading.md assembly, writer, and frontmatter helpers.
+
+Interleaves Stage 1a segment headers with Stage 1b bullets, renders
+inline uncertainty flags, applies `name_corrections` during rendering,
+and produces clickable `h:mm:ss` links (for YouTube sources) via
+URL post-processing.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from auto_lorebook._io import atomic_write_text
+from auto_lorebook.timestamps import format_timestamp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from auto_lorebook.info_yaml import Info
+    from auto_lorebook.stage1b import Bullet, ReadingBullets
+    from auto_lorebook.structure import Segment, Structure, UncertaintyFlag
+
+_logger = logging.getLogger(__name__)
+
+VALID_STATUSES = frozenset({"draft", "approved"})
+
+_FRONTMATTER_RE = re.compile(r"^---\n(?P<body>.*?)\n---\n(?P<rest>.*)$", re.DOTALL)
+
+
+class ReadingError(ValueError):
+    """Raised for missing files, missing frontmatter, or invalid status."""
+
+
+def linkify_timestamp(source_url: str | None, seconds: float) -> str | None:
+    """Return a URL with a `t=` query for the given timestamp, or None."""
+    if not source_url:
+        return None
+    sep = "&" if "?" in source_url else "?"
+    return f"{source_url}{sep}t={int(seconds)}"
+
+
+def apply_name_corrections(text: str, name_corrections: dict[str, str]) -> str:
+    """Literally substitute each wrong→right mapping in text."""
+    out = text
+    for wrong, right in name_corrections.items():
+        out = out.replace(wrong, right)
+    return out
+
+
+def assemble(
+    *,
+    info: Info,
+    structure: Structure,
+    bullets: ReadingBullets,
+    name_corrections: dict[str, str] | None = None,
+) -> str:
+    """Render reading.md as a string.
+
+    :param name_corrections: mapping applied to rendered text and
+        written into the frontmatter map. Callers pass pre-existing
+        corrections from the previous reading.md when regenerating.
+    """
+    corrections = dict(name_corrections or {})
+    parts: list[str] = [_render_frontmatter(info, structure, corrections)]
+    parts.append(f"# Reading: {info.title or info.source_id}")
+
+    by_segment = bullets.segments
+    flags_by_segment = _flags_by_segment(structure)
+
+    for seg in structure.segments:
+        parts.append(_render_segment(seg, info.source_url, corrections))
+        parts.extend(
+            _render_uncertainty_flag(flag) for flag in flags_by_segment.get(seg.id, [])
+        )
+        seg_bullets = by_segment.get(seg.id, [])
+        if not seg_bullets:
+            parts.append("_No claims extracted from this segment._")
+        else:
+            parts.extend(
+                _render_bullet(b, info.source_url, corrections) for b in seg_bullets
+            )
+    return "\n\n".join(parts) + "\n"
+
+
+def write(path: Path, text: str) -> None:
+    """Atomically write reading.md."""
+    atomic_write_text(path, text)
+
+
+def read_frontmatter(path: Path) -> dict[str, Any]:
+    """Parse the YAML frontmatter block of a reading.md file.
+
+    :raises ReadingError: missing file, missing frontmatter fence, or
+        invalid YAML.
+    """
+    if not path.exists():
+        msg = f"{path}: file not found"
+        raise ReadingError(msg)
+    text = path.read_text(encoding="utf-8")
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        msg = f"{path}: no '---' frontmatter block at top of file"
+        raise ReadingError(msg)
+    try:
+        parsed = yaml.safe_load(m.group("body"))
+    except yaml.YAMLError as e:
+        msg = f"{path}: frontmatter YAML parse error: {e}"
+        raise ReadingError(msg) from e
+    if not isinstance(parsed, dict):
+        msg = f"{path}: frontmatter is not a mapping"
+        raise ReadingError(msg)
+    return parsed
+
+
+def set_status(path: Path, status: str) -> None:
+    """Rewrite the `reading_status` field in place."""
+    if status not in VALID_STATUSES:
+        msg = (
+            f"invalid reading_status {status!r}; "
+            f"expected one of {sorted(VALID_STATUSES)}"
+        )
+        raise ReadingError(msg)
+    text = path.read_text(encoding="utf-8")
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        msg = f"{path}: no frontmatter block"
+        raise ReadingError(msg)
+    body = m.group("body")
+    rest = m.group("rest")
+    parsed = yaml.safe_load(body) or {}
+    if not isinstance(parsed, dict):
+        msg = f"{path}: frontmatter is not a mapping"
+        raise ReadingError(msg)
+    parsed["reading_status"] = status
+    new_fm = yaml.safe_dump(
+        parsed, allow_unicode=True, sort_keys=False, default_flow_style=False
+    ).rstrip("\n")
+    atomic_write_text(path, f"---\n{new_fm}\n---\n{rest}")
+
+
+def _render_frontmatter(
+    info: Info,
+    structure: Structure,
+    name_corrections: dict[str, str],
+) -> str:
+    fm: dict[str, Any] = {
+        "schema_version": 1,
+        "source_id": info.source_id,
+        "source_name": info.title,
+        "source_url": info.source_url,
+        "source_type": info.source_type,
+        "session_date": info.session_date,
+        "ingested_at": info.fetched_at,
+        "reading_status": "draft",
+        "default_speaker": structure.default_speaker,
+        "name_corrections": dict(name_corrections),
+    }
+    body = yaml.safe_dump(
+        fm,
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    ).rstrip("\n")
+    return f"---\n{body}\n---"
+
+
+def _render_segment(
+    seg: Segment,
+    source_url: str | None,
+    name_corrections: dict[str, str],
+) -> str:
+    start_ts = format_timestamp(seg.start)
+    end_ts = format_timestamp(seg.end)
+    header_text = apply_name_corrections(seg.title, name_corrections)
+    link = linkify_timestamp(source_url, seg.start)
+    if link:
+        header = f"## [[{start_ts}-{end_ts}]]({link}) {header_text}"
+    else:
+        header = f"## [{start_ts}-{end_ts}] {header_text}"
+    speaker_line = f"Speaker: {seg.speaker}"
+    return f"{header}\n\n{speaker_line}"
+
+
+def _render_bullet(
+    b: Bullet,
+    source_url: str | None,
+    name_corrections: dict[str, str],
+) -> str:
+    text = apply_name_corrections(b.text, name_corrections)
+    anchor_ts = format_timestamp(b.anchor)
+    link = linkify_timestamp(source_url, b.anchor)
+    if link:
+        return f"- {text} [[{anchor_ts}]]({link})"
+    return f"- {text} [{anchor_ts}]"
+
+
+def _render_uncertainty_flag(flag: UncertaintyFlag) -> str:
+    ts = format_timestamp(flag.locator)
+    note = f"; {flag.note}" if flag.note else ""
+    return f"- [{ts}] uncertain {flag.kind}: {flag.span}{note}"
+
+
+def _flags_by_segment(structure: Structure) -> dict[str, list[UncertaintyFlag]]:
+    out: dict[str, list[UncertaintyFlag]] = {}
+    for flag in structure.uncertainty_flags:
+        for seg in structure.segments:
+            if seg.start <= flag.locator <= seg.end:
+                out.setdefault(seg.id, []).append(flag)
+                break
+    return out

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -8,11 +8,10 @@ this module handles the wiring between stages.
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING
 
+from auto_lorebook import config as cfg_mod
 from auto_lorebook import (
     corrections as corrections_mod,
 )
@@ -31,7 +30,8 @@ from auto_lorebook import wiki_context as wiki_context_mod
 from auto_lorebook.openrouter import OpenRouterClient, OpenRouterError
 
 if TYPE_CHECKING:
-    from auto_lorebook import config as cfg_mod
+    from pathlib import Path
+
     from auto_lorebook.gap_check import GapWarning
     from auto_lorebook.info_yaml import Info
 
@@ -54,7 +54,7 @@ class GenerateResult:
 
 def generate(cfg: cfg_mod.Config, source_id: str) -> GenerateResult:
     """Run Stage 1a + 1b from scratch and write the draft reading.md."""
-    return _run_full(cfg, source_id, preserve_bullets_for=None)
+    return _run_full(cfg, source_id)
 
 
 def regenerate(
@@ -69,7 +69,7 @@ def regenerate(
         if segment_ids is not None:
             msg = "--segments is only valid with --from=summarize"
             raise ReadingPipelineError(msg)
-        return _run_full(cfg, source_id, preserve_bullets_for=None)
+        return _run_full(cfg, source_id)
     if from_stage == "summarize":
         return _run_summarize_only(cfg, source_id, segment_ids=segment_ids)
     msg = f"unknown --from value: {from_stage!r} (expected structure|summarize)"
@@ -78,43 +78,37 @@ def regenerate(
 
 def approve(cfg: cfg_mod.Config, source_id: str) -> Path:
     """Flip the draft to approved and copy it into the wiki."""
-    pending_path = pending_reading_path(cfg, source_id)
-    if not pending_path.exists():
+    pending_path = pending_reading_path(source_id)
+    try:
+        approved_text = reading_mod.with_status(pending_path, "approved")
+    except FileNotFoundError as e:
         msg = f"No draft reading for {source_id!r}. Run `generate-reading` first."
-        raise ReadingPipelineError(msg)
-
-    reading_mod.set_status(pending_path, "approved")
+        raise ReadingPipelineError(msg) from e
+    reading_mod.write(pending_path, approved_text)
     dest = cfg.wiki_repo_path / "sources" / source_id / "reading.md"
     dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_text(pending_path.read_text(encoding="utf-8"), encoding="utf-8")
+    reading_mod.write(dest, approved_text)
     return dest
 
 
-def pending_dir(cfg: cfg_mod.Config, source_id: str) -> Path:  # noqa: ARG001
+def pending_dir(source_id: str) -> Path:
     """Return the pending directory for a source."""
-    home = os.environ.get("AUTO_LOREBOOK_HOME")
-    base = Path(home) if home else Path.home() / ".auto-lorebook"
-    return base / "pending" / source_id / "reading"
+    return cfg_mod.config_dir() / "pending" / source_id / "reading"
 
 
-def pending_reading_path(cfg: cfg_mod.Config, source_id: str) -> Path:
-    return pending_dir(cfg, source_id) / "reading.md"
+def pending_reading_path(source_id: str) -> Path:
+    return pending_dir(source_id) / "reading.md"
 
 
-def pending_structure_path(cfg: cfg_mod.Config, source_id: str) -> Path:
-    return pending_dir(cfg, source_id) / "structure.yaml"
+def pending_structure_path(source_id: str) -> Path:
+    return pending_dir(source_id) / "structure.yaml"
 
 
-def pending_bullets_path(cfg: cfg_mod.Config, source_id: str) -> Path:
-    return pending_dir(cfg, source_id) / "bullets.yaml"
+def pending_bullets_path(source_id: str) -> Path:
+    return pending_dir(source_id) / "bullets.yaml"
 
 
-def _run_full(
-    cfg: cfg_mod.Config,
-    source_id: str,
-    *,
-    preserve_bullets_for: list[str] | None,
-) -> GenerateResult:
+def _run_full(cfg: cfg_mod.Config, source_id: str) -> GenerateResult:
     info, ctx = _load_context(cfg, source_id)
     client = _build_client(cfg)
     model = cfg.models.primary
@@ -126,50 +120,36 @@ def _run_full(
         client=client,
         model=model,
     )
-    pdir = pending_dir(cfg, source_id)
+    pdir = pending_dir(source_id)
     pdir.mkdir(parents=True, exist_ok=True)
-    structure_mod.write(structure, pending_structure_path(cfg, source_id))
+    structure_mod.write(structure, pending_structure_path(source_id))
 
     warnings = gap_check_mod.check(structure)
 
-    preserved = (
-        {
-            sid: bullets
-            for sid, bullets in _load_existing_bullets(cfg, source_id).segments.items()
-            if sid in (preserve_bullets_for or [])
-        }
-        if preserve_bullets_for is not None
-        else {}
-    )
-    targets = [s.id for s in structure.segments if s.id not in preserved]
     bullets = stage1b_mod.run(
         transcript=ctx.transcript,
         structure=structure,
         preamble_text=ctx.preamble_text,
         client=client,
         model=model,
-        segment_ids=targets or None,
     )
-    for sid, existing in preserved.items():
-        bullets.segments[sid] = existing
-    # fill any segment missing from 1b output with an empty list
     for seg in structure.segments:
         bullets.segments.setdefault(seg.id, [])
-    stage1b_mod.write_bullets(bullets, pending_bullets_path(cfg, source_id))
+    stage1b_mod.write_bullets(bullets, pending_bullets_path(source_id))
 
-    name_corrections = _load_existing_name_corrections(cfg, source_id)
+    name_corrections = _load_existing_name_corrections(source_id)
     text = reading_mod.assemble(
         info=info,
         structure=structure,
         bullets=bullets,
         name_corrections=name_corrections,
     )
-    reading_mod.write(pending_reading_path(cfg, source_id), text)
+    reading_mod.write(pending_reading_path(source_id), text)
 
     return GenerateResult(
-        pending_reading_path=pending_reading_path(cfg, source_id),
-        structure_path=pending_structure_path(cfg, source_id),
-        bullets_path=pending_bullets_path(cfg, source_id),
+        pending_reading_path=pending_reading_path(source_id),
+        structure_path=pending_structure_path(source_id),
+        bullets_path=pending_bullets_path(source_id),
         gap_warnings=warnings,
     )
 
@@ -180,7 +160,7 @@ def _run_summarize_only(
     *,
     segment_ids: list[str] | None,
 ) -> GenerateResult:
-    structure_path = pending_structure_path(cfg, source_id)
+    structure_path = pending_structure_path(source_id)
     if not structure_path.exists():
         msg = (
             f"No prior structure.yaml for {source_id!r}. "
@@ -193,7 +173,7 @@ def _run_summarize_only(
     client = _build_client(cfg)
     model = cfg.models.primary
 
-    existing = _load_existing_bullets(cfg, source_id)
+    existing = _load_existing_bullets(source_id)
     new_bullets = stage1b_mod.run(
         transcript=ctx.transcript,
         structure=structure,
@@ -202,28 +182,28 @@ def _run_summarize_only(
         model=model,
         segment_ids=segment_ids,
     )
-    # merge: rebuilt segments overwrite; untouched segments keep existing bullets
+    # rebuilt segments overwrite; untouched segments keep existing bullets
     merged = existing.segments.copy()
     for sid, bullets_list in new_bullets.segments.items():
         merged[sid] = bullets_list
     for seg in structure.segments:
         merged.setdefault(seg.id, [])
     new_bullets.segments = merged
-    stage1b_mod.write_bullets(new_bullets, pending_bullets_path(cfg, source_id))
+    stage1b_mod.write_bullets(new_bullets, pending_bullets_path(source_id))
 
-    name_corrections = _load_existing_name_corrections(cfg, source_id)
+    name_corrections = _load_existing_name_corrections(source_id)
     text = reading_mod.assemble(
         info=info,
         structure=structure,
         bullets=new_bullets,
         name_corrections=name_corrections,
     )
-    reading_mod.write(pending_reading_path(cfg, source_id), text)
+    reading_mod.write(pending_reading_path(source_id), text)
 
     return GenerateResult(
-        pending_reading_path=pending_reading_path(cfg, source_id),
-        structure_path=pending_structure_path(cfg, source_id),
-        bullets_path=pending_bullets_path(cfg, source_id),
+        pending_reading_path=pending_reading_path(source_id),
+        structure_path=pending_structure_path(source_id),
+        bullets_path=pending_bullets_path(source_id),
         gap_warnings=gap_check_mod.check(structure),
     )
 
@@ -283,10 +263,8 @@ def _build_client(cfg: cfg_mod.Config) -> OpenRouterClient:
         raise ReadingPipelineError(str(e)) from e
 
 
-def _load_existing_bullets(
-    cfg: cfg_mod.Config, source_id: str
-) -> stage1b_mod.ReadingBullets:
-    path = pending_bullets_path(cfg, source_id)
+def _load_existing_bullets(source_id: str) -> stage1b_mod.ReadingBullets:
+    path = pending_bullets_path(source_id)
     if not path.exists():
         return stage1b_mod.ReadingBullets(
             source_id=source_id, generated_at="", segments={}
@@ -294,10 +272,8 @@ def _load_existing_bullets(
     return stage1b_mod.read_bullets(path)
 
 
-def _load_existing_name_corrections(
-    cfg: cfg_mod.Config, source_id: str
-) -> dict[str, str]:
-    path = pending_reading_path(cfg, source_id)
+def _load_existing_name_corrections(source_id: str) -> dict[str, str]:
+    path = pending_reading_path(source_id)
     if not path.exists():
         return {}
     try:

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -1,0 +1,310 @@
+"""High-level orchestration of the Stage 1 reading pipeline.
+
+Exposes `generate`, `approve`, and `regenerate` entry points used by
+the three reading subcommands. The command modules handle argparse;
+this module handles the wiring between stages.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from auto_lorebook import (
+    corrections as corrections_mod,
+)
+from auto_lorebook import (
+    entity_index as entity_index_mod,
+)
+from auto_lorebook import gap_check as gap_check_mod
+from auto_lorebook import info_yaml as info_yaml_mod
+from auto_lorebook import preamble as preamble_mod
+from auto_lorebook import reading as reading_mod
+from auto_lorebook import stage1a as stage1a_mod
+from auto_lorebook import stage1b as stage1b_mod
+from auto_lorebook import structure as structure_mod
+from auto_lorebook import transcript as transcript_mod
+from auto_lorebook import wiki_context as wiki_context_mod
+from auto_lorebook.openrouter import OpenRouterClient, OpenRouterError
+
+if TYPE_CHECKING:
+    from auto_lorebook import config as cfg_mod
+    from auto_lorebook.gap_check import GapWarning
+    from auto_lorebook.info_yaml import Info
+
+_logger = logging.getLogger(__name__)
+
+
+class ReadingPipelineError(RuntimeError):
+    """Raised for any user-facing failure in the reading pipeline."""
+
+
+@dataclass
+class GenerateResult:
+    """Paths and warnings produced by a generate/regenerate run."""
+
+    pending_reading_path: Path
+    structure_path: Path
+    bullets_path: Path
+    gap_warnings: list[GapWarning]
+
+
+def generate(cfg: cfg_mod.Config, source_id: str) -> GenerateResult:
+    """Run Stage 1a + 1b from scratch and write the draft reading.md."""
+    return _run_full(cfg, source_id, preserve_bullets_for=None)
+
+
+def regenerate(
+    cfg: cfg_mod.Config,
+    source_id: str,
+    *,
+    from_stage: str,
+    segment_ids: list[str] | None = None,
+) -> GenerateResult:
+    """Re-run from the given stage, preserving name_corrections + selective bullets."""
+    if from_stage == "structure":
+        if segment_ids is not None:
+            msg = "--segments is only valid with --from=summarize"
+            raise ReadingPipelineError(msg)
+        return _run_full(cfg, source_id, preserve_bullets_for=None)
+    if from_stage == "summarize":
+        return _run_summarize_only(cfg, source_id, segment_ids=segment_ids)
+    msg = f"unknown --from value: {from_stage!r} (expected structure|summarize)"
+    raise ReadingPipelineError(msg)
+
+
+def approve(cfg: cfg_mod.Config, source_id: str) -> Path:
+    """Flip the draft to approved and copy it into the wiki."""
+    pending_path = pending_reading_path(cfg, source_id)
+    if not pending_path.exists():
+        msg = f"No draft reading for {source_id!r}. Run `generate-reading` first."
+        raise ReadingPipelineError(msg)
+
+    reading_mod.set_status(pending_path, "approved")
+    dest = cfg.wiki_repo_path / "sources" / source_id / "reading.md"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(pending_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return dest
+
+
+def pending_dir(cfg: cfg_mod.Config, source_id: str) -> Path:  # noqa: ARG001
+    """Return the pending directory for a source."""
+    home = os.environ.get("AUTO_LOREBOOK_HOME")
+    base = Path(home) if home else Path.home() / ".auto-lorebook"
+    return base / "pending" / source_id / "reading"
+
+
+def pending_reading_path(cfg: cfg_mod.Config, source_id: str) -> Path:
+    return pending_dir(cfg, source_id) / "reading.md"
+
+
+def pending_structure_path(cfg: cfg_mod.Config, source_id: str) -> Path:
+    return pending_dir(cfg, source_id) / "structure.yaml"
+
+
+def pending_bullets_path(cfg: cfg_mod.Config, source_id: str) -> Path:
+    return pending_dir(cfg, source_id) / "bullets.yaml"
+
+
+def _run_full(
+    cfg: cfg_mod.Config,
+    source_id: str,
+    *,
+    preserve_bullets_for: list[str] | None,
+) -> GenerateResult:
+    info, ctx = _load_context(cfg, source_id)
+    client = _build_client(cfg)
+    model = cfg.models.primary
+
+    structure = stage1a_mod.run(
+        transcript=ctx.transcript,
+        preamble_text=ctx.preamble_text,
+        source_id=source_id,
+        client=client,
+        model=model,
+    )
+    pdir = pending_dir(cfg, source_id)
+    pdir.mkdir(parents=True, exist_ok=True)
+    structure_mod.write(structure, pending_structure_path(cfg, source_id))
+
+    warnings = gap_check_mod.check(structure)
+
+    preserved = (
+        {
+            sid: bullets
+            for sid, bullets in _load_existing_bullets(cfg, source_id).segments.items()
+            if sid in (preserve_bullets_for or [])
+        }
+        if preserve_bullets_for is not None
+        else {}
+    )
+    targets = [s.id for s in structure.segments if s.id not in preserved]
+    bullets = stage1b_mod.run(
+        transcript=ctx.transcript,
+        structure=structure,
+        preamble_text=ctx.preamble_text,
+        client=client,
+        model=model,
+        segment_ids=targets or None,
+    )
+    for sid, existing in preserved.items():
+        bullets.segments[sid] = existing
+    # fill any segment missing from 1b output with an empty list
+    for seg in structure.segments:
+        bullets.segments.setdefault(seg.id, [])
+    stage1b_mod.write_bullets(bullets, pending_bullets_path(cfg, source_id))
+
+    name_corrections = _load_existing_name_corrections(cfg, source_id)
+    text = reading_mod.assemble(
+        info=info,
+        structure=structure,
+        bullets=bullets,
+        name_corrections=name_corrections,
+    )
+    reading_mod.write(pending_reading_path(cfg, source_id), text)
+
+    return GenerateResult(
+        pending_reading_path=pending_reading_path(cfg, source_id),
+        structure_path=pending_structure_path(cfg, source_id),
+        bullets_path=pending_bullets_path(cfg, source_id),
+        gap_warnings=warnings,
+    )
+
+
+def _run_summarize_only(
+    cfg: cfg_mod.Config,
+    source_id: str,
+    *,
+    segment_ids: list[str] | None,
+) -> GenerateResult:
+    structure_path = pending_structure_path(cfg, source_id)
+    if not structure_path.exists():
+        msg = (
+            f"No prior structure.yaml for {source_id!r}. "
+            "Run `regenerate-reading --from=structure` or `generate-reading` first."
+        )
+        raise ReadingPipelineError(msg)
+    structure = structure_mod.read(structure_path)
+
+    info, ctx = _load_context(cfg, source_id)
+    client = _build_client(cfg)
+    model = cfg.models.primary
+
+    existing = _load_existing_bullets(cfg, source_id)
+    new_bullets = stage1b_mod.run(
+        transcript=ctx.transcript,
+        structure=structure,
+        preamble_text=ctx.preamble_text,
+        client=client,
+        model=model,
+        segment_ids=segment_ids,
+    )
+    # merge: rebuilt segments overwrite; untouched segments keep existing bullets
+    merged = existing.segments.copy()
+    for sid, bullets_list in new_bullets.segments.items():
+        merged[sid] = bullets_list
+    for seg in structure.segments:
+        merged.setdefault(seg.id, [])
+    new_bullets.segments = merged
+    stage1b_mod.write_bullets(new_bullets, pending_bullets_path(cfg, source_id))
+
+    name_corrections = _load_existing_name_corrections(cfg, source_id)
+    text = reading_mod.assemble(
+        info=info,
+        structure=structure,
+        bullets=new_bullets,
+        name_corrections=name_corrections,
+    )
+    reading_mod.write(pending_reading_path(cfg, source_id), text)
+
+    return GenerateResult(
+        pending_reading_path=pending_reading_path(cfg, source_id),
+        structure_path=pending_structure_path(cfg, source_id),
+        bullets_path=pending_bullets_path(cfg, source_id),
+        gap_warnings=gap_check_mod.check(structure),
+    )
+
+
+@dataclass
+class _Context:
+    transcript: transcript_mod.LoadedTranscript
+    preamble_text: str
+
+
+def _load_context(cfg: cfg_mod.Config, source_id: str) -> tuple[Info, _Context]:
+    wiki_repo = cfg.wiki_repo_path
+    info_path = wiki_repo / "sources" / source_id / "info.yaml"
+    if not info_path.exists():
+        msg = f"info.yaml not found for {source_id!r}: run `ingest` first"
+        raise ReadingPipelineError(msg)
+    try:
+        info = info_yaml_mod.read(info_path)
+    except info_yaml_mod.InfoError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    wc = wiki_context_mod.read(wiki_repo / ".wiki-context.yaml")
+    cors = corrections_mod.read(wiki_repo / ".transcription-corrections.yaml")
+    idx = entity_index_mod.build(wiki_repo)
+
+    try:
+        loaded = transcript_mod.load(wiki_repo, info, cors)
+    except transcript_mod.TranscriptError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    p = preamble_mod.assemble(info, wc, cors, idx, reduced=False)
+    try:
+        p.check_budget(
+            context_window=cfg.models.primary_context_window,
+            budget_fraction=cfg.preamble.budget_fraction,
+        )
+    except preamble_mod.PreambleTooLargeError as e:
+        raise ReadingPipelineError(str(e)) from e
+    return info, _Context(transcript=loaded, preamble_text=p.text)
+
+
+def _build_client(cfg: cfg_mod.Config) -> OpenRouterClient:
+    api_key = cfg.get_api_key()
+    if not api_key:
+        msg = (
+            f"OpenRouter API key not found (expected env var "
+            f"{cfg.openrouter.api_key_env}). Export it and retry."
+        )
+        raise ReadingPipelineError(msg)
+    try:
+        return OpenRouterClient(
+            api_key=api_key,
+            default_model=cfg.models.primary,
+            app_title="auto-lorebook",
+        )
+    except OpenRouterError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+
+def _load_existing_bullets(
+    cfg: cfg_mod.Config, source_id: str
+) -> stage1b_mod.ReadingBullets:
+    path = pending_bullets_path(cfg, source_id)
+    if not path.exists():
+        return stage1b_mod.ReadingBullets(
+            source_id=source_id, generated_at="", segments={}
+        )
+    return stage1b_mod.read_bullets(path)
+
+
+def _load_existing_name_corrections(
+    cfg: cfg_mod.Config, source_id: str
+) -> dict[str, str]:
+    path = pending_reading_path(cfg, source_id)
+    if not path.exists():
+        return {}
+    try:
+        fm = reading_mod.read_frontmatter(path)
+    except reading_mod.ReadingError:
+        return {}
+    raw = fm.get("name_corrections") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items()}

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -249,8 +249,10 @@ def _build_client(cfg: cfg_mod.Config) -> OpenRouterClient:
     api_key = cfg.get_api_key()
     if not api_key:
         msg = (
-            f"OpenRouter API key not found (expected env var "
-            f"{cfg.openrouter.api_key_env}). Export it and retry."
+            "OpenRouter API key not found. Either export "
+            f"${cfg.openrouter.api_key_env} or store the key in "
+            "~/.auto-lorebook/credentials (the interactive ingest setup "
+            "writes this for you)."
         )
         raise ReadingPipelineError(msg)
     try:

--- a/src/auto_lorebook/source_store.py
+++ b/src/auto_lorebook/source_store.py
@@ -22,7 +22,7 @@ class CollisionError(Exception):
 
 
 def _transcript_filename(source_type: str) -> str:
-    if source_type == "srt":
+    if source_type in {"srt", "youtube"}:
         return "transcript.en.srt"
     if source_type == "markdown":
         return "transcript.md"

--- a/src/auto_lorebook/srt.py
+++ b/src/auto_lorebook/srt.py
@@ -1,0 +1,111 @@
+"""SRT subtitle parser.
+
+Produces a list of cues with start/end in seconds and text.
+Tolerates BOM, CRLF, extra blank lines, non-integer indices.
+Raises on missing `-->`, unparseable timestamps, or end-before-start.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from auto_lorebook.timestamps import TimestampError, parse_timestamp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_ARROW = "-->"
+
+
+class SrtError(ValueError):
+    """Raised for unrecoverable SRT parse errors."""
+
+
+@dataclass(frozen=True)
+class Cue:
+    """One SRT cue. Times in seconds."""
+
+    index: int
+    start: float
+    end: float
+    text: str
+
+
+def parse(text: str) -> list[Cue]:
+    """Parse SRT text into cues."""
+    # strip BOM, normalize line endings
+    text = text.removeprefix("﻿")
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    if not text.strip():
+        return []
+
+    cues: list[Cue] = []
+    # split on runs of blank lines
+    blocks = _split_blocks(text)
+    for raw_block in blocks:
+        lines = raw_block.split("\n")
+        if not lines:
+            continue
+        cue = _parse_block(lines, fallback_index=len(cues) + 1)
+        cues.append(cue)
+    return cues
+
+
+def parse_file(path: Path) -> list[Cue]:
+    """Read and parse an SRT file."""
+    return parse(path.read_text(encoding="utf-8"))
+
+
+def _split_blocks(text: str) -> list[str]:
+    blocks: list[str] = []
+    current: list[str] = []
+    for line in text.split("\n"):
+        if not line.strip():
+            if current:
+                blocks.append("\n".join(current))
+                current = []
+        else:
+            current.append(line)
+    if current:
+        blocks.append("\n".join(current))
+    return blocks
+
+
+def _parse_block(lines: list[str], *, fallback_index: int) -> Cue:
+    # first line may be index (int) or timestamp line
+    timestamp_idx = 0
+    index = fallback_index
+    if _ARROW not in lines[0]:
+        # consume index line (may be non-integer; tolerate)
+        raw = lines[0].strip()
+        try:
+            index = int(raw)
+        except ValueError:
+            index = fallback_index
+        timestamp_idx = 1
+
+    if timestamp_idx >= len(lines):
+        msg = f"cue missing timestamp line: {lines!r}"
+        raise SrtError(msg)
+
+    ts_line = lines[timestamp_idx]
+    if _ARROW not in ts_line:
+        msg = f"cue missing '-->' separator: {ts_line!r}"
+        raise SrtError(msg)
+
+    left, _, right = ts_line.partition(_ARROW)
+    try:
+        start = parse_timestamp(left)
+        end = parse_timestamp(right.split()[0] if right.split() else right)
+    except TimestampError as e:
+        msg = f"bad timestamp in {ts_line!r}: {e}"
+        raise SrtError(msg) from e
+
+    if end < start:
+        msg = f"end before start in {ts_line!r}"
+        raise SrtError(msg)
+
+    body_lines = lines[timestamp_idx + 1 :]
+    text = "\n".join(body_lines).strip()
+    return Cue(index=index, start=start, end=end, text=text)

--- a/src/auto_lorebook/stage1a.py
+++ b/src/auto_lorebook/stage1a.py
@@ -1,0 +1,184 @@
+"""Stage 1a: segment + attribute transcript in one LLM call.
+
+Emits a `Structure` validated by `structure.validate`.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from auto_lorebook import structure as structure_mod
+from auto_lorebook.structure import Structure, StructureValidationError
+
+if TYPE_CHECKING:
+    from auto_lorebook.openrouter import OpenRouterClient
+    from auto_lorebook.transcript import LoadedTranscript
+
+_logger = logging.getLogger(__name__)
+
+_CODE_FENCE_RE = re.compile(r"^```(?:json)?\s*\n(?P<body>.*?)\n```\s*$", re.DOTALL)
+
+_TASK_INSTRUCTIONS = """\
+You are segmenting an actual-play or lore transcript into a structured
+reading for a wiki. Read the transcript and emit a single JSON object
+matching this schema exactly:
+
+{
+  "default_speaker": "<str>",
+  "segments": [
+    {
+      "id": "seg-001",
+      "start": "h:mm:ss",
+      "end":   "h:mm:ss",
+      "title": "<short topic>",
+      "speaker": "<speaker name or 'mixed'>",
+      "notes": null | "<optional note for low-yield segments>",
+      "overrides": [
+        {
+          "start": "h:mm:ss",
+          "end":   "h:mm:ss",
+          "speaker": "<who was actually speaking>",
+          "voiced_by": null | "<who voiced them>",
+          "note":      null | "<note>"
+        }
+      ]
+    }
+  ],
+  "uncertainty_flags": [
+    {
+      "locator": "h:mm:ss",
+      "span":    "<short quote or description>",
+      "kind":    "name" | "attribution" | "other",
+      "note":    null | "<note>"
+    }
+  ]
+}
+
+Hard rules:
+- Segments MUST cover the transcript contiguously from 0:00:00 to the
+  transcript's end. No gaps, no overlaps. If a stretch is silence or
+  off-topic, still emit a segment (title: "silence", "break",
+  "off-topic rules lookup", etc.) — explicit is better than absent.
+- Segment IDs are `seg-NNN`, 1-indexed, in order.
+- Timestamps are `h:mm:ss` (variable-width hour, zero-padded m/s).
+- Overrides are optional and must fall inside their parent segment.
+- Err on the side of flagging uncertainty: a dismissed flag costs
+  seconds; a silently-swallowed uncertain name pollutes a downstream
+  fact.
+
+Emit ONLY the JSON object. No prose, no code fences, no commentary.
+"""
+
+
+class Stage1aError(RuntimeError):
+    """Stage 1a failed: bad JSON, schema violation, or validation failure."""
+
+
+def run(
+    *,
+    transcript: LoadedTranscript,
+    preamble_text: str,
+    source_id: str,
+    client: OpenRouterClient,
+    model: str,
+) -> Structure:
+    """Run Stage 1a on a loaded transcript.
+
+    :raises Stage1aError: bad LLM output or mechanical-validation failure
+    """
+    system_content = _build_system(preamble_text)
+    user_content = _build_user(transcript)
+    messages = [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_content},
+    ]
+
+    resp = client.complete(
+        messages,
+        model=model,
+        response_format={"type": "json_object"},
+    )
+
+    payload = _parse_json(resp.text)
+    structure = _payload_to_structure(
+        payload,
+        source_id=source_id,
+        generated_at=_now_iso(),
+    )
+
+    try:
+        structure_mod.validate(structure, transcript.total_duration)
+    except StructureValidationError as e:
+        msg = f"Stage 1a mechanical validation failed: {e}"
+        raise Stage1aError(msg) from e
+
+    return structure
+
+
+def _build_system(preamble_text: str) -> str:
+    if preamble_text.strip():
+        return f"{preamble_text}\n\n---\n\n{_TASK_INSTRUCTIONS}"
+    return _TASK_INSTRUCTIONS
+
+
+def _build_user(transcript: LoadedTranscript) -> str:
+    return (
+        f"Transcript (total duration ~{transcript.total_duration:.0f}s):\n\n"
+        f"{transcript.text_for_llm}"
+    )
+
+
+def _parse_json(text: str) -> dict[str, Any]:
+    raw = text.strip()
+    m = _CODE_FENCE_RE.match(raw)
+    if m:
+        raw = m.group("body").strip()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        msg = f"Stage 1a response was not valid JSON: {e}"
+        raise Stage1aError(msg) from e
+    if not isinstance(parsed, dict):
+        msg = f"Stage 1a response must be a JSON object, got {type(parsed).__name__}"
+        raise Stage1aError(msg)
+    return parsed
+
+
+def _payload_to_structure(
+    payload: dict[str, Any],
+    *,
+    source_id: str,
+    generated_at: str,
+) -> Structure:
+    segments_raw = payload.get("segments")
+    if not isinstance(segments_raw, list) or not segments_raw:
+        msg = "Stage 1a response has no segments"
+        raise Stage1aError(msg)
+    try:
+        segments = [structure_mod._parse_segment(s) for s in segments_raw]  # noqa: SLF001
+    except (KeyError, ValueError, TypeError) as e:
+        msg = f"Stage 1a segment schema violation: {e}"
+        raise Stage1aError(msg) from e
+
+    flags_raw = payload.get("uncertainty_flags") or []
+    try:
+        flags = [structure_mod._parse_flag(f) for f in flags_raw]  # noqa: SLF001
+    except (KeyError, ValueError, TypeError) as e:
+        msg = f"Stage 1a uncertainty_flag schema violation: {e}"
+        raise Stage1aError(msg) from e
+
+    return Structure(
+        source_id=source_id,
+        generated_at=generated_at,
+        default_speaker=str(payload.get("default_speaker") or ""),
+        segments=segments,
+        uncertainty_flags=flags,
+    )
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/src/auto_lorebook/stage1a.py
+++ b/src/auto_lorebook/stage1a.py
@@ -5,22 +5,19 @@ Emits a `Structure` validated by `structure.validate`.
 
 from __future__ import annotations
 
-import datetime
-import json
 import logging
-import re
 from typing import TYPE_CHECKING, Any
 
 from auto_lorebook import structure as structure_mod
+from auto_lorebook.llm_helpers import build_system_prompt, parse_json_object
 from auto_lorebook.structure import Structure, StructureValidationError
+from auto_lorebook.timestamps import format_iso_now
 
 if TYPE_CHECKING:
     from auto_lorebook.openrouter import OpenRouterClient
     from auto_lorebook.transcript import LoadedTranscript
 
 _logger = logging.getLogger(__name__)
-
-_CODE_FENCE_RE = re.compile(r"^```(?:json)?\s*\n(?P<body>.*?)\n```\s*$", re.DOTALL)
 
 _TASK_INSTRUCTIONS = """\
 You are segmenting an actual-play or lore transcript into a structured
@@ -90,11 +87,12 @@ def run(
 
     :raises Stage1aError: bad LLM output or mechanical-validation failure
     """
-    system_content = _build_system(preamble_text)
-    user_content = _build_user(transcript)
     messages = [
-        {"role": "system", "content": system_content},
-        {"role": "user", "content": user_content},
+        {
+            "role": "system",
+            "content": build_system_prompt(preamble_text, _TASK_INSTRUCTIONS),
+        },
+        {"role": "user", "content": _build_user(transcript)},
     ]
 
     resp = client.complete(
@@ -103,11 +101,14 @@ def run(
         response_format={"type": "json_object"},
     )
 
-    payload = _parse_json(resp.text)
+    try:
+        payload = parse_json_object(resp.text, "Stage 1a")
+    except ValueError as e:
+        raise Stage1aError(str(e)) from e
     structure = _payload_to_structure(
         payload,
         source_id=source_id,
-        generated_at=_now_iso(),
+        generated_at=format_iso_now(),
     )
 
     try:
@@ -119,33 +120,11 @@ def run(
     return structure
 
 
-def _build_system(preamble_text: str) -> str:
-    if preamble_text.strip():
-        return f"{preamble_text}\n\n---\n\n{_TASK_INSTRUCTIONS}"
-    return _TASK_INSTRUCTIONS
-
-
 def _build_user(transcript: LoadedTranscript) -> str:
     return (
         f"Transcript (total duration ~{transcript.total_duration:.0f}s):\n\n"
         f"{transcript.text_for_llm}"
     )
-
-
-def _parse_json(text: str) -> dict[str, Any]:
-    raw = text.strip()
-    m = _CODE_FENCE_RE.match(raw)
-    if m:
-        raw = m.group("body").strip()
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError as e:
-        msg = f"Stage 1a response was not valid JSON: {e}"
-        raise Stage1aError(msg) from e
-    if not isinstance(parsed, dict):
-        msg = f"Stage 1a response must be a JSON object, got {type(parsed).__name__}"
-        raise Stage1aError(msg)
-    return parsed
 
 
 def _payload_to_structure(
@@ -159,14 +138,14 @@ def _payload_to_structure(
         msg = "Stage 1a response has no segments"
         raise Stage1aError(msg)
     try:
-        segments = [structure_mod._parse_segment(s) for s in segments_raw]  # noqa: SLF001
+        segments = [structure_mod.parse_segment(s) for s in segments_raw]
     except (KeyError, ValueError, TypeError) as e:
         msg = f"Stage 1a segment schema violation: {e}"
         raise Stage1aError(msg) from e
 
     flags_raw = payload.get("uncertainty_flags") or []
     try:
-        flags = [structure_mod._parse_flag(f) for f in flags_raw]  # noqa: SLF001
+        flags = [structure_mod.parse_flag(f) for f in flags_raw]
     except (KeyError, ValueError, TypeError) as e:
         msg = f"Stage 1a uncertainty_flag schema violation: {e}"
         raise Stage1aError(msg) from e
@@ -178,7 +157,3 @@ def _payload_to_structure(
         segments=segments,
         uncertainty_flags=flags,
     )
-
-
-def _now_iso() -> str:
-    return datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/src/auto_lorebook/stage1b.py
+++ b/src/auto_lorebook/stage1b.py
@@ -1,0 +1,330 @@
+"""Stage 1b: per-segment claim extraction, parallelized across segments.
+
+Takes Stage 1a's Structure plus the loaded transcript; produces a
+`ReadingBullets` artifact keyed by segment id. Each bullet carries an
+anchor timestamp and a `locator_hint` window that flows into the
+planner/extractor downstream.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import re
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from auto_lorebook._io import atomic_write_text
+from auto_lorebook.schema import SchemaVersionError, read_schema_version
+from auto_lorebook.timestamps import (
+    TimestampError,
+    format_timestamp,
+    parse_timestamp,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from auto_lorebook.openrouter import OpenRouterClient
+    from auto_lorebook.structure import Segment, Structure
+    from auto_lorebook.transcript import LoadedTranscript
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_HINT_WINDOW_SECONDS = 15.0
+DEFAULT_MAX_CONCURRENCY = 4
+
+_CODE_FENCE_RE = re.compile(r"^```(?:json)?\s*\n(?P<body>.*?)\n```\s*$", re.DOTALL)
+_TIMESTAMP_LINE_RE = re.compile(r"^\[(?P<ts>[0-9:,.]+)\]\s?(?P<body>.*)$")
+
+_TASK_INSTRUCTIONS = """\
+You are extracting worldbuilding and narrative claims from ONE segment
+of an actual-play / lore transcript. Read the segment below and emit a
+single JSON object of the form:
+
+{
+  "bullets": [
+    {
+      "text":   "<one short, self-contained claim>",
+      "anchor": "h:mm:ss"
+    }
+  ]
+}
+
+Hard rules:
+- `bullets` MAY be empty. An off-topic, rules, or silence segment
+  typically yields no bullets — emit `{"bullets": []}` in that case.
+- `anchor` is a plain `h:mm:ss` timestamp INSIDE the segment where the
+  claim is made. Use the timestamps visible in the transcript lines.
+- Prefer short, factual bullets; one claim per bullet. Resolve pronouns
+  where possible ("The king" → "King Theron").
+- Err on the side of over-inclusion: a spurious bullet costs the human
+  seconds to reject; a missed claim is a permanent gap.
+
+Emit ONLY the JSON object. No prose, no code fences, no commentary.
+"""
+
+
+class Stage1bError(RuntimeError):
+    """Stage 1b failed on at least one segment."""
+
+
+@dataclass(frozen=True)
+class Bullet:
+    """One extracted claim with anchor and locator-hint window."""
+
+    text: str
+    anchor: float
+    locator_hint_start: float
+    locator_hint_end: float
+
+
+@dataclass
+class ReadingBullets:
+    """Stage 1b output: bullets keyed by segment id."""
+
+    source_id: str
+    generated_at: str
+    segments: dict[str, list[Bullet]] = field(default_factory=dict)
+
+
+def slice_transcript_for_segment(
+    transcript: LoadedTranscript,
+    segment: Segment,
+) -> str:
+    """Return only the `[h:mm:ss] ...` lines whose timestamp lies in segment.
+
+    Lines without a recognised `[h:mm:ss]` marker are preserved only if
+    the transcript has no timestamp markers at all (plain text).
+    """
+    lines = transcript.text_for_llm.splitlines()
+    if not any(_TIMESTAMP_LINE_RE.match(ln) for ln in lines):
+        return transcript.text_for_llm
+
+    kept: list[str] = []
+    for ln in lines:
+        m = _TIMESTAMP_LINE_RE.match(ln)
+        if not m:
+            continue
+        try:
+            t = parse_timestamp(m.group("ts"))
+        except TimestampError:
+            continue
+        if segment.start <= t < segment.end:
+            kept.append(ln)
+    return "\n".join(kept)
+
+
+def run(
+    *,
+    transcript: LoadedTranscript,
+    structure: Structure,
+    preamble_text: str,
+    client: OpenRouterClient,
+    model: str,
+    hint_window_seconds: float = DEFAULT_HINT_WINDOW_SECONDS,
+    max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+    segment_ids: list[str] | None = None,
+) -> ReadingBullets:
+    """Run Stage 1b in parallel across `structure.segments`.
+
+    :param segment_ids: if given, run only these segments (unknown ids
+        raise). Default: run all segments.
+    :raises Stage1bError: any segment's LLM response fails parsing /
+        validation
+    """
+    if segment_ids is not None:
+        known = {s.id for s in structure.segments}
+        unknown = [sid for sid in segment_ids if sid not in known]
+        if unknown:
+            msg = f"unknown segment ids: {unknown}"
+            raise Stage1bError(msg)
+        targets = [s for s in structure.segments if s.id in set(segment_ids)]
+    else:
+        targets = list(structure.segments)
+
+    results: dict[str, list[Bullet]] = {}
+    with ThreadPoolExecutor(max_workers=max_concurrency) as ex:
+        futures = {
+            ex.submit(
+                _run_one,
+                seg,
+                transcript,
+                preamble_text,
+                client,
+                model,
+                hint_window_seconds,
+            ): seg.id
+            for seg in targets
+        }
+        for future, seg_id in futures.items():
+            results[seg_id] = future.result()
+
+    return ReadingBullets(
+        source_id=structure.source_id,
+        generated_at=_now_iso(),
+        segments=results,
+    )
+
+
+def _run_one(
+    segment: Segment,
+    transcript: LoadedTranscript,
+    preamble_text: str,
+    client: OpenRouterClient,
+    model: str,
+    hint_window_seconds: float,
+) -> list[Bullet]:
+    segment_text = slice_transcript_for_segment(transcript, segment)
+    system_content = _build_system(preamble_text)
+    user_content = _build_user(segment, segment_text)
+    messages = [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_content},
+    ]
+    resp = client.complete(
+        messages,
+        model=model,
+        response_format={"type": "json_object"},
+    )
+    payload = _parse_json(resp.text, segment.id)
+    raw_bullets = payload.get("bullets")
+    if raw_bullets is None:
+        raw_bullets = []
+    if not isinstance(raw_bullets, list):
+        msg = f"Stage 1b for {segment.id}: 'bullets' must be a list"
+        raise Stage1bError(msg)
+
+    return [_parse_bullet(raw, segment, hint_window_seconds) for raw in raw_bullets]
+
+
+def _build_system(preamble_text: str) -> str:
+    if preamble_text.strip():
+        return f"{preamble_text}\n\n---\n\n{_TASK_INSTRUCTIONS}"
+    return _TASK_INSTRUCTIONS
+
+
+def _build_user(segment: Segment, segment_text: str) -> str:
+    return (
+        f'Segment {segment.id}: "{segment.title}" '
+        f"(speaker: {segment.speaker})\n"
+        f"Range: {segment.start:.0f}s - {segment.end:.0f}s\n\n"
+        f"Transcript for this segment:\n\n{segment_text}"
+    )
+
+
+def _parse_json(text: str, segment_id: str) -> dict[str, Any]:
+    raw = text.strip()
+    m = _CODE_FENCE_RE.match(raw)
+    if m:
+        raw = m.group("body").strip()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        msg = f"Stage 1b for {segment_id}: response was not valid JSON: {e}"
+        raise Stage1bError(msg) from e
+    if not isinstance(parsed, dict):
+        msg = f"Stage 1b for {segment_id}: response must be a JSON object"
+        raise Stage1bError(msg)
+    return parsed
+
+
+def _parse_bullet(
+    raw: dict[str, Any],
+    segment: Segment,
+    hint_window_seconds: float,
+) -> Bullet:
+    if not isinstance(raw, dict):
+        msg = f"Stage 1b for {segment.id}: each bullet must be an object"
+        raise Stage1bError(msg)
+    text = str(raw.get("text") or "").strip()
+    if not text:
+        msg = f"Stage 1b for {segment.id}: bullet has empty text"
+        raise Stage1bError(msg)
+    try:
+        anchor = parse_timestamp(str(raw.get("anchor") or ""))
+    except TimestampError as e:
+        msg = f"Stage 1b for {segment.id}: bad anchor timestamp: {e}"
+        raise Stage1bError(msg) from e
+    if not (segment.start <= anchor <= segment.end):
+        msg = (
+            f"Stage 1b for {segment.id}: bullet anchor {anchor}s outside "
+            f"segment ({segment.start}-{segment.end})"
+        )
+        raise Stage1bError(msg)
+    hint_start = max(segment.start, anchor - hint_window_seconds)
+    hint_end = min(segment.end, anchor + hint_window_seconds)
+    return Bullet(
+        text=text,
+        anchor=anchor,
+        locator_hint_start=hint_start,
+        locator_hint_end=hint_end,
+    )
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+_BULLETS_SCHEMA = 1
+
+
+def write_bullets(bullets: ReadingBullets, path: Path) -> None:
+    """Atomically write a ReadingBullets snapshot for regeneration."""
+    data: dict[str, Any] = {
+        "schema_version": _BULLETS_SCHEMA,
+        "source_id": bullets.source_id,
+        "generated_at": bullets.generated_at,
+        "segments": {
+            seg_id: [
+                {
+                    "text": b.text,
+                    "anchor": format_timestamp(b.anchor),
+                    "locator_hint_start": format_timestamp(b.locator_hint_start),
+                    "locator_hint_end": format_timestamp(b.locator_hint_end),
+                }
+                for b in bullet_list
+            ]
+            for seg_id, bullet_list in bullets.segments.items()
+        },
+    }
+    text = yaml.safe_dump(
+        data, allow_unicode=True, sort_keys=False, default_flow_style=False
+    )
+    atomic_write_text(path, text)
+
+
+def read_bullets(path: Path) -> ReadingBullets:
+    """Read a bullets.yaml snapshot."""
+    if not path.exists():
+        msg = f"{path}: file not found"
+        raise Stage1bError(msg)
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        msg = f"{path}: expected a YAML mapping"
+        raise Stage1bError(msg)
+    try:
+        read_schema_version(raw, str(path), max_supported=_BULLETS_SCHEMA)
+    except SchemaVersionError as e:
+        raise Stage1bError(str(e)) from e
+    segments_raw = raw.get("segments") or {}
+    segments: dict[str, list[Bullet]] = {}
+    for seg_id, bullet_list in segments_raw.items():
+        segments[str(seg_id)] = [
+            Bullet(
+                text=str(b["text"]),
+                anchor=parse_timestamp(str(b["anchor"])),
+                locator_hint_start=parse_timestamp(str(b["locator_hint_start"])),
+                locator_hint_end=parse_timestamp(str(b["locator_hint_end"])),
+            )
+            for b in bullet_list
+        ]
+    return ReadingBullets(
+        source_id=str(raw.get("source_id") or ""),
+        generated_at=str(raw.get("generated_at") or ""),
+        segments=segments,
+    )

--- a/src/auto_lorebook/stage1b.py
+++ b/src/auto_lorebook/stage1b.py
@@ -8,8 +8,6 @@ planner/extractor downstream.
 
 from __future__ import annotations
 
-import datetime
-import json
 import logging
 import re
 from concurrent.futures import ThreadPoolExecutor
@@ -19,9 +17,11 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 from auto_lorebook._io import atomic_write_text
+from auto_lorebook.llm_helpers import build_system_prompt, parse_json_object
 from auto_lorebook.schema import SchemaVersionError, read_schema_version
 from auto_lorebook.timestamps import (
     TimestampError,
+    format_iso_now,
     format_timestamp,
     parse_timestamp,
 )
@@ -38,7 +38,6 @@ _logger = logging.getLogger(__name__)
 DEFAULT_HINT_WINDOW_SECONDS = 15.0
 DEFAULT_MAX_CONCURRENCY = 4
 
-_CODE_FENCE_RE = re.compile(r"^```(?:json)?\s*\n(?P<body>.*?)\n```\s*$", re.DOTALL)
 _TIMESTAMP_LINE_RE = re.compile(r"^\[(?P<ts>[0-9:,.]+)\]\s?(?P<body>.*)$")
 
 _TASK_INSTRUCTIONS = """\
@@ -166,7 +165,7 @@ def run(
 
     return ReadingBullets(
         source_id=structure.source_id,
-        generated_at=_now_iso(),
+        generated_at=format_iso_now(),
         segments=results,
     )
 
@@ -179,33 +178,33 @@ def _run_one(
     model: str,
     hint_window_seconds: float,
 ) -> list[Bullet]:
-    segment_text = slice_transcript_for_segment(transcript, segment)
-    system_content = _build_system(preamble_text)
-    user_content = _build_user(segment, segment_text)
     messages = [
-        {"role": "system", "content": system_content},
-        {"role": "user", "content": user_content},
+        {
+            "role": "system",
+            "content": build_system_prompt(preamble_text, _TASK_INSTRUCTIONS),
+        },
+        {
+            "role": "user",
+            "content": _build_user(
+                segment, slice_transcript_for_segment(transcript, segment)
+            ),
+        },
     ]
     resp = client.complete(
         messages,
         model=model,
         response_format={"type": "json_object"},
     )
-    payload = _parse_json(resp.text, segment.id)
-    raw_bullets = payload.get("bullets")
-    if raw_bullets is None:
-        raw_bullets = []
+    try:
+        payload = parse_json_object(resp.text, f"Stage 1b for {segment.id}")
+    except ValueError as e:
+        raise Stage1bError(str(e)) from e
+    raw_bullets = payload.get("bullets") or []
     if not isinstance(raw_bullets, list):
         msg = f"Stage 1b for {segment.id}: 'bullets' must be a list"
         raise Stage1bError(msg)
 
     return [_parse_bullet(raw, segment, hint_window_seconds) for raw in raw_bullets]
-
-
-def _build_system(preamble_text: str) -> str:
-    if preamble_text.strip():
-        return f"{preamble_text}\n\n---\n\n{_TASK_INSTRUCTIONS}"
-    return _TASK_INSTRUCTIONS
 
 
 def _build_user(segment: Segment, segment_text: str) -> str:
@@ -215,22 +214,6 @@ def _build_user(segment: Segment, segment_text: str) -> str:
         f"Range: {segment.start:.0f}s - {segment.end:.0f}s\n\n"
         f"Transcript for this segment:\n\n{segment_text}"
     )
-
-
-def _parse_json(text: str, segment_id: str) -> dict[str, Any]:
-    raw = text.strip()
-    m = _CODE_FENCE_RE.match(raw)
-    if m:
-        raw = m.group("body").strip()
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError as e:
-        msg = f"Stage 1b for {segment_id}: response was not valid JSON: {e}"
-        raise Stage1bError(msg) from e
-    if not isinstance(parsed, dict):
-        msg = f"Stage 1b for {segment_id}: response must be a JSON object"
-        raise Stage1bError(msg)
-    return parsed
 
 
 def _parse_bullet(
@@ -264,10 +247,6 @@ def _parse_bullet(
         locator_hint_start=hint_start,
         locator_hint_end=hint_end,
     )
-
-
-def _now_iso() -> str:
-    return datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 _BULLETS_SCHEMA = 1

--- a/src/auto_lorebook/structure.py
+++ b/src/auto_lorebook/structure.py
@@ -135,7 +135,7 @@ def _parse_override(raw: dict[str, Any]) -> Override:
     )
 
 
-def _parse_segment(raw: dict[str, Any]) -> Segment:
+def parse_segment(raw: dict[str, Any]) -> Segment:
     overrides_raw = raw.get("overrides") or []
     return Segment(
         id=str(raw["id"]),
@@ -148,7 +148,7 @@ def _parse_segment(raw: dict[str, Any]) -> Segment:
     )
 
 
-def _parse_flag(raw: dict[str, Any]) -> UncertaintyFlag:
+def parse_flag(raw: dict[str, Any]) -> UncertaintyFlag:
     return UncertaintyFlag(
         locator=parse_timestamp(str(raw["locator"])),
         span=str(raw.get("span") or ""),
@@ -178,9 +178,9 @@ def read(path: Path) -> Structure:
             source_id=str(raw["source_id"]),
             generated_at=str(raw["generated_at"]),
             default_speaker=str(raw.get("default_speaker") or ""),
-            segments=[_parse_segment(s) for s in (raw.get("segments") or [])],
+            segments=[parse_segment(s) for s in (raw.get("segments") or [])],
             uncertainty_flags=[
-                _parse_flag(f) for f in (raw.get("uncertainty_flags") or [])
+                parse_flag(f) for f in (raw.get("uncertainty_flags") or [])
             ],
         )
     except (KeyError, ValueError) as e:

--- a/src/auto_lorebook/structure.py
+++ b/src/auto_lorebook/structure.py
@@ -1,0 +1,276 @@
+"""Stage 1a `structure.yaml`: schema, read/write, mechanical validation.
+
+Internal representation uses float seconds. Writers emit canonical
+`h:mm:ss` strings; readers accept any form `parse_timestamp` handles.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from auto_lorebook._io import atomic_write_text
+from auto_lorebook.schema import SchemaVersionError, read_schema_version
+from auto_lorebook.timestamps import format_timestamp, parse_timestamp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_MAX_SCHEMA = 1
+UNCERTAINTY_KINDS = frozenset({"name", "attribution", "other"})
+
+
+class StructureError(ValueError):
+    """Raised when structure.yaml is missing or malformed on read."""
+
+
+class StructureValidationError(ValueError):
+    """Raised when mechanical checks on a Structure fail."""
+
+
+@dataclass
+class Override:
+    """Mid-segment speaker override."""
+
+    start: float
+    end: float
+    speaker: str
+    voiced_by: str | None = None
+    note: str | None = None
+
+
+@dataclass
+class Segment:
+    """One topic-bounded segment with attributed speaker."""
+
+    id: str
+    start: float
+    end: float
+    title: str
+    speaker: str
+    notes: str | None = None
+    overrides: list[Override] = field(default_factory=list)
+
+
+@dataclass
+class UncertaintyFlag:
+    """Model-flagged uncertain word, name, or attribution."""
+
+    locator: float
+    span: str
+    kind: str  # name | attribution | other
+    note: str | None = None
+
+
+@dataclass
+class Structure:
+    """In-memory representation of structure.yaml."""
+
+    source_id: str
+    generated_at: str
+    default_speaker: str
+    segments: list[Segment] = field(default_factory=list)
+    uncertainty_flags: list[UncertaintyFlag] = field(default_factory=list)
+
+
+def _override_to_dict(o: Override) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "start": format_timestamp(o.start),
+        "end": format_timestamp(o.end),
+        "speaker": o.speaker,
+    }
+    if o.voiced_by is not None:
+        out["voiced_by"] = o.voiced_by
+    if o.note is not None:
+        out["note"] = o.note
+    return out
+
+
+def _segment_to_dict(s: Segment) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "id": s.id,
+        "start": format_timestamp(s.start),
+        "end": format_timestamp(s.end),
+        "title": s.title,
+        "speaker": s.speaker,
+    }
+    if s.notes is not None:
+        out["notes"] = s.notes
+    if s.overrides:
+        out["overrides"] = [_override_to_dict(o) for o in s.overrides]
+    return out
+
+
+def _flag_to_dict(f: UncertaintyFlag) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "locator": format_timestamp(f.locator),
+        "span": f.span,
+        "kind": f.kind,
+    }
+    if f.note is not None:
+        out["note"] = f.note
+    return out
+
+
+def _to_dict(s: Structure) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "source_id": s.source_id,
+        "generated_at": s.generated_at,
+        "default_speaker": s.default_speaker,
+        "segments": [_segment_to_dict(seg) for seg in s.segments],
+        "uncertainty_flags": [_flag_to_dict(f) for f in s.uncertainty_flags],
+    }
+
+
+def _parse_override(raw: dict[str, Any]) -> Override:
+    return Override(
+        start=parse_timestamp(str(raw["start"])),
+        end=parse_timestamp(str(raw["end"])),
+        speaker=str(raw["speaker"]),
+        voiced_by=(raw.get("voiced_by") or None),
+        note=(raw.get("note") or None),
+    )
+
+
+def _parse_segment(raw: dict[str, Any]) -> Segment:
+    overrides_raw = raw.get("overrides") or []
+    return Segment(
+        id=str(raw["id"]),
+        start=parse_timestamp(str(raw["start"])),
+        end=parse_timestamp(str(raw["end"])),
+        title=str(raw["title"]),
+        speaker=str(raw["speaker"]),
+        notes=(raw.get("notes") or None),
+        overrides=[_parse_override(o) for o in overrides_raw],
+    )
+
+
+def _parse_flag(raw: dict[str, Any]) -> UncertaintyFlag:
+    return UncertaintyFlag(
+        locator=parse_timestamp(str(raw["locator"])),
+        span=str(raw.get("span") or ""),
+        kind=str(raw.get("kind") or "other"),
+        note=(raw.get("note") or None),
+    )
+
+
+def read(path: Path) -> Structure:
+    """Read and parse structure.yaml.
+
+    :raises StructureError: missing / malformed / unsupported schema
+    """
+    if not path.exists():
+        msg = f"{path}: file not found"
+        raise StructureError(msg)
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        msg = f"{path}: expected a YAML mapping"
+        raise StructureError(msg)
+    try:
+        read_schema_version(raw, str(path), max_supported=_MAX_SCHEMA)
+    except SchemaVersionError as e:
+        raise StructureError(str(e)) from e
+    try:
+        return Structure(
+            source_id=str(raw["source_id"]),
+            generated_at=str(raw["generated_at"]),
+            default_speaker=str(raw.get("default_speaker") or ""),
+            segments=[_parse_segment(s) for s in (raw.get("segments") or [])],
+            uncertainty_flags=[
+                _parse_flag(f) for f in (raw.get("uncertainty_flags") or [])
+            ],
+        )
+    except (KeyError, ValueError) as e:
+        msg = f"{path}: malformed structure ({e})"
+        raise StructureError(msg) from e
+
+
+def write(structure: Structure, path: Path) -> None:
+    """Atomically write structure.yaml."""
+    text = yaml.safe_dump(
+        _to_dict(structure),
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    )
+    atomic_write_text(path, text)
+
+
+def validate(
+    structure: Structure,
+    total_duration: float,
+    *,
+    tolerance: float = 1.0,
+) -> None:
+    """Run mechanical checks on a Structure.
+
+    :param total_duration: transcript length in seconds
+    :param tolerance: allowed slack (seconds) at segment boundaries / coverage
+    :raises StructureValidationError: on first failing check
+    """
+    if not structure.segments:
+        msg = "structure has no segments"
+        raise StructureValidationError(msg)
+
+    ids = [s.id for s in structure.segments]
+    if len(set(ids)) != len(ids):
+        msg = f"duplicate segment ids: {[i for i in ids if ids.count(i) > 1]}"
+        raise StructureValidationError(msg)
+
+    first = structure.segments[0]
+    last = structure.segments[-1]
+    if first.start > tolerance:
+        msg = f"first segment must start at 0 (got {first.start}s)"
+        raise StructureValidationError(msg)
+    if last.end < total_duration - tolerance:
+        msg = (
+            f"last segment ends at {last.end}s but transcript "
+            f"duration is {total_duration}s"
+        )
+        raise StructureValidationError(msg)
+
+    for seg in structure.segments:
+        if seg.end < seg.start:
+            msg = f"segment {seg.id}: end {seg.end} before start {seg.start}"
+            raise StructureValidationError(msg)
+
+    for prev, nxt in zip(structure.segments, structure.segments[1:], strict=False):
+        delta = nxt.start - prev.end
+        if delta > tolerance:
+            msg = (
+                f"gap between {prev.id} (ends {prev.end}s) and "
+                f"{nxt.id} (starts {nxt.start}s): {delta:.1f}s"
+            )
+            raise StructureValidationError(msg)
+        if delta < -tolerance:
+            msg = (
+                f"overlap between {prev.id} (ends {prev.end}s) and "
+                f"{nxt.id} (starts {nxt.start}s): {-delta:.1f}s"
+            )
+            raise StructureValidationError(msg)
+
+    for seg in structure.segments:
+        for ov in seg.overrides:
+            if ov.start < seg.start - tolerance or ov.end > seg.end + tolerance:
+                msg = (
+                    f"override in {seg.id} ({ov.start}-{ov.end}) falls outside "
+                    f"parent segment ({seg.start}-{seg.end})"
+                )
+                raise StructureValidationError(msg)
+            if ov.end < ov.start:
+                msg = f"override in {seg.id}: end {ov.end} before start {ov.start}"
+                raise StructureValidationError(msg)
+
+    for flag in structure.uncertainty_flags:
+        if flag.kind not in UNCERTAINTY_KINDS:
+            msg = f"uncertainty flag kind must be one of {sorted(UNCERTAINTY_KINDS)}"
+            raise StructureValidationError(msg)
+        if not any(
+            seg.start - tolerance <= flag.locator <= seg.end + tolerance
+            for seg in structure.segments
+        ):
+            msg = f"uncertainty flag locator {flag.locator}s outside all segments"
+            raise StructureValidationError(msg)

--- a/src/auto_lorebook/timestamps.py
+++ b/src/auto_lorebook/timestamps.py
@@ -1,0 +1,66 @@
+"""Canonical timestamp handling.
+
+Writers emit `h:mm:ss` (variable-width hour, zero-padded minutes/seconds).
+Parser is lenient: accepts canonical form, leading-zero hours, `mm:ss`,
+fractional seconds with `.` or SRT-style `,` decimal separators.
+"""
+
+from __future__ import annotations
+
+
+class TimestampError(ValueError):
+    """Raised for invalid timestamp input."""
+
+
+def format_timestamp(seconds: float) -> str:
+    """Format seconds as canonical `h:mm:ss`.
+
+    :raises TimestampError: negative input
+    """
+    if seconds < 0:
+        msg = f"negative timestamp: {seconds!r}"
+        raise TimestampError(msg)
+    whole = int(seconds)
+    h, rem = divmod(whole, 3_600)
+    m, s = divmod(rem, 60)
+    return f"{h}:{m:02d}:{s:02d}"
+
+
+def parse_timestamp(text: str) -> float:
+    """Parse a lenient timestamp string to seconds.
+
+    :raises TimestampError: empty, malformed, or negative
+    """
+    if not isinstance(text, str):
+        msg = f"timestamp must be str, got {type(text).__name__}"
+        raise TimestampError(msg)
+    raw = text.strip()
+    if not raw:
+        msg = "empty timestamp"
+        raise TimestampError(msg)
+
+    # SRT-style comma decimal → dot
+    normalized = raw.replace(",", ".")
+    parts = normalized.split(":")
+    if len(parts) not in {2, 3}:
+        msg = f"expected h:mm:ss or mm:ss, got {text!r}"
+        raise TimestampError(msg)
+
+    try:
+        if len(parts) == 3:
+            h = int(parts[0])
+            m = int(parts[1])
+            s = float(parts[2])
+        else:
+            h = 0
+            m = int(parts[0])
+            s = float(parts[1])
+    except ValueError as e:
+        msg = f"malformed timestamp {text!r}: {e}"
+        raise TimestampError(msg) from e
+
+    if h < 0 or m < 0 or s < 0:
+        msg = f"negative component in {text!r}"
+        raise TimestampError(msg)
+
+    return h * 3_600 + m * 60 + s

--- a/src/auto_lorebook/timestamps.py
+++ b/src/auto_lorebook/timestamps.py
@@ -3,13 +3,22 @@
 Writers emit `h:mm:ss` (variable-width hour, zero-padded minutes/seconds).
 Parser is lenient: accepts canonical form, leading-zero hours, `mm:ss`,
 fractional seconds with `.` or SRT-style `,` decimal separators.
+
+`format_iso_now` emits RFC 3339 UTC for wall-clock `*_at` fields.
 """
 
 from __future__ import annotations
 
+import datetime
+
 
 class TimestampError(ValueError):
     """Raised for invalid timestamp input."""
+
+
+def format_iso_now() -> str:
+    """Return current UTC time as `YYYY-MM-DDTHH:MM:SSZ`."""
+    return datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def format_timestamp(seconds: float) -> str:

--- a/src/auto_lorebook/transcript.py
+++ b/src/auto_lorebook/transcript.py
@@ -1,0 +1,83 @@
+"""Load a source's transcript for LLM input.
+
+SRT cues are flattened to `[h:mm:ss] text` lines. Plain-text sources are
+returned verbatim. `.transcription-corrections.yaml` literal
+substitutions are applied before returning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from auto_lorebook.srt import parse as parse_srt
+from auto_lorebook.timestamps import format_timestamp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from auto_lorebook.corrections import Corrections
+    from auto_lorebook.info_yaml import Info
+
+
+class TranscriptError(ValueError):
+    """Raised when a source's transcript file cannot be loaded."""
+
+
+@dataclass(frozen=True)
+class LoadedTranscript:
+    """Flattened transcript + duration for a source."""
+
+    text_for_llm: str
+    total_duration: float
+
+
+def apply_corrections(text: str, corrections: Corrections) -> str:
+    """Apply every correction's `wrong` → `right` substitution literally."""
+    out = text
+    for c in corrections.corrections:
+        out = out.replace(c.wrong, c.right)
+    return out
+
+
+def load(
+    wiki_repo: Path,
+    info: Info,
+    corrections: Corrections,
+) -> LoadedTranscript:
+    """Read the stored transcript for `info` under `wiki_repo`."""
+    fname = info.transcript_filename or _default_filename(info.source_type)
+    path = wiki_repo / "sources" / info.source_id / fname
+    if not path.exists():
+        msg = f"transcript not found: {path}"
+        raise TranscriptError(msg)
+
+    raw = path.read_text(encoding="utf-8")
+    if info.source_type in {"srt", "youtube"} or fname.endswith(".srt"):
+        text, duration = _render_srt(raw)
+    else:
+        text = raw
+        duration = float(info.duration_seconds or 0)
+
+    if info.duration_seconds is not None:
+        duration = float(info.duration_seconds)
+
+    corrected = apply_corrections(text, corrections)
+    return LoadedTranscript(text_for_llm=corrected, total_duration=duration)
+
+
+def _default_filename(source_type: str) -> str:
+    if source_type in {"srt", "youtube"}:
+        return "transcript.en.srt"
+    if source_type == "markdown":
+        return "transcript.md"
+    return "transcript.txt"
+
+
+def _render_srt(raw: str) -> tuple[str, float]:
+    cues = parse_srt(raw)
+    if not cues:
+        return "", 0.0
+    lines = [f"[{format_timestamp(c.start)}] {c.text}" for c in cues]
+    duration = cues[-1].end
+    return "\n".join(lines) + "\n", duration

--- a/src/auto_lorebook/ytdlp.py
+++ b/src/auto_lorebook/ytdlp.py
@@ -38,16 +38,23 @@ class FetchResult:
     srt_path: Path
 
 
-def fetch(url: str, target_dir: Path) -> FetchResult:
+def fetch(
+    url: str,
+    target_dir: Path,
+    *,
+    cookies_from_browser: str | None = None,
+) -> FetchResult:
     """Fetch title, duration, and English SRT for a YouTube URL.
 
     Writes `<id>.en[.auto].srt` into `target_dir`.
 
+    :param cookies_from_browser: browser name to load cookies from
+        (e.g. "chrome", "firefox"); helps bypass YouTube rate limits
     :raises NoSubtitlesError: no English subtitles available
     :raises YtDlpError: download failed or info missing required fields
     """
     target_dir.mkdir(parents=True, exist_ok=True)
-    ydl_opts = {
+    ydl_opts: dict[str, object] = {
         "skip_download": True,
         "writesubtitles": True,
         "writeautomaticsub": True,
@@ -58,6 +65,8 @@ def fetch(url: str, target_dir: Path) -> FetchResult:
         "quiet": True,
         "no_warnings": True,
     }
+    if cookies_from_browser:
+        ydl_opts["cookiesfrombrowser"] = (cookies_from_browser,)
     try:
         with YoutubeDL(ydl_opts) as ydl:
             info = ydl.extract_info(url, download=True)

--- a/src/auto_lorebook/ytdlp.py
+++ b/src/auto_lorebook/ytdlp.py
@@ -1,32 +1,27 @@
-"""yt-dlp subprocess wrapper.
+"""yt-dlp Python API wrapper.
 
-One call to fetch a YouTube source's info JSON and English SRT. The
-wrapper is intentionally thin — it shells out, surfaces errors with
-actionable messages, and returns a small dataclass.
+One call to fetch a YouTube source's English SRT via the yt-dlp library.
+Bundled ffmpeg (imageio-ffmpeg) handles subtitle format conversion.
 """
 
 from __future__ import annotations
 
-import json
 import logging
-import subprocess  # noqa: S404
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+import imageio_ffmpeg
+from yt_dlp import YoutubeDL
+from yt_dlp.utils import DownloadError
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
-_YT_DLP = "yt-dlp"
-
 
 class YtDlpError(RuntimeError):
     """yt-dlp failed or produced unexpected output."""
-
-
-class YtDlpNotFoundError(YtDlpError):
-    """yt-dlp binary not installed / not on PATH."""
 
 
 class NoSubtitlesError(YtDlpError):
@@ -41,71 +36,46 @@ class FetchResult:
     title: str
     duration: float
     srt_path: Path
-    info_json_path: Path
 
 
 def fetch(url: str, target_dir: Path) -> FetchResult:
     """Fetch title, duration, and English SRT for a YouTube URL.
 
-    Writes `<id>.info.json` and `<id>.en[.auto].srt` into `target_dir`.
+    Writes `<id>.en[.auto].srt` into `target_dir`.
 
-    :raises YtDlpNotFoundError: yt-dlp binary missing
     :raises NoSubtitlesError: no English subtitles available
-    :raises YtDlpError: subprocess non-zero exit or malformed output
+    :raises YtDlpError: download failed or info missing required fields
     """
     target_dir.mkdir(parents=True, exist_ok=True)
-    cmd = [
-        _YT_DLP,
-        "--skip-download",
-        "--write-info-json",
-        "--write-subs",
-        "--write-auto-subs",
-        "--sub-langs",
-        "en.*,en",
-        "--convert-subs",
-        "srt",
-        "-o",
-        "%(id)s.%(ext)s",
-        url,
-    ]
+    ydl_opts = {
+        "skip_download": True,
+        "writesubtitles": True,
+        "writeautomaticsub": True,
+        "subtitleslangs": ["en.*", "en"],
+        "subtitlesformat": "srt",
+        "outtmpl": str(target_dir / "%(id)s.%(ext)s"),
+        "ffmpeg_location": imageio_ffmpeg.get_ffmpeg_exe(),
+        "quiet": True,
+        "no_warnings": True,
+    }
     try:
-        proc = subprocess.run(  # noqa: S603
-            cmd,
-            cwd=target_dir,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    except FileNotFoundError as e:
-        msg = (
-            "yt-dlp not found on PATH. Install it "
-            "(e.g. `pipx install yt-dlp`) and retry."
-        )
-        raise YtDlpNotFoundError(msg) from e
+        with YoutubeDL(ydl_opts) as ydl:
+            info = ydl.extract_info(url, download=True)
+    except DownloadError as e:
+        raise YtDlpError(str(e)) from e
 
-    if proc.returncode != 0:
-        stderr = (proc.stderr or "").strip() or "(no stderr)"
-        msg = f"yt-dlp exited {proc.returncode}: {stderr}"
+    if not isinstance(info, dict):
+        msg = f"yt-dlp returned no info for {url}"
         raise YtDlpError(msg)
-
-    info_path = _find_info_json(target_dir)
-    if info_path is None:
-        msg = "yt-dlp succeeded but no *.info.json was written"
-        raise YtDlpError(msg)
-    try:
-        info = json.loads(info_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as e:
-        msg = f"could not read {info_path.name}: {e}"
-        raise YtDlpError(msg) from e
 
     video_id = info.get("id")
     title = info.get("title")
     duration = info.get("duration")
     if not video_id or not title or duration is None:
-        msg = f"info.json missing id/title/duration: {info_path.name}"
+        msg = f"yt-dlp info missing id/title/duration for {url}"
         raise YtDlpError(msg)
 
-    srt_path = _pick_srt(target_dir, video_id)
+    srt_path = _pick_srt(target_dir, str(video_id))
     if srt_path is None:
         msg = (
             f"no English subtitles available for {url}. "
@@ -118,13 +88,7 @@ def fetch(url: str, target_dir: Path) -> FetchResult:
         title=str(title),
         duration=float(duration),
         srt_path=srt_path,
-        info_json_path=info_path,
     )
-
-
-def _find_info_json(target_dir: Path) -> Path | None:
-    matches = sorted(target_dir.glob("*.info.json"))
-    return matches[0] if matches else None
 
 
 def _pick_srt(target_dir: Path, video_id: str) -> Path | None:

--- a/src/auto_lorebook/ytdlp.py
+++ b/src/auto_lorebook/ytdlp.py
@@ -62,6 +62,10 @@ def fetch(
         "subtitlesformat": "srt",
         "outtmpl": str(target_dir / "%(id)s.%(ext)s"),
         "ffmpeg_location": imageio_ffmpeg.get_ffmpeg_exe(),
+        # yt-dlp validates format selection even with skip_download; the
+        # default `bv*+ba/b` can fail on videos lacking that combination.
+        # Chain falls back through video+audio, video-only, audio-only, any.
+        "format": "bv*+ba/b/bv/ba/b",
         "quiet": True,
         "no_warnings": True,
     }

--- a/src/auto_lorebook/ytdlp.py
+++ b/src/auto_lorebook/ytdlp.py
@@ -1,0 +1,136 @@
+"""yt-dlp subprocess wrapper.
+
+One call to fetch a YouTube source's info JSON and English SRT. The
+wrapper is intentionally thin — it shells out, surfaces errors with
+actionable messages, and returns a small dataclass.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess  # noqa: S404
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+_YT_DLP = "yt-dlp"
+
+
+class YtDlpError(RuntimeError):
+    """yt-dlp failed or produced unexpected output."""
+
+
+class YtDlpNotFoundError(YtDlpError):
+    """yt-dlp binary not installed / not on PATH."""
+
+
+class NoSubtitlesError(YtDlpError):
+    """yt-dlp ran but no English subtitles were written."""
+
+
+@dataclass(frozen=True)
+class FetchResult:
+    """Returned from `fetch`. Durations in seconds."""
+
+    video_id: str
+    title: str
+    duration: float
+    srt_path: Path
+    info_json_path: Path
+
+
+def fetch(url: str, target_dir: Path) -> FetchResult:
+    """Fetch title, duration, and English SRT for a YouTube URL.
+
+    Writes `<id>.info.json` and `<id>.en[.auto].srt` into `target_dir`.
+
+    :raises YtDlpNotFoundError: yt-dlp binary missing
+    :raises NoSubtitlesError: no English subtitles available
+    :raises YtDlpError: subprocess non-zero exit or malformed output
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        _YT_DLP,
+        "--skip-download",
+        "--write-info-json",
+        "--write-subs",
+        "--write-auto-subs",
+        "--sub-langs",
+        "en.*,en",
+        "--convert-subs",
+        "srt",
+        "-o",
+        "%(id)s.%(ext)s",
+        url,
+    ]
+    try:
+        proc = subprocess.run(  # noqa: S603
+            cmd,
+            cwd=target_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as e:
+        msg = (
+            "yt-dlp not found on PATH. Install it "
+            "(e.g. `pipx install yt-dlp`) and retry."
+        )
+        raise YtDlpNotFoundError(msg) from e
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip() or "(no stderr)"
+        msg = f"yt-dlp exited {proc.returncode}: {stderr}"
+        raise YtDlpError(msg)
+
+    info_path = _find_info_json(target_dir)
+    if info_path is None:
+        msg = "yt-dlp succeeded but no *.info.json was written"
+        raise YtDlpError(msg)
+    try:
+        info = json.loads(info_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        msg = f"could not read {info_path.name}: {e}"
+        raise YtDlpError(msg) from e
+
+    video_id = info.get("id")
+    title = info.get("title")
+    duration = info.get("duration")
+    if not video_id or not title or duration is None:
+        msg = f"info.json missing id/title/duration: {info_path.name}"
+        raise YtDlpError(msg)
+
+    srt_path = _pick_srt(target_dir, video_id)
+    if srt_path is None:
+        msg = (
+            f"no English subtitles available for {url}. "
+            "Video may lack captions or require a different language."
+        )
+        raise NoSubtitlesError(msg)
+
+    return FetchResult(
+        video_id=str(video_id),
+        title=str(title),
+        duration=float(duration),
+        srt_path=srt_path,
+        info_json_path=info_path,
+    )
+
+
+def _find_info_json(target_dir: Path) -> Path | None:
+    matches = sorted(target_dir.glob("*.info.json"))
+    return matches[0] if matches else None
+
+
+def _pick_srt(target_dir: Path, video_id: str) -> Path | None:
+    # prefer manual subs (<id>.en.srt) over auto (<id>.en.auto.srt)
+    preferred = target_dir / f"{video_id}.en.srt"
+    if preferred.exists():
+        return preferred
+    candidates = sorted(target_dir.glob(f"{video_id}.en*.srt"))
+    return candidates[0] if candidates else None

--- a/src/auto_lorebook/ytdlp.py
+++ b/src/auto_lorebook/ytdlp.py
@@ -62,10 +62,10 @@ def fetch(
         "subtitlesformat": "srt",
         "outtmpl": str(target_dir / "%(id)s.%(ext)s"),
         "ffmpeg_location": imageio_ffmpeg.get_ffmpeg_exe(),
-        # yt-dlp validates format selection even with skip_download; the
-        # default `bv*+ba/b` can fail on videos lacking that combination.
-        # Chain falls back through video+audio, video-only, audio-only, any.
-        "format": "bv*+ba/b/bv/ba/b",
+        # SABR/PO-Token gating can leave only image formats exposed; format
+        # selection then aborts with "Requested format is not available"
+        # *after* subtitles have already been written. Make it non-fatal.
+        "ignore_no_formats_error": True,
         "quiet": True,
         "no_warnings": True,
     }

--- a/tests/_ytdlp_fakes.py
+++ b/tests/_ytdlp_fakes.py
@@ -1,0 +1,52 @@
+"""Shared fake YoutubeDL class factory for ytdlp tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Self
+
+
+def make_fake_youtubedl(
+    *,
+    info: dict[str, Any] | None,
+    subs: dict[str, str] | None = None,
+    raises: Exception | None = None,
+) -> tuple[type, dict[str, Any]]:
+    """Return ``(FakeYDL class, captured_opts)`` for patching `YoutubeDL`.
+
+    On `extract_info`:
+    - If `raises` is set, raise it.
+    - Otherwise write each `subs` entry into `Path(captured_opts["outtmpl"]).parent`
+      and return `info`.
+
+    `captured_opts` is populated when the fake is constructed (i.e. when
+    `YoutubeDL(opts)` is called in the patched code).
+    """
+    captured_opts: dict[str, Any] = {}
+
+    class FakeYDL:
+        def __init__(self, opts: dict[str, Any]) -> None:
+            captured_opts.clear()
+            captured_opts.update(opts)
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            pass
+
+        def extract_info(
+            self,
+            _url: str,
+            *,
+            download: bool = True,  # noqa: ARG002
+        ) -> dict[str, Any] | None:
+            if raises is not None:
+                raise raises
+            if subs:
+                target_dir = Path(captured_opts["outtmpl"]).parent
+                for fname, body in subs.items():
+                    (target_dir / fname).write_text(body, encoding="utf-8")
+            return info
+
+    return FakeYDL, captured_opts

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 from auto_lorebook.config import (
+    Config,
     ConfigError,
     LastContext,
     MissingConfigError,
@@ -79,14 +80,24 @@ def test_load_config_missing_file_raises(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _patch_setup_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    inputs: list[str],
+    api_key: str = "",
+) -> None:
+    """Mock the visible-input answers and the hidden API-key prompt."""
+    answers = iter(inputs)
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    monkeypatch.setattr("auto_lorebook.config.getpass.getpass", lambda _prompt: api_key)
+
+
 def test_interactive_setup_writes_config_and_skeleton(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     home = tmp_path / "home"
     wiki = tmp_path / "wiki"
-    answers = iter([str(wiki), "", ""])  # accept defaults for env + model
-
-    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    _patch_setup_inputs(monkeypatch, inputs=[str(wiki), ""])
 
     cfg = interactive_setup(home=home)
 
@@ -101,17 +112,18 @@ def test_interactive_setup_writes_config_and_skeleton(
     assert (wiki / ".transcription-corrections.yaml").exists()
 
 
-def test_interactive_setup_custom_values(
+def test_interactive_setup_custom_model(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     home = tmp_path / "home"
     wiki = tmp_path / "mywiki"
-    answers = iter([str(wiki), "MY_KEY", "openrouter/anthropic/claude-opus-4-7"])
-    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    _patch_setup_inputs(
+        monkeypatch, inputs=[str(wiki), "openrouter/anthropic/claude-opus-4-7"]
+    )
 
     cfg = interactive_setup(home=home)
 
-    assert cfg.openrouter.api_key_env == "MY_KEY"
+    assert cfg.openrouter.api_key_env == "OPENROUTER_API_KEY"
     assert cfg.models.primary == "openrouter/anthropic/claude-opus-4-7"
 
 
@@ -120,9 +132,8 @@ def test_interactive_setup_reprompts_on_blank_required(
 ) -> None:
     home = tmp_path / "home"
     wiki = tmp_path / "wiki"
-    # first answer blank, second valid; defaults accepted for the rest
-    answers = iter(["", str(wiki), "", ""])
-    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    # first answer blank for wiki, second valid; default accepted for model
+    _patch_setup_inputs(monkeypatch, inputs=["", str(wiki), ""])
 
     cfg = interactive_setup(home=home)
     assert cfg.wiki_repo_path == wiki.resolve()
@@ -139,12 +150,75 @@ def test_interactive_setup_preserves_existing_wiki_files(
         "schema_version: 1\nsetting:\n  name: Aether\n", encoding="utf-8"
     )
 
-    answers = iter([str(wiki), "", ""])
-    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    _patch_setup_inputs(monkeypatch, inputs=[str(wiki), ""])
 
     interactive_setup(home=home)
     # existing content preserved
     assert "Aether" in existing.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# credentials file (~/.auto-lorebook/credentials)
+# ---------------------------------------------------------------------------
+
+
+def test_interactive_setup_writes_credentials_file_with_strict_perms(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hidden API-key prompt → 0600 credentials file alongside config.yaml."""
+    home = tmp_path / "home"
+    wiki = tmp_path / "wiki"
+    _patch_setup_inputs(monkeypatch, inputs=[str(wiki), ""], api_key="sk-or-v1-test")
+
+    interactive_setup(home=home)
+
+    cred_path = home / "credentials"
+    assert cred_path.exists()
+    assert cred_path.read_text(encoding="utf-8").strip() == "sk-or-v1-test"
+    mode = cred_path.stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_interactive_setup_blank_api_key_skips_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Blank → no credentials file written; user expected to use env var."""
+    home = tmp_path / "home"
+    wiki = tmp_path / "wiki"
+    _patch_setup_inputs(monkeypatch, inputs=[str(wiki), ""], api_key="")
+
+    interactive_setup(home=home)
+
+    assert not (home / "credentials").exists()
+
+
+def test_get_api_key_falls_back_to_credentials_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(tmp_path))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    (tmp_path / "credentials").write_text("sk-or-v1-fromfile\n", encoding="utf-8")
+    cfg = Config(wiki_repo_path=tmp_path / "wiki")
+    assert cfg.get_api_key() == "sk-or-v1-fromfile"
+
+
+def test_get_api_key_env_var_wins_over_credentials_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-fromenv")
+    (tmp_path / "credentials").write_text("sk-or-v1-fromfile", encoding="utf-8")
+    cfg = Config(wiki_repo_path=tmp_path / "wiki")
+    assert cfg.get_api_key() == "sk-or-v1-fromenv"
+
+
+def test_get_api_key_returns_none_when_neither_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(tmp_path))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    cfg = Config(wiki_repo_path=tmp_path / "wiki")
+    assert cfg.get_api_key() is None
 
 
 def test_load_config_missing_wiki_repo_raises(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,8 @@ import yaml
 from auto_lorebook.config import (
     ConfigError,
     LastContext,
+    MissingConfigError,
+    interactive_setup,
     load_config,
     load_last_context,
     save_last_context,
@@ -68,8 +70,81 @@ def test_load_config_with_all_fields(tmp_path: Path) -> None:
 
 
 def test_load_config_missing_file_raises(tmp_path: Path) -> None:
-    with pytest.raises(ConfigError, match="not found"):
+    with pytest.raises(MissingConfigError, match="not found"):
         load_config(home=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# interactive_setup
+# ---------------------------------------------------------------------------
+
+
+def test_interactive_setup_writes_config_and_skeleton(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    wiki = tmp_path / "wiki"
+    answers = iter([str(wiki), "", ""])  # accept defaults for env + model
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+
+    cfg = interactive_setup(home=home)
+
+    assert (home / "config.yaml").exists()
+    assert cfg.wiki_repo_path == wiki.resolve()
+    assert cfg.openrouter.api_key_env == "OPENROUTER_API_KEY"
+    assert cfg.models.primary == "openrouter/anthropic/claude-sonnet-4-5"
+    # wiki skeleton created
+    assert (wiki / "characters").is_dir()
+    assert (wiki / "concepts").is_dir()
+    assert (wiki / ".wiki-context.yaml").exists()
+    assert (wiki / ".transcription-corrections.yaml").exists()
+
+
+def test_interactive_setup_custom_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    wiki = tmp_path / "mywiki"
+    answers = iter([str(wiki), "MY_KEY", "openrouter/anthropic/claude-opus-4-7"])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+
+    cfg = interactive_setup(home=home)
+
+    assert cfg.openrouter.api_key_env == "MY_KEY"
+    assert cfg.models.primary == "openrouter/anthropic/claude-opus-4-7"
+
+
+def test_interactive_setup_reprompts_on_blank_required(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    wiki = tmp_path / "wiki"
+    # first answer blank, second valid; defaults accepted for the rest
+    answers = iter(["", str(wiki), "", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+
+    cfg = interactive_setup(home=home)
+    assert cfg.wiki_repo_path == wiki.resolve()
+
+
+def test_interactive_setup_preserves_existing_wiki_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    existing = wiki / ".wiki-context.yaml"
+    existing.write_text(
+        "schema_version: 1\nsetting:\n  name: Aether\n", encoding="utf-8"
+    )
+
+    answers = iter([str(wiki), "", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+
+    interactive_setup(home=home)
+    # existing content preserved
+    assert "Aether" in existing.read_text(encoding="utf-8")
 
 
 def test_load_config_missing_wiki_repo_raises(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -117,9 +117,7 @@ def test_interactive_setup_custom_model(
 ) -> None:
     home = tmp_path / "home"
     wiki = tmp_path / "mywiki"
-    _patch_setup_inputs(
-        monkeypatch, inputs=[str(wiki), "anthropic/claude-opus-4-7"]
-    )
+    _patch_setup_inputs(monkeypatch, inputs=[str(wiki), "anthropic/claude-opus-4-7"])
 
     cfg = interactive_setup(home=home)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,13 +37,13 @@ def test_load_config_minimal(tmp_path: Path) -> None:
             "schema_version": 1,
             "wiki_repo_path": wiki_path,
             "openrouter": {"api_key_env": "OPENROUTER_API_KEY"},
-            "models": {"primary": "openrouter/anthropic/claude-sonnet-4-5"},
+            "models": {"primary": "anthropic/claude-sonnet-4-5"},
         },
     )
     cfg = load_config(home=tmp_path)
     assert cfg.wiki_repo_path == Path(wiki_path)
     assert cfg.openrouter.api_key_env == "OPENROUTER_API_KEY"
-    assert cfg.models.primary == "openrouter/anthropic/claude-sonnet-4-5"
+    assert cfg.models.primary == "anthropic/claude-sonnet-4-5"
     assert cfg.models.primary_context_window == 200_000
     assert cfg.preamble.budget_fraction == pytest.approx(0.8)
 
@@ -57,16 +57,16 @@ def test_load_config_with_all_fields(tmp_path: Path) -> None:
             "wiki_repo_path": wiki_path,
             "openrouter": {"api_key_env": "MY_KEY"},
             "models": {
-                "primary": "openrouter/anthropic/claude-opus-4-7",
+                "primary": "anthropic/claude-opus-4-7",
                 "primary_context_window": 100_000,
-                "extractor": "openrouter/anthropic/claude-haiku-4-5",
+                "extractor": "anthropic/claude-haiku-4-5",
             },
             "preamble": {"budget_fraction": 0.6},
         },
     )
     cfg = load_config(home=tmp_path)
     assert cfg.models.primary_context_window == 100_000
-    assert cfg.models.extractor == "openrouter/anthropic/claude-haiku-4-5"
+    assert cfg.models.extractor == "anthropic/claude-haiku-4-5"
     assert cfg.preamble.budget_fraction == pytest.approx(0.6)
 
 
@@ -104,7 +104,7 @@ def test_interactive_setup_writes_config_and_skeleton(
     assert (home / "config.yaml").exists()
     assert cfg.wiki_repo_path == wiki.resolve()
     assert cfg.openrouter.api_key_env == "OPENROUTER_API_KEY"
-    assert cfg.models.primary == "openrouter/anthropic/claude-sonnet-4-5"
+    assert cfg.models.primary == "anthropic/claude-sonnet-4-5"
     # wiki skeleton created
     assert (wiki / "characters").is_dir()
     assert (wiki / "concepts").is_dir()
@@ -118,13 +118,13 @@ def test_interactive_setup_custom_model(
     home = tmp_path / "home"
     wiki = tmp_path / "mywiki"
     _patch_setup_inputs(
-        monkeypatch, inputs=[str(wiki), "openrouter/anthropic/claude-opus-4-7"]
+        monkeypatch, inputs=[str(wiki), "anthropic/claude-opus-4-7"]
     )
 
     cfg = interactive_setup(home=home)
 
     assert cfg.openrouter.api_key_env == "OPENROUTER_API_KEY"
-    assert cfg.models.primary == "openrouter/anthropic/claude-opus-4-7"
+    assert cfg.models.primary == "anthropic/claude-opus-4-7"
 
 
 def test_interactive_setup_reprompts_on_blank_required(

--- a/tests/test_gap_check.py
+++ b/tests/test_gap_check.py
@@ -1,0 +1,125 @@
+"""Tests for gap_check.py."""
+
+from __future__ import annotations
+
+from auto_lorebook.gap_check import DEFAULT_LOW_YIELD_PATTERNS, check
+from auto_lorebook.structure import Segment, Structure
+
+
+def _struct(segments: list[Segment]) -> Structure:
+    return Structure(
+        source_id="yt-x",
+        generated_at="2026-04-20T00:00:00Z",
+        default_speaker="DM",
+        segments=segments,
+    )
+
+
+class TestCheck:
+    def test_no_low_yield_segments(self) -> None:
+        s = _struct([
+            Segment(id="seg-001", start=0, end=600, title="Founding", speaker="DM"),
+        ])
+        assert check(s, threshold_seconds=300) == []
+
+    def test_single_short_low_yield_below_threshold(self) -> None:
+        s = _struct([
+            Segment(id="seg-001", start=0, end=120, title="Break", speaker="DM"),
+            Segment(id="seg-002", start=120, end=1200, title="Founding", speaker="DM"),
+        ])
+        assert check(s, threshold_seconds=300) == []
+
+    def test_long_low_yield_stretch_warns(self) -> None:
+        s = _struct([
+            Segment(
+                id="seg-001", start=0, end=600, title="Rules discussion", speaker="DM"
+            ),
+            Segment(id="seg-002", start=600, end=1200, title="Break", speaker="DM"),
+        ])
+        warnings = check(s, threshold_seconds=300)
+        assert len(warnings) == 1
+        w = warnings[0]
+        assert w.start == 0
+        assert w.end == 1200
+        assert len(w.segment_ids) == 2
+
+    def test_notes_signal_low_yield(self) -> None:
+        s = _struct([
+            Segment(
+                id="seg-001",
+                start=0,
+                end=500,
+                title="Tangent",
+                speaker="DM",
+                notes="off-topic pizza order",
+            ),
+            Segment(
+                id="seg-002",
+                start=500,
+                end=1100,
+                title="Aside",
+                speaker="DM",
+                notes="break",
+            ),
+            Segment(
+                id="seg-003",
+                start=1100,
+                end=2000,
+                title="Founding",
+                speaker="DM",
+            ),
+        ])
+        warnings = check(s, threshold_seconds=300)
+        assert len(warnings) == 1
+        assert warnings[0].end == 1100
+
+    def test_split_by_claim_bearing_segment(self) -> None:
+        # two separate low-yield stretches split by a real segment
+        s = _struct([
+            Segment(id="seg-001", start=0, end=400, title="Break", speaker="DM"),
+            Segment(
+                id="seg-002",
+                start=400,
+                end=1000,
+                title="Founding",
+                speaker="DM",
+            ),
+            Segment(id="seg-003", start=1000, end=1500, title="Break", speaker="DM"),
+        ])
+        # only 400s stretches; below 500s threshold → no warnings
+        assert check(s, threshold_seconds=500) == []
+        # but raise threshold low → both stretches fire
+        warnings = check(s, threshold_seconds=300)
+        assert len(warnings) == 2
+
+    def test_case_insensitive_match(self) -> None:
+        s = _struct([
+            Segment(id="seg-001", start=0, end=800, title="BREAK", speaker="DM"),
+        ])
+        warnings = check(s, threshold_seconds=300)
+        assert len(warnings) == 1
+
+    def test_custom_patterns(self) -> None:
+        s = _struct([
+            Segment(id="seg-001", start=0, end=800, title="Lunch", speaker="DM"),
+        ])
+        # default patterns don't include "lunch"
+        assert check(s, threshold_seconds=300) == []
+        # but custom patterns do
+        warnings = check(s, threshold_seconds=300, low_yield_patterns=["lunch"])
+        assert len(warnings) == 1
+
+    def test_default_patterns_include_common_low_yield(self) -> None:
+        expected = {"rules", "break", "off-topic", "silence", "inaudible"}
+        assert expected <= {p.lower() for p in DEFAULT_LOW_YIELD_PATTERNS}
+
+    def test_warning_format_string(self) -> None:
+        s = _struct([
+            Segment(id="seg-001", start=2_050, end=2_902, title="Break", speaker="DM"),
+        ])
+        warnings = check(s, threshold_seconds=500)
+        assert len(warnings) == 1
+        msg = warnings[0].format_warning()
+        assert "0:34:10" in msg
+        assert "0:48:22" in msg
+        assert "Break" in msg

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -3,16 +3,14 @@
 from __future__ import annotations
 
 import argparse
-import json
-import subprocess  # noqa: S404
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 from auto_lorebook import info_yaml, ytdlp
 from auto_lorebook.commands import ingest
+from tests._ytdlp_fakes import make_fake_youtubedl
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from pathlib import Path
 
     import pytest
@@ -53,45 +51,30 @@ _SAMPLE_SRT = (
 )
 
 
-def _fake_yt_run(
-    video_id: str, title: str, duration: float
-) -> Callable[..., subprocess.CompletedProcess[str]]:
-    """Patch target for subprocess.run that fakes yt-dlp output."""
-
-    def side_effect(
-        cmd: list[str], cwd: Path, **_kwargs: object
-    ) -> subprocess.CompletedProcess[str]:
-        info = {"id": video_id, "title": title, "duration": duration}
-        (cwd / f"{video_id}.info.json").write_text(json.dumps(info), encoding="utf-8")
-        (cwd / f"{video_id}.en.srt").write_text(_SAMPLE_SRT, encoding="utf-8")
-        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
-    return side_effect
-
-
 def test_youtube_url_ingests_via_ytdlp(tmp_wiki: Path) -> None:
     args = _args(url_or_path="https://youtube.com/watch?v=abc12345678")
+    info = {"id": "abc12345678", "title": "The Video", "duration": 7200}
+    fake_ydl, _ = make_fake_youtubedl(
+        info=info, subs={"abc12345678.en.srt": _SAMPLE_SRT}
+    )
     with (
         patch(
             "auto_lorebook.commands.ingest.cfg_mod.load_config",
             return_value=_mock_config(tmp_wiki),
         ),
-        patch(
-            "auto_lorebook.ytdlp.subprocess.run",
-            side_effect=_fake_yt_run("abc12345678", "The Video", 7200),
-        ),
+        patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl),
     ):
         result = ingest.run(args)
     assert result == 0
 
     source_dir = tmp_wiki / "sources" / "yt-abc12345678"
     assert (source_dir / "transcript.en.srt").exists()
-    info = info_yaml.read(source_dir / "info.yaml")
-    assert info.source_type == "youtube"
-    assert info.title == "The Video"
-    assert info.duration_seconds == 7200
-    assert info.caption_type == "manual"
-    assert info.source_url == "https://youtube.com/watch?v=abc12345678"
+    info_data = info_yaml.read(source_dir / "info.yaml")
+    assert info_data.source_type == "youtube"
+    assert info_data.title == "The Video"
+    assert info_data.duration_seconds == 7200
+    assert info_data.caption_type == "manual"
+    assert info_data.source_url == "https://youtube.com/watch?v=abc12345678"
 
 
 def test_non_youtube_url_errors(tmp_wiki: Path) -> None:
@@ -99,22 +82,6 @@ def test_non_youtube_url_errors(tmp_wiki: Path) -> None:
     with patch(
         "auto_lorebook.commands.ingest.cfg_mod.load_config",
         return_value=_mock_config(tmp_wiki),
-    ):
-        result = ingest.run(args)
-    assert result == 1
-
-
-def test_ytdlp_missing_returns_error(tmp_wiki: Path) -> None:
-    args = _args(url_or_path="https://youtube.com/watch?v=abcdefghijk")
-    with (
-        patch(
-            "auto_lorebook.commands.ingest.cfg_mod.load_config",
-            return_value=_mock_config(tmp_wiki),
-        ),
-        patch(
-            "auto_lorebook.ytdlp.subprocess.run",
-            side_effect=FileNotFoundError("yt-dlp"),
-        ),
     ):
         result = ingest.run(args)
     assert result == 1

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+    import pytest
+
 
 def _mock_config(wiki: Path) -> MagicMock:
     cfg = MagicMock()
@@ -132,6 +134,37 @@ def test_ytdlp_failure_returns_error(tmp_wiki: Path) -> None:
     ):
         result = ingest.run(args)
     assert result == 1
+
+
+def test_first_run_triggers_interactive_setup(
+    tmp_path: Path, tmp_wiki: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing config.yaml invokes interactive_setup when interactive."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    src = tmp_path / "notes.txt"
+    src.write_bytes(b"hello world")
+
+    setup_mock = MagicMock(return_value=_mock_config(tmp_wiki))
+    args = _args(url_or_path=str(src), no_interactive=False)
+    with patch("auto_lorebook.commands.ingest.cfg_mod.interactive_setup", setup_mock):
+        ingest.run(args)
+    assert setup_mock.called
+
+
+def test_first_run_no_interactive_propagates_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--no-interactive` surfaces the missing-config error without prompting."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    src = tmp_path / "notes.txt"
+    src.write_bytes(b"hello world")
+
+    args = _args(url_or_path=str(src), no_interactive=True)
+    result = ingest.run(args)
+    assert result == 1
+    assert not (home / "config.yaml").exists()
 
 
 def test_unreadable_info_yaml_returns_error(tmp_path: Path, tmp_wiki: Path) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import argparse
+import json
+import subprocess  # noqa: S404
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+from auto_lorebook import info_yaml, ytdlp
 from auto_lorebook.commands import ingest
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -36,14 +40,95 @@ def _args(**kwargs: object) -> argparse.Namespace:
     return argparse.Namespace(**defaults)
 
 
-def test_url_with_source_id_still_errors(tmp_wiki: Path) -> None:
-    """URL positional always errors — --source-id is not a fetch bypass."""
-    args = _args(
-        url_or_path="https://youtube.com/watch?v=abc123", source_id="yt-abc123"
-    )
+_SAMPLE_SRT = (
+    "1\n"
+    "00:00:01,000 --> 00:00:02,000\n"
+    "hello\n"
+    "\n"
+    "2\n"
+    "00:00:03,000 --> 00:00:04,000\n"
+    "world\n"
+)
+
+
+def _fake_yt_run(
+    video_id: str, title: str, duration: float
+) -> Callable[..., subprocess.CompletedProcess[str]]:
+    """Patch target for subprocess.run that fakes yt-dlp output."""
+
+    def side_effect(
+        cmd: list[str], cwd: Path, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        info = {"id": video_id, "title": title, "duration": duration}
+        (cwd / f"{video_id}.info.json").write_text(json.dumps(info), encoding="utf-8")
+        (cwd / f"{video_id}.en.srt").write_text(_SAMPLE_SRT, encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    return side_effect
+
+
+def test_youtube_url_ingests_via_ytdlp(tmp_wiki: Path) -> None:
+    args = _args(url_or_path="https://youtube.com/watch?v=abc12345678")
+    with (
+        patch(
+            "auto_lorebook.commands.ingest.cfg_mod.load_config",
+            return_value=_mock_config(tmp_wiki),
+        ),
+        patch(
+            "auto_lorebook.ytdlp.subprocess.run",
+            side_effect=_fake_yt_run("abc12345678", "The Video", 7200),
+        ),
+    ):
+        result = ingest.run(args)
+    assert result == 0
+
+    source_dir = tmp_wiki / "sources" / "yt-abc12345678"
+    assert (source_dir / "transcript.en.srt").exists()
+    info = info_yaml.read(source_dir / "info.yaml")
+    assert info.source_type == "youtube"
+    assert info.title == "The Video"
+    assert info.duration_seconds == 7200
+    assert info.caption_type == "manual"
+    assert info.source_url == "https://youtube.com/watch?v=abc12345678"
+
+
+def test_non_youtube_url_errors(tmp_wiki: Path) -> None:
+    args = _args(url_or_path="https://example.com/some.srt")
     with patch(
         "auto_lorebook.commands.ingest.cfg_mod.load_config",
         return_value=_mock_config(tmp_wiki),
+    ):
+        result = ingest.run(args)
+    assert result == 1
+
+
+def test_ytdlp_missing_returns_error(tmp_wiki: Path) -> None:
+    args = _args(url_or_path="https://youtube.com/watch?v=abcdefghijk")
+    with (
+        patch(
+            "auto_lorebook.commands.ingest.cfg_mod.load_config",
+            return_value=_mock_config(tmp_wiki),
+        ),
+        patch(
+            "auto_lorebook.ytdlp.subprocess.run",
+            side_effect=FileNotFoundError("yt-dlp"),
+        ),
+    ):
+        result = ingest.run(args)
+    assert result == 1
+
+
+def test_ytdlp_failure_returns_error(tmp_wiki: Path) -> None:
+    args = _args(url_or_path="https://youtube.com/watch?v=abcdefghijk")
+    with (
+        patch(
+            "auto_lorebook.commands.ingest.cfg_mod.load_config",
+            return_value=_mock_config(tmp_wiki),
+        ),
+        patch(
+            "auto_lorebook.ytdlp.fetch",
+            side_effect=ytdlp.NoSubtitlesError("no subs"),
+        ),
     ):
         result = ingest.run(args)
     assert result == 1

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -35,6 +35,7 @@ def _args(**kwargs: object) -> argparse.Namespace:
         "setting": None,
         "notes": None,
         "no_interactive": True,
+        "cookies_from_browser": None,
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -1,0 +1,172 @@
+"""Tests for openrouter.py HTTP client."""
+
+from __future__ import annotations
+
+import email.message
+import json
+from io import BytesIO
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from auto_lorebook.openrouter import (
+    OpenRouterAPIError,
+    OpenRouterAuthError,
+    OpenRouterClient,
+    OpenRouterError,
+    OpenRouterRateLimitError,
+    OpenRouterResponse,
+    OpenRouterTransportError,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def _ok_payload(
+    text: str = "hello",
+    model: str = "anthropic/claude-sonnet-4-5",
+    tokens_in: int = 10,
+    tokens_out: int = 5,
+) -> bytes:
+    return json.dumps({
+        "id": "gen-xxx",
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": tokens_in,
+            "completion_tokens": tokens_out,
+            "total_tokens": tokens_in + tokens_out,
+        },
+    }).encode("utf-8")
+
+
+def _mock_http_response(status: int, body: bytes) -> MagicMock:
+    resp = MagicMock()
+    resp.status = status
+    resp.read.return_value = body
+    resp.__enter__ = lambda self: self
+    resp.__exit__ = lambda *_a: None
+    return resp
+
+
+@pytest.fixture
+def urlopen_patch() -> Iterator[MagicMock]:
+    with patch("auto_lorebook.openrouter.urlopen") as m:
+        yield m
+
+
+class TestComplete:
+    def test_success(self, urlopen_patch: MagicMock) -> None:
+        urlopen_patch.return_value = _mock_http_response(200, _ok_payload("hi"))
+        client = OpenRouterClient(api_key="sk-test", default_model="m/one")
+        resp = client.complete(
+            [{"role": "user", "content": "hi"}],
+        )
+        assert isinstance(resp, OpenRouterResponse)
+        assert resp.text == "hi"
+        assert resp.model == "anthropic/claude-sonnet-4-5"
+        assert resp.tokens_in == 10
+        assert resp.tokens_out == 5
+
+    def test_sends_expected_request(self, urlopen_patch: MagicMock) -> None:
+        urlopen_patch.return_value = _mock_http_response(200, _ok_payload())
+        client = OpenRouterClient(api_key="sk-test", default_model="m/one")
+        client.complete(
+            [{"role": "user", "content": "hello"}],
+            model="m/two",
+            temperature=0.3,
+        )
+        req = urlopen_patch.call_args[0][0]
+        assert req.full_url.endswith("/chat/completions")
+        assert req.get_header("Authorization") == "Bearer sk-test"
+        assert req.get_header("Content-type") == "application/json"
+        body = json.loads(req.data.decode("utf-8"))
+        assert body["model"] == "m/two"
+        assert body["messages"] == [{"role": "user", "content": "hello"}]
+        assert body["temperature"] == pytest.approx(0.3)
+
+    def test_uses_default_model(self, urlopen_patch: MagicMock) -> None:
+        urlopen_patch.return_value = _mock_http_response(200, _ok_payload())
+        client = OpenRouterClient(api_key="sk-test", default_model="d/flt")
+        client.complete([{"role": "user", "content": "x"}])
+        body = json.loads(urlopen_patch.call_args[0][0].data.decode("utf-8"))
+        assert body["model"] == "d/flt"
+
+    def test_response_format_passthrough(self, urlopen_patch: MagicMock) -> None:
+        urlopen_patch.return_value = _mock_http_response(200, _ok_payload("{}"))
+        client = OpenRouterClient(api_key="sk-test", default_model="m/one")
+        client.complete(
+            [{"role": "user", "content": "x"}],
+            response_format={"type": "json_object"},
+        )
+        body = json.loads(urlopen_patch.call_args[0][0].data.decode("utf-8"))
+        assert body["response_format"] == {"type": "json_object"}
+
+    def test_missing_api_key_raises(self) -> None:
+        with pytest.raises(OpenRouterError, match="api_key"):
+            OpenRouterClient(api_key="", default_model="m/one")
+
+    def test_401_raises_auth_error(self, urlopen_patch: MagicMock) -> None:
+        urlopen_patch.side_effect = HTTPError(
+            "url",
+            401,
+            "Unauthorized",
+            hdrs=email.message.Message(),
+            fp=BytesIO(b'{"error":{"message":"bad key"}}'),
+        )
+        client = OpenRouterClient(api_key="sk-bad", default_model="m/one")
+        with pytest.raises(OpenRouterAuthError):
+            client.complete([{"role": "user", "content": "x"}])
+
+    def test_429_raises_rate_limit(self, urlopen_patch: MagicMock) -> None:
+        urlopen_patch.side_effect = HTTPError(
+            "url",
+            429,
+            "Too Many Requests",
+            hdrs=email.message.Message(),
+            fp=BytesIO(b'{"error":{"message":"slow down"}}'),
+        )
+        client = OpenRouterClient(api_key="sk-test", default_model="m/one")
+        with pytest.raises(OpenRouterRateLimitError):
+            client.complete([{"role": "user", "content": "x"}])
+
+    def test_500_raises_api_error(self, urlopen_patch: MagicMock) -> None:
+        urlopen_patch.side_effect = HTTPError(
+            "url",
+            500,
+            "Internal Server Error",
+            hdrs=email.message.Message(),
+            fp=BytesIO(b'{"error":{"message":"boom"}}'),
+        )
+        client = OpenRouterClient(api_key="sk-test", default_model="m/one")
+        with pytest.raises(OpenRouterAPIError, match="boom"):
+            client.complete([{"role": "user", "content": "x"}])
+
+    def test_network_error_raises_transport(self, urlopen_patch: MagicMock) -> None:
+        urlopen_patch.side_effect = URLError("dns fail")
+        client = OpenRouterClient(api_key="sk-test", default_model="m/one")
+        with pytest.raises(OpenRouterTransportError):
+            client.complete([{"role": "user", "content": "x"}])
+
+    def test_malformed_response_raises(self, urlopen_patch: MagicMock) -> None:
+        urlopen_patch.return_value = _mock_http_response(200, b"not json")
+        client = OpenRouterClient(api_key="sk-test", default_model="m/one")
+        with pytest.raises(OpenRouterAPIError):
+            client.complete([{"role": "user", "content": "x"}])
+
+    def test_no_choices_raises(self, urlopen_patch: MagicMock) -> None:
+        urlopen_patch.return_value = _mock_http_response(
+            200, json.dumps({"choices": []}).encode("utf-8")
+        )
+        client = OpenRouterClient(api_key="sk-test", default_model="m/one")
+        with pytest.raises(OpenRouterAPIError, match="no choices"):
+            client.complete([{"role": "user", "content": "x"}])

--- a/tests/test_reading.py
+++ b/tests/test_reading.py
@@ -1,0 +1,234 @@
+"""Tests for reading.py — reading.md assembly + frontmatter helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from auto_lorebook.info_yaml import Info, SourceContext
+from auto_lorebook.reading import (
+    ReadingError,
+    apply_name_corrections,
+    assemble,
+    linkify_timestamp,
+    read_frontmatter,
+    set_status,
+    write,
+)
+from auto_lorebook.stage1b import Bullet, ReadingBullets
+from auto_lorebook.structure import Segment, Structure, UncertaintyFlag
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _info(
+    *,
+    source_url: str | None = "https://youtube.com/watch?v=abc12345678",
+    title: str | None = "Session 3",
+) -> Info:
+    return Info(
+        source_id="yt-abc12345678",
+        source_type="youtube",
+        fetched_at="2026-04-20T14:35:12Z",
+        source_url=source_url,
+        title=title,
+        duration_seconds=600,
+        transcript_filename="transcript.en.srt",
+        context=SourceContext(),
+    )
+
+
+def _structure() -> Structure:
+    return Structure(
+        source_id="yt-abc12345678",
+        generated_at="2026-04-20T14:32:00Z",
+        default_speaker="DM",
+        segments=[
+            Segment(
+                id="seg-001",
+                start=0.0,
+                end=120.0,
+                title="Introduction",
+                speaker="DM",
+            ),
+            Segment(
+                id="seg-002",
+                start=120.0,
+                end=270.0,
+                title="Rules discussion: grappling",
+                speaker="mixed",
+                notes="off-topic",
+            ),
+            Segment(
+                id="seg-003",
+                start=270.0,
+                end=600.0,
+                title="Founding of Aldara",
+                speaker="DM",
+            ),
+        ],
+        uncertainty_flags=[
+            UncertaintyFlag(
+                locator=347.0,
+                span="a place name",
+                kind="name",
+                note="unclear",
+            )
+        ],
+    )
+
+
+def _bullets() -> ReadingBullets:
+    return ReadingBullets(
+        source_id="yt-abc12345678",
+        generated_at="2026-04-20T14:34:00Z",
+        segments={
+            "seg-001": [],  # empty is permitted
+            "seg-002": [],
+            "seg-003": [
+                Bullet(
+                    text="King Theron founded Aldara in the Second Age",
+                    anchor=272.0,
+                    locator_hint_start=257.0,
+                    locator_hint_end=287.0,
+                ),
+                Bullet(
+                    text="The founding displaced an earlier elven presence",
+                    anchor=314.0,
+                    locator_hint_start=299.0,
+                    locator_hint_end=329.0,
+                ),
+            ],
+        },
+    )
+
+
+class TestLinkifyTimestamp:
+    def test_youtube_watch_url(self) -> None:
+        assert (
+            linkify_timestamp("https://youtube.com/watch?v=abc", 270)
+            == "https://youtube.com/watch?v=abc&t=270"
+        )
+
+    def test_youtube_short_url(self) -> None:
+        assert (
+            linkify_timestamp("https://youtu.be/abc", 270)
+            == "https://youtu.be/abc?t=270"
+        )
+
+    def test_no_url_returns_none(self) -> None:
+        assert linkify_timestamp(None, 270) is None
+
+    def test_preserves_existing_query(self) -> None:
+        got = linkify_timestamp("https://example.com/path?x=1", 5)
+        assert got == "https://example.com/path?x=1&t=5"
+
+
+class TestApplyNameCorrections:
+    def test_empty_returns_unchanged(self) -> None:
+        assert apply_name_corrections("King Fair-on", {}) == "King Fair-on"
+
+    def test_substitutes_literally(self) -> None:
+        got = apply_name_corrections("King Fair-on", {"Fair-on": "Theron"})
+        assert got == "King Theron"
+
+    def test_handles_multiple(self) -> None:
+        got = apply_name_corrections("A says B", {"A": "Alice", "B": "Bob"})
+        assert got == "Alice says Bob"
+
+
+class TestAssemble:
+    def test_frontmatter_contains_expected_keys(self) -> None:
+        md = assemble(info=_info(), structure=_structure(), bullets=_bullets())
+        assert md.startswith("---\n")
+        assert "schema_version: 1" in md
+        assert "source_id: yt-abc12345678" in md
+        assert "reading_status: draft" in md
+        assert "default_speaker: DM" in md
+
+    def test_segment_headers_linkified(self) -> None:
+        md = assemble(info=_info(), structure=_structure(), bullets=_bullets())
+        # seg-003 starts at 270s
+        assert (
+            "[[0:04:30-0:10:00]]"
+            "(https://youtube.com/watch?v=abc12345678&t=270)"
+            " Founding of Aldara"
+        ) in md
+
+    def test_speaker_line_emitted(self) -> None:
+        md = assemble(info=_info(), structure=_structure(), bullets=_bullets())
+        assert "Speaker: DM" in md
+        assert "Speaker: mixed" in md
+
+    def test_empty_segment_gets_explicit_marker(self) -> None:
+        md = assemble(info=_info(), structure=_structure(), bullets=_bullets())
+        assert "_No claims extracted from this segment._" in md
+
+    def test_bullets_rendered_with_clickable_anchor(self) -> None:
+        md = assemble(info=_info(), structure=_structure(), bullets=_bullets())
+        assert (
+            "- King Theron founded Aldara in the Second Age "
+            "[[0:04:32]](https://youtube.com/watch?v=abc12345678&t=272)"
+        ) in md
+
+    def test_uncertainty_flags_rendered(self) -> None:
+        md = assemble(info=_info(), structure=_structure(), bullets=_bullets())
+        assert "[0:05:47]" in md
+        assert "a place name" in md
+
+    def test_no_source_url_omits_links(self) -> None:
+        info = _info(source_url=None)
+        md = assemble(info=info, structure=_structure(), bullets=_bullets())
+        # header still appears, just without URL
+        assert "## [0:00:00-0:02:00] Introduction" in md
+
+    def test_existing_frontmatter_name_corrections_applied(self) -> None:
+        # if the human added corrections to the frontmatter map on a
+        # previous pass, assemble() applies them to rendered text.
+        md = assemble(
+            info=_info(),
+            structure=_structure(),
+            bullets=_bullets(),
+            name_corrections={"Aldara": "Aldaria"},
+        )
+        assert "Aldaria" in md
+        assert (
+            "King Theron founded Aldara in the Second Age" not in md or "Aldaria" in md
+        )
+
+
+class TestWriteReadFrontmatter:
+    def test_write_and_read_round_trip(self, tmp_path: Path) -> None:
+        path = tmp_path / "reading.md"
+        text = assemble(info=_info(), structure=_structure(), bullets=_bullets())
+        write(path, text)
+        fm = read_frontmatter(path)
+        assert fm["source_id"] == "yt-abc12345678"
+        assert fm["reading_status"] == "draft"
+
+    def test_read_frontmatter_missing_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ReadingError):
+            read_frontmatter(tmp_path / "nope.md")
+
+    def test_read_frontmatter_no_fence_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "reading.md"
+        path.write_text("no frontmatter here", encoding="utf-8")
+        with pytest.raises(ReadingError):
+            read_frontmatter(path)
+
+    def test_set_status_flip_to_approved(self, tmp_path: Path) -> None:
+        path = tmp_path / "reading.md"
+        text = assemble(info=_info(), structure=_structure(), bullets=_bullets())
+        write(path, text)
+        set_status(path, "approved")
+        fm = read_frontmatter(path)
+        assert fm["reading_status"] == "approved"
+
+    def test_set_status_rejects_bad_value(self, tmp_path: Path) -> None:
+        path = tmp_path / "reading.md"
+        text = assemble(info=_info(), structure=_structure(), bullets=_bullets())
+        write(path, text)
+        with pytest.raises(ReadingError):
+            set_status(path, "published")

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -145,7 +145,7 @@ def ingested_wiki(tmp_wiki: Path, tmp_home: Path) -> Path:  # noqa: ARG001
 
 
 def _write_user_config(
-    home: Path, wiki: Path, model: str = "openrouter/anthropic/claude-sonnet-4-5"
+    home: Path, wiki: Path, model: str = "anthropic/claude-sonnet-4-5"
 ) -> None:
     cfg_path = home / "config.yaml"
     cfg_path.write_text(

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -1,0 +1,288 @@
+"""End-to-end tests for generate-reading / approve-reading / regenerate-reading.
+
+The OpenRouter HTTP layer is mocked so the pipeline runs deterministically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from auto_lorebook.commands import (
+    approve_reading_cmd,
+    generate_reading_cmd,
+    regenerate_reading_cmd,
+)
+from auto_lorebook.openrouter import OpenRouterResponse
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_SRT = (
+    "1\n"
+    "00:00:00,000 --> 00:00:30,000\n"
+    "Welcome to the session.\n"
+    "\n"
+    "2\n"
+    "00:00:30,000 --> 00:02:00,000\n"
+    "Today we talk about Aldara.\n"
+    "\n"
+    "3\n"
+    "00:02:00,000 --> 00:05:00,000\n"
+    "King Theron founded Aldara in the Second Age.\n"
+    "\n"
+    "4\n"
+    "00:05:00,000 --> 00:10:00,000\n"
+    "The war followed. Many died.\n"
+)
+
+
+def _stub_structure_payload() -> str:
+    return json.dumps({
+        "default_speaker": "DM",
+        "segments": [
+            {
+                "id": "seg-001",
+                "start": "0:00:00",
+                "end": "0:02:00",
+                "title": "Intro",
+                "speaker": "DM",
+            },
+            {
+                "id": "seg-002",
+                "start": "0:02:00",
+                "end": "0:10:00",
+                "title": "Founding of Aldara",
+                "speaker": "DM",
+            },
+        ],
+        "uncertainty_flags": [],
+    })
+
+
+def _seg_bullets_payload(segment_id: str) -> str:
+    # One bullet per segment; anchor inside the segment
+    per_seg = {
+        "seg-001": [{"text": "Intro bullet", "anchor": "0:00:15"}],
+        "seg-002": [
+            {"text": "King Theron founded Aldara", "anchor": "0:02:30"},
+        ],
+    }
+    return json.dumps({"bullets": per_seg.get(segment_id, [])})
+
+
+def _wire_client_responses(client_mock: MagicMock) -> None:
+    """Route client.complete by message content (structure vs per-segment)."""
+
+    def side_effect(
+        messages: list[dict[str, str]], **_kwargs: object
+    ) -> OpenRouterResponse:
+        system = next((m for m in messages if m["role"] == "system"), {})
+        user = next((m for m in messages if m["role"] == "user"), {})
+        system_text = system.get("content", "")
+        user_text = user.get("content", "")
+
+        if "segmenting" in system_text:
+            text = _stub_structure_payload()
+        else:
+            # stage 1b: find which segment id is in user_text
+            for seg_id in ("seg-001", "seg-002"):
+                if seg_id in user_text:
+                    text = _seg_bullets_payload(seg_id)
+                    break
+            else:
+                text = json.dumps({"bullets": []})
+        return OpenRouterResponse(text=text, model="m", tokens_in=0, tokens_out=0)
+
+    client_mock.complete.side_effect = side_effect
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def ingested_wiki(tmp_wiki: Path, tmp_home: Path) -> Path:  # noqa: ARG001
+    # Ingest a fake source
+    source_id = "yt-abc12345678"
+    src_dir = tmp_wiki / "sources" / source_id
+    src_dir.mkdir(parents=True)
+    (src_dir / "transcript.en.srt").write_text(_SRT, encoding="utf-8")
+
+    info = {
+        "schema_version": 1,
+        "source_id": source_id,
+        "source_type": "youtube",
+        "source_url": "https://youtube.com/watch?v=abc12345678",
+        "title": "Session 3",
+        "duration_seconds": 600,
+        "caption_type": "manual",
+        "fetched_at": "2026-04-20T14:35:12Z",
+        "session_date": None,
+        "transcript_filename": "transcript.en.srt",
+        "context": {
+            "perspective": None,
+            "source_nature": None,
+            "setting": None,
+            "speakers": [],
+            "notes": None,
+        },
+    }
+    (src_dir / "info.yaml").write_text(
+        yaml.safe_dump(info, sort_keys=False), encoding="utf-8"
+    )
+    return tmp_wiki
+
+
+def _write_user_config(
+    home: Path, wiki: Path, model: str = "openrouter/anthropic/claude-sonnet-4-5"
+) -> None:
+    cfg_path = home / "config.yaml"
+    cfg_path.write_text(
+        f"""schema_version: 1
+wiki_repo_path: {wiki}
+openrouter:
+  api_key_env: FAKE_OR_KEY
+models:
+  primary: {model}
+""",
+        encoding="utf-8",
+    )
+
+
+def _args(**kwargs: object) -> argparse.Namespace:
+    return argparse.Namespace(**kwargs)
+
+
+class TestGenerateReading:
+    def test_happy_path(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            rc = generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Draft reading" in out
+
+        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        assert (pending / "structure.yaml").exists()
+        assert (pending / "bullets.yaml").exists()
+        assert (pending / "reading.md").exists()
+        md = (pending / "reading.md").read_text(encoding="utf-8")
+        assert "reading_status: draft" in md
+        assert "King Theron founded Aldara" in md
+
+    def test_missing_api_key_errors(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        # FAKE_OR_KEY is not set
+        rc = generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+        assert rc == 1
+
+    def test_missing_source_errors(self, tmp_home: Path, ingested_wiki: Path) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        rc = generate_reading_cmd.run(_args(source_id="yt-not-ingested"))
+        assert rc == 1
+
+
+class TestApproveReading:
+    def test_flips_and_copies(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678"))
+
+        assert rc == 0
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert approved.exists()
+        assert "reading_status: approved" in approved.read_text(encoding="utf-8")
+        out = capsys.readouterr().out
+        assert "Approved" in out
+
+    def test_no_draft_errors(self, tmp_home: Path, ingested_wiki: Path) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678"))
+        assert rc == 1
+
+
+class TestRegenerateReading:
+    def test_rejects_segments_with_from_structure(
+        self, tmp_home: Path, ingested_wiki: Path
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        rc = regenerate_reading_cmd.run(
+            _args(
+                source_id="yt-abc12345678",
+                from_stage="structure",
+                segments="seg-001",
+            )
+        )
+        assert rc == 1
+
+    def test_summarize_only_preserves_structure(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            # count structure calls after first generate
+            first_complete_count = client.complete.call_count
+
+            # now regenerate --from=summarize --segments seg-002
+            rc = regenerate_reading_cmd.run(
+                _args(
+                    source_id="yt-abc12345678",
+                    from_stage="summarize",
+                    segments="seg-002",
+                )
+            )
+        assert rc == 0
+        # second run should NOT re-call stage 1a (structure), only 1 seg of 1b
+        added = client.complete.call_count - first_complete_count
+        # one call for seg-002
+        assert added == 1

--- a/tests/test_srt.py
+++ b/tests/test_srt.py
@@ -1,0 +1,108 @@
+"""Tests for srt.py parser."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from auto_lorebook.srt import Cue, SrtError, parse, parse_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+SIMPLE = (
+    "1\n"
+    "00:00:01,000 --> 00:00:05,000\n"
+    "First cue.\n"
+    "\n"
+    "2\n"
+    "00:00:06,500 --> 00:00:09,000\n"
+    "Second cue\n"
+    "across two lines.\n"
+)
+
+
+class TestParse:
+    def test_simple(self) -> None:
+        cues = parse(SIMPLE)
+        assert cues == [
+            Cue(index=1, start=1.0, end=5.0, text="First cue."),
+            Cue(
+                index=2,
+                start=6.5,
+                end=9.0,
+                text="Second cue\nacross two lines.",
+            ),
+        ]
+
+    def test_crlf(self) -> None:
+        cues = parse(SIMPLE.replace("\n", "\r\n"))
+        assert len(cues) == 2
+        assert cues[0].text == "First cue."
+
+    def test_bom_stripped(self) -> None:
+        cues = parse("﻿" + SIMPLE)
+        assert len(cues) == 2
+
+    def test_empty_returns_empty(self) -> None:
+        assert parse("") == []
+
+    def test_whitespace_only_returns_empty(self) -> None:
+        assert parse("   \n\n\n") == []
+
+    def test_extra_blank_lines_between_cues(self) -> None:
+        text = (
+            "1\n"
+            "00:00:01,000 --> 00:00:02,000\n"
+            "A\n"
+            "\n\n\n"
+            "2\n"
+            "00:00:03,000 --> 00:00:04,000\n"
+            "B\n"
+        )
+        cues = parse(text)
+        assert [c.text for c in cues] == ["A", "B"]
+
+    def test_missing_arrow_raises(self) -> None:
+        text = "1\n00:00:01,000 00:00:02,000\ntext\n"
+        with pytest.raises(SrtError):
+            parse(text)
+
+    def test_non_integer_index_tolerated(self) -> None:
+        # some SRTs have garbage indices; we keep the cue and assign sequence
+        text = (
+            "X\n"
+            "00:00:01,000 --> 00:00:02,000\n"
+            "A\n"
+            "\n"
+            "Y\n"
+            "00:00:03,000 --> 00:00:04,000\n"
+            "B\n"
+        )
+        cues = parse(text)
+        assert [c.index for c in cues] == [1, 2]
+        assert [c.text for c in cues] == ["A", "B"]
+
+    def test_bad_timestamp_raises(self) -> None:
+        text = "1\nnot-a-time --> 00:00:02,000\ntext\n"
+        with pytest.raises(SrtError):
+            parse(text)
+
+    def test_end_before_start_raises(self) -> None:
+        text = "1\n00:00:05,000 --> 00:00:02,000\ntext\n"
+        with pytest.raises(SrtError):
+            parse(text)
+
+
+class TestParseFile:
+    def test_reads_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "sample.srt"
+        path.write_text(SIMPLE, encoding="utf-8")
+        cues = parse_file(path)
+        assert len(cues) == 2
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            parse_file(tmp_path / "nope.srt")

--- a/tests/test_stage1a.py
+++ b/tests/test_stage1a.py
@@ -1,0 +1,161 @@
+"""Tests for stage1a.py — structure generation."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from auto_lorebook.openrouter import OpenRouterResponse
+from auto_lorebook.stage1a import Stage1aError, run
+from auto_lorebook.structure import Structure
+from auto_lorebook.transcript import LoadedTranscript
+
+
+def _mock_client(text: str) -> MagicMock:
+    client = MagicMock()
+    client.complete.return_value = OpenRouterResponse(
+        text=text, model="m/one", tokens_in=10, tokens_out=5
+    )
+    return client
+
+
+def _valid_payload() -> str:
+    return json.dumps({
+        "default_speaker": "DM",
+        "segments": [
+            {
+                "id": "seg-001",
+                "start": "0:00:00",
+                "end": "0:01:00",
+                "title": "Intro",
+                "speaker": "DM",
+            },
+            {
+                "id": "seg-002",
+                "start": "0:01:00",
+                "end": "0:02:00",
+                "title": "Body",
+                "speaker": "DM",
+            },
+        ],
+        "uncertainty_flags": [{"locator": "0:00:47", "span": "a name", "kind": "name"}],
+    })
+
+
+class TestRun:
+    def test_happy_path(self) -> None:
+        client = _mock_client(_valid_payload())
+        transcript = LoadedTranscript(
+            text_for_llm="[0:00:01] hello\n", total_duration=120.0
+        )
+        result = run(
+            transcript=transcript,
+            preamble_text="## Setting\n(none)\n",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+        )
+        assert isinstance(result, Structure)
+        assert result.source_id == "yt-x"
+        assert len(result.segments) == 2
+        assert result.segments[0].id == "seg-001"
+        assert result.default_speaker == "DM"
+
+    def test_sends_preamble_and_transcript(self) -> None:
+        client = _mock_client(_valid_payload())
+        transcript = LoadedTranscript(
+            text_for_llm="[0:00:01] hello world\n", total_duration=120.0
+        )
+        run(
+            transcript=transcript,
+            preamble_text="## Setting\n(none)",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+        )
+        client.complete.assert_called_once()
+        call = client.complete.call_args
+        messages = call.args[0]
+        kwargs = call.kwargs
+        assert kwargs["model"] == "m/one"
+        assert kwargs["response_format"] == {"type": "json_object"}
+        # system message contains preamble; user message contains transcript
+        assert any(
+            m["role"] == "system" and "Setting" in m["content"] for m in messages
+        )
+        assert any(
+            m["role"] == "user" and "hello world" in m["content"] for m in messages
+        )
+
+    def test_json_wrapped_in_code_fence_tolerated(self) -> None:
+        fenced = "```json\n" + _valid_payload() + "\n```\n"
+        client = _mock_client(fenced)
+        transcript = LoadedTranscript(
+            text_for_llm="[0:00:01] hi\n", total_duration=120.0
+        )
+        result = run(
+            transcript=transcript,
+            preamble_text="",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+        )
+        assert len(result.segments) == 2
+
+    def test_malformed_json_raises(self) -> None:
+        client = _mock_client("not valid json at all")
+        transcript = LoadedTranscript(
+            text_for_llm="[0:00:01] hi\n", total_duration=120.0
+        )
+        with pytest.raises(Stage1aError, match="JSON"):
+            run(
+                transcript=transcript,
+                preamble_text="",
+                source_id="yt-x",
+                client=client,
+                model="m/one",
+            )
+
+    def test_validation_failure_raises(self) -> None:
+        # segments don't cover full 120s duration
+        bad = json.dumps({
+            "default_speaker": "DM",
+            "segments": [
+                {
+                    "id": "seg-001",
+                    "start": "0:00:00",
+                    "end": "0:00:30",
+                    "title": "Short",
+                    "speaker": "DM",
+                }
+            ],
+            "uncertainty_flags": [],
+        })
+        client = _mock_client(bad)
+        transcript = LoadedTranscript(
+            text_for_llm="[0:00:01] hi\n", total_duration=120.0
+        )
+        with pytest.raises(Stage1aError):
+            run(
+                transcript=transcript,
+                preamble_text="",
+                source_id="yt-x",
+                client=client,
+                model="m/one",
+            )
+
+    def test_missing_segments_raises(self) -> None:
+        client = _mock_client('{"segments": []}')
+        transcript = LoadedTranscript(
+            text_for_llm="[0:00:01] hi\n", total_duration=120.0
+        )
+        with pytest.raises(Stage1aError):
+            run(
+                transcript=transcript,
+                preamble_text="",
+                source_id="yt-x",
+                client=client,
+                model="m/one",
+            )

--- a/tests/test_stage1b.py
+++ b/tests/test_stage1b.py
@@ -1,0 +1,314 @@
+"""Tests for stage1b.py — per-segment summarize."""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from auto_lorebook.openrouter import OpenRouterResponse
+from auto_lorebook.stage1b import (
+    Bullet,
+    ReadingBullets,
+    Stage1bError,
+    read_bullets,
+    run,
+    slice_transcript_for_segment,
+    write_bullets,
+)
+from auto_lorebook.structure import Segment, Structure
+from auto_lorebook.transcript import LoadedTranscript
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_TRANSCRIPT = (
+    "[0:00:00] Welcome to the session.\n"
+    "[0:00:30] Today we'll discuss Aldara.\n"
+    "[0:02:00] King Theron founded Aldara.\n"
+    "[0:03:30] It was in the Second Age.\n"
+    "[0:05:00] The War of the Dusk followed.\n"
+)
+
+
+def _struct() -> Structure:
+    return Structure(
+        source_id="yt-x",
+        generated_at="2026-04-20T00:00:00Z",
+        default_speaker="DM",
+        segments=[
+            Segment(
+                id="seg-001",
+                start=0.0,
+                end=120.0,
+                title="Intro",
+                speaker="DM",
+            ),
+            Segment(
+                id="seg-002",
+                start=120.0,
+                end=300.0,
+                title="Founding of Aldara",
+                speaker="DM",
+            ),
+            Segment(
+                id="seg-003",
+                start=300.0,
+                end=600.0,
+                title="War of the Dusk",
+                speaker="DM",
+            ),
+        ],
+    )
+
+
+def _bullets_payload(bullets: list[dict[str, object]]) -> str:
+    return json.dumps({"bullets": bullets})
+
+
+class TestSliceTranscript:
+    def test_slices_by_time(self) -> None:
+        transcript = LoadedTranscript(text_for_llm=_TRANSCRIPT, total_duration=600.0)
+        seg = Segment(
+            id="seg-002",
+            start=120.0,
+            end=300.0,
+            title="Founding",
+            speaker="DM",
+        )
+        sliced = slice_transcript_for_segment(transcript, seg)
+        assert "King Theron" in sliced
+        assert "Welcome" not in sliced
+        assert "War of the Dusk" not in sliced
+
+    def test_empty_slice_for_out_of_range_segment(self) -> None:
+        transcript = LoadedTranscript(text_for_llm="[0:00:01] a\n", total_duration=10.0)
+        seg = Segment(
+            id="seg-001",
+            start=100.0,
+            end=200.0,
+            title="x",
+            speaker="DM",
+        )
+        sliced = slice_transcript_for_segment(transcript, seg)
+        assert not sliced
+
+    def test_text_without_brackets_returned_in_full(self) -> None:
+        # plain-text sources have no [h:mm:ss] markers; whole text used
+        transcript = LoadedTranscript(
+            text_for_llm="Line one. Line two.", total_duration=100.0
+        )
+        seg = Segment(
+            id="seg-001",
+            start=0.0,
+            end=50.0,
+            title="x",
+            speaker="DM",
+        )
+        sliced = slice_transcript_for_segment(transcript, seg)
+        assert sliced == "Line one. Line two."
+
+
+class TestRun:
+    def _client_per_segment(
+        self, per_segment: dict[str, list[dict[str, object]]]
+    ) -> MagicMock:
+        """Route responses by looking up the segment id in the user message."""
+        client = MagicMock()
+        lock = threading.Lock()
+
+        def side_effect(
+            messages: list[dict[str, str]], **_kwargs: object
+        ) -> OpenRouterResponse:
+            user = next((m for m in messages if m["role"] == "user"), None)
+            assert user is not None
+            for seg_id, bullets in per_segment.items():
+                if seg_id in user["content"]:
+                    with lock:
+                        return OpenRouterResponse(
+                            text=_bullets_payload(bullets),
+                            model="m",
+                            tokens_in=0,
+                            tokens_out=0,
+                        )
+            msg = f"no canned response for message: {user['content'][:100]}"
+            raise AssertionError(msg)
+
+        client.complete.side_effect = side_effect
+        return client
+
+    def test_all_segments_get_bullets(self) -> None:
+        client = self._client_per_segment({
+            "seg-001": [{"text": "Intro note", "anchor": "0:00:05"}],
+            "seg-002": [
+                {"text": "King Theron founded Aldara", "anchor": "0:02:00"},
+                {"text": "Second Age", "anchor": "0:03:30"},
+            ],
+            "seg-003": [],
+        })
+        transcript = LoadedTranscript(text_for_llm=_TRANSCRIPT, total_duration=600.0)
+        result = run(
+            transcript=transcript,
+            structure=_struct(),
+            preamble_text="",
+            client=client,
+            model="m/one",
+        )
+        assert isinstance(result, ReadingBullets)
+        assert len(result.segments) == 3
+        assert {b.text for b in result.segments["seg-002"]} == {
+            "King Theron founded Aldara",
+            "Second Age",
+        }
+        assert result.segments["seg-003"] == []
+        assert client.complete.call_count == 3
+
+    def test_empty_bullet_list_permitted(self) -> None:
+        client = self._client_per_segment({
+            "seg-001": [],
+            "seg-002": [],
+            "seg-003": [],
+        })
+        transcript = LoadedTranscript(text_for_llm=_TRANSCRIPT, total_duration=600.0)
+        result = run(
+            transcript=transcript,
+            structure=_struct(),
+            preamble_text="",
+            client=client,
+            model="m/one",
+        )
+        for bullets in result.segments.values():
+            assert bullets == []
+
+    def test_locator_hint_pads_anchor(self) -> None:
+        client = self._client_per_segment({
+            "seg-001": [{"text": "x", "anchor": "0:00:30"}],
+            "seg-002": [{"text": "y", "anchor": "0:02:30"}],
+            "seg-003": [{"text": "z", "anchor": "0:05:30"}],
+        })
+        transcript = LoadedTranscript(text_for_llm=_TRANSCRIPT, total_duration=600.0)
+        result = run(
+            transcript=transcript,
+            structure=_struct(),
+            preamble_text="",
+            client=client,
+            model="m/one",
+            hint_window_seconds=15.0,
+        )
+        b = result.segments["seg-001"][0]
+        assert b.anchor == pytest.approx(30.0)
+        assert b.locator_hint_start == pytest.approx(15.0)
+        assert b.locator_hint_end == pytest.approx(45.0)
+
+    def test_locator_hint_clamps_to_segment(self) -> None:
+        client = self._client_per_segment({
+            # anchor at segment start, hint should clamp to start
+            "seg-001": [{"text": "x", "anchor": "0:00:00"}],
+            # anchor near segment end, hint clamps to end
+            "seg-002": [{"text": "y", "anchor": "0:04:59"}],
+            "seg-003": [],
+        })
+        transcript = LoadedTranscript(text_for_llm=_TRANSCRIPT, total_duration=600.0)
+        result = run(
+            transcript=transcript,
+            structure=_struct(),
+            preamble_text="",
+            client=client,
+            model="m/one",
+            hint_window_seconds=30.0,
+        )
+        b1 = result.segments["seg-001"][0]
+        assert b1.locator_hint_start == pytest.approx(0.0)
+        b2 = result.segments["seg-002"][0]
+        assert b2.locator_hint_end == pytest.approx(300.0)
+
+    def test_malformed_json_raises(self) -> None:
+        client = MagicMock()
+        client.complete.return_value = OpenRouterResponse(
+            text="not json", model="m", tokens_in=0, tokens_out=0
+        )
+        transcript = LoadedTranscript(text_for_llm=_TRANSCRIPT, total_duration=600.0)
+        with pytest.raises(Stage1bError, match="JSON"):
+            run(
+                transcript=transcript,
+                structure=_struct(),
+                preamble_text="",
+                client=client,
+                model="m/one",
+            )
+
+    def test_bullet_anchor_outside_segment_raises(self) -> None:
+        # anchor is in seg-001 range but returned for seg-002
+        client = MagicMock()
+        client.complete.return_value = OpenRouterResponse(
+            text=_bullets_payload([{"text": "x", "anchor": "0:00:10"}]),
+            model="m",
+            tokens_in=0,
+            tokens_out=0,
+        )
+        s = Structure(
+            source_id="yt-x",
+            generated_at="2026-04-20T00:00:00Z",
+            default_speaker="DM",
+            segments=[
+                Segment(
+                    id="seg-002",
+                    start=120.0,
+                    end=300.0,
+                    title="x",
+                    speaker="DM",
+                ),
+            ],
+        )
+        transcript = LoadedTranscript(
+            text_for_llm="[0:02:30] x\n", total_duration=300.0
+        )
+        with pytest.raises(Stage1bError, match="anchor"):
+            run(
+                transcript=transcript,
+                structure=s,
+                preamble_text="",
+                client=client,
+                model="m/one",
+            )
+
+
+class TestBullet:
+    def test_bullet_dataclass_fields(self) -> None:
+        b = Bullet(
+            text="hello",
+            anchor=30.0,
+            locator_hint_start=15.0,
+            locator_hint_end=45.0,
+        )
+        assert b.text == "hello"
+        assert b.anchor == pytest.approx(30.0)
+
+
+class TestBulletsIO:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        bullets = ReadingBullets(
+            source_id="yt-x",
+            generated_at="2026-04-20T00:00:00Z",
+            segments={
+                "seg-001": [
+                    Bullet(
+                        text="Hello Aldara",
+                        anchor=30.0,
+                        locator_hint_start=15.0,
+                        locator_hint_end=45.0,
+                    )
+                ],
+                "seg-002": [],
+            },
+        )
+        path = tmp_path / "bullets.yaml"
+        write_bullets(bullets, path)
+        loaded = read_bullets(path)
+        assert loaded.source_id == "yt-x"
+        assert len(loaded.segments["seg-001"]) == 1
+        assert loaded.segments["seg-001"][0].text == "Hello Aldara"
+        assert loaded.segments["seg-002"] == []

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,0 +1,193 @@
+"""Tests for structure.py — Stage 1a output schema + validation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from auto_lorebook.structure import (
+    Override,
+    Segment,
+    Structure,
+    StructureValidationError,
+    UncertaintyFlag,
+    read,
+    validate,
+    write,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _mk_struct(**overrides: object) -> Structure:
+    defaults: dict[str, object] = {
+        "source_id": "yt-abc",
+        "generated_at": "2026-04-20T00:00:00Z",
+        "default_speaker": "DM",
+        "segments": [
+            Segment(
+                id="seg-001",
+                start=0.0,
+                end=120.0,
+                title="Intro",
+                speaker="DM",
+            ),
+            Segment(
+                id="seg-002",
+                start=120.0,
+                end=600.0,
+                title="Body",
+                speaker="DM",
+            ),
+        ],
+        "uncertainty_flags": [],
+    }
+    defaults.update(overrides)
+    return Structure(**defaults)  # type: ignore[arg-type]
+
+
+class TestReadWrite:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        s = _mk_struct(
+            uncertainty_flags=[
+                UncertaintyFlag(
+                    locator=347.0, span="a place name", kind="name", note="unclear"
+                )
+            ],
+        )
+        s.segments[1].overrides = [
+            Override(start=180.0, end=195.0, speaker="NPC", voiced_by="DM")
+        ]
+        path = tmp_path / "structure.yaml"
+        write(s, path)
+        loaded = read(path)
+        assert loaded.source_id == "yt-abc"
+        assert len(loaded.segments) == 2
+        assert loaded.segments[1].overrides[0].speaker == "NPC"
+        assert loaded.uncertainty_flags[0].span == "a place name"
+
+    def test_writer_emits_canonical_timestamps(self, tmp_path: Path) -> None:
+        s = _mk_struct()
+        path = tmp_path / "structure.yaml"
+        write(s, path)
+        text = path.read_text(encoding="utf-8")
+        assert "0:00:00" in text
+        assert "0:02:00" in text
+        assert "0:10:00" in text
+
+    def test_reader_accepts_srt_comma_decimals(self, tmp_path: Path) -> None:
+        path = tmp_path / "structure.yaml"
+        path.write_text(
+            """schema_version: 1
+source_id: yt-abc
+generated_at: '2026-04-20T00:00:00Z'
+default_speaker: DM
+segments:
+  - id: seg-001
+    start: '00:00:00,000'
+    end: '00:02:00,500'
+    title: Intro
+    speaker: DM
+uncertainty_flags: []
+""",
+            encoding="utf-8",
+        )
+        loaded = read(path)
+        assert loaded.segments[0].start == pytest.approx(0.0)
+        assert loaded.segments[0].end == pytest.approx(120.5)
+
+
+class TestValidate:
+    def test_ok(self) -> None:
+        validate(_mk_struct(), total_duration=600.0)
+
+    def test_no_segments_raises(self) -> None:
+        s = _mk_struct(segments=[])
+        with pytest.raises(StructureValidationError, match="no segments"):
+            validate(s, total_duration=600.0)
+
+    def test_first_segment_must_start_at_zero(self) -> None:
+        s = _mk_struct(
+            segments=[
+                Segment(id="seg-001", start=30.0, end=600.0, title="x", speaker="DM"),
+            ]
+        )
+        with pytest.raises(StructureValidationError, match="start"):
+            validate(s, total_duration=600.0)
+
+    def test_last_segment_must_reach_duration(self) -> None:
+        s = _mk_struct(
+            segments=[
+                Segment(id="seg-001", start=0.0, end=300.0, title="x", speaker="DM"),
+            ]
+        )
+        with pytest.raises(StructureValidationError, match=r"end|duration"):
+            validate(s, total_duration=600.0)
+
+    def test_gap_between_segments_raises(self) -> None:
+        s = _mk_struct(
+            segments=[
+                Segment(id="seg-001", start=0.0, end=100.0, title="a", speaker="DM"),
+                Segment(id="seg-002", start=150.0, end=600.0, title="b", speaker="DM"),
+            ]
+        )
+        with pytest.raises(StructureValidationError, match="gap"):
+            validate(s, total_duration=600.0)
+
+    def test_overlap_between_segments_raises(self) -> None:
+        s = _mk_struct(
+            segments=[
+                Segment(id="seg-001", start=0.0, end=200.0, title="a", speaker="DM"),
+                Segment(id="seg-002", start=100.0, end=600.0, title="b", speaker="DM"),
+            ]
+        )
+        with pytest.raises(StructureValidationError, match=r"overlap|gap"):
+            validate(s, total_duration=600.0)
+
+    def test_segment_end_before_start_raises(self) -> None:
+        s = _mk_struct(
+            segments=[
+                Segment(id="seg-001", start=100.0, end=50.0, title="x", speaker="DM"),
+            ]
+        )
+        with pytest.raises(StructureValidationError):
+            validate(s, total_duration=600.0)
+
+    def test_override_outside_segment_raises(self) -> None:
+        s = _mk_struct()
+        s.segments[0].overrides = [
+            Override(start=500.0, end=550.0, speaker="NPC"),
+        ]
+        with pytest.raises(StructureValidationError, match="override"):
+            validate(s, total_duration=600.0)
+
+    def test_uncertainty_locator_outside_segments_raises(self) -> None:
+        s = _mk_struct(
+            uncertainty_flags=[
+                UncertaintyFlag(locator=700.0, span="x", kind="name"),
+            ]
+        )
+        with pytest.raises(StructureValidationError, match="uncertainty"):
+            validate(s, total_duration=600.0)
+
+    def test_duplicate_segment_ids_raise(self) -> None:
+        s = _mk_struct(
+            segments=[
+                Segment(id="seg-001", start=0.0, end=100.0, title="a", speaker="DM"),
+                Segment(id="seg-001", start=100.0, end=600.0, title="b", speaker="DM"),
+            ]
+        )
+        with pytest.raises(StructureValidationError, match="duplicate"):
+            validate(s, total_duration=600.0)
+
+    def test_tolerance_allows_small_gap(self) -> None:
+        # small gap/overlap within tolerance should not raise
+        s = _mk_struct(
+            segments=[
+                Segment(id="seg-001", start=0.0, end=100.5, title="a", speaker="DM"),
+                Segment(id="seg-002", start=100.0, end=600.0, title="b", speaker="DM"),
+            ]
+        )
+        validate(s, total_duration=600.0, tolerance=1.0)

--- a/tests/test_timestamps.py
+++ b/tests/test_timestamps.py
@@ -1,0 +1,82 @@
+"""Tests for timestamps.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from auto_lorebook.timestamps import (
+    TimestampError,
+    format_timestamp,
+    parse_timestamp,
+)
+
+
+class TestFormat:
+    def test_zero(self) -> None:
+        assert format_timestamp(0) == "0:00:00"
+
+    def test_seconds_only(self) -> None:
+        assert format_timestamp(7) == "0:00:07"
+
+    def test_minutes(self) -> None:
+        assert format_timestamp(65) == "0:01:05"
+
+    def test_hours(self) -> None:
+        assert format_timestamp(3_661) == "1:01:01"
+
+    def test_multi_digit_hours(self) -> None:
+        assert format_timestamp(36_000) == "10:00:00"
+
+    def test_float_truncates_to_whole_seconds(self) -> None:
+        # canonical form drops sub-second precision
+        assert format_timestamp(3_661.9) == "1:01:01"
+
+    def test_rejects_negative(self) -> None:
+        with pytest.raises(TimestampError):
+            format_timestamp(-1)
+
+
+class TestParse:
+    def test_canonical(self) -> None:
+        assert parse_timestamp("1:02:03") == pytest.approx(3_723.0)
+
+    def test_zero_hour(self) -> None:
+        assert parse_timestamp("0:00:07") == pytest.approx(7.0)
+
+    def test_leading_zero_hour(self) -> None:
+        assert parse_timestamp("01:02:03") == pytest.approx(3_723.0)
+
+    def test_mm_ss_allowed(self) -> None:
+        assert parse_timestamp("02:03") == pytest.approx(123.0)
+
+    def test_fractional_seconds_dot(self) -> None:
+        assert parse_timestamp("0:00:01.500") == pytest.approx(1.5)
+
+    def test_srt_comma_decimal(self) -> None:
+        # SRT uses comma as decimal separator
+        assert parse_timestamp("00:00:01,500") == pytest.approx(1.5)
+
+    def test_whitespace_tolerated(self) -> None:
+        assert parse_timestamp("  1:02:03  ") == pytest.approx(3_723.0)
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(TimestampError):
+            parse_timestamp("")
+
+    def test_garbage_raises(self) -> None:
+        with pytest.raises(TimestampError):
+            parse_timestamp("not a time")
+
+    def test_too_many_parts_raises(self) -> None:
+        with pytest.raises(TimestampError):
+            parse_timestamp("1:2:3:4")
+
+    def test_negative_component_raises(self) -> None:
+        with pytest.raises(TimestampError):
+            parse_timestamp("-1:00:00")
+
+
+class TestRoundTrip:
+    def test_canonical_round_trip(self) -> None:
+        for s in (0, 7, 65, 3_661, 36_000):
+            assert parse_timestamp(format_timestamp(s)) == pytest.approx(float(s))

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -1,0 +1,118 @@
+"""Tests for transcript.py."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from auto_lorebook.corrections import Correction, Corrections
+from auto_lorebook.info_yaml import Info, SourceContext
+from auto_lorebook.transcript import (
+    TranscriptError,
+    apply_corrections,
+    load,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_SRT = (
+    "1\n"
+    "00:00:01,000 --> 00:00:03,000\n"
+    "King Fair-on rules Aldara.\n"
+    "\n"
+    "2\n"
+    "00:01:00,000 --> 00:01:04,500\n"
+    "His son is heir.\n"
+)
+
+
+def _info(
+    source_type: str, duration: int | None = None, source_id: str = "yt-x"
+) -> Info:
+    return Info(
+        source_id=source_id,
+        source_type=source_type,
+        fetched_at="2026-04-20T00:00:00Z",
+        title="t",
+        duration_seconds=duration,
+        transcript_filename="transcript.en.srt"
+        if source_type in {"srt", "youtube"}
+        else "transcript.txt",
+        context=SourceContext(),
+    )
+
+
+class TestApplyCorrections:
+    def test_empty_corrections_returns_unchanged(self) -> None:
+        assert apply_corrections("hello", Corrections()) == "hello"
+
+    def test_single_correction(self) -> None:
+        cors = Corrections(corrections=[Correction(wrong="Fair-on", right="Theron")])
+        assert apply_corrections("King Fair-on", cors) == "King Theron"
+
+    def test_multiple_occurrences(self) -> None:
+        cors = Corrections(corrections=[Correction(wrong="x", right="y")])
+        assert apply_corrections("x and x and x", cors) == "y and y and y"
+
+    def test_order_independent(self) -> None:
+        cors = Corrections(
+            corrections=[
+                Correction(wrong="a", right="b"),
+                Correction(wrong="c", right="d"),
+            ]
+        )
+        assert apply_corrections("a c a c", cors) == "b d b d"
+
+
+class TestLoad:
+    def test_srt(self, tmp_wiki: Path) -> None:
+        src_dir = tmp_wiki / "sources" / "yt-x"
+        src_dir.mkdir(parents=True)
+        (src_dir / "transcript.en.srt").write_text(_SRT, encoding="utf-8")
+        info = _info("youtube", duration=120)
+        loaded = load(tmp_wiki, info, Corrections())
+        # flattened with canonical timestamps
+        assert "[0:00:01]" in loaded.text_for_llm
+        assert "King Fair-on rules Aldara." in loaded.text_for_llm
+        assert "[0:01:00]" in loaded.text_for_llm
+        assert loaded.total_duration == pytest.approx(120.0)
+
+    def test_srt_duration_falls_back_to_last_cue_end(self, tmp_wiki: Path) -> None:
+        src_dir = tmp_wiki / "sources" / "yt-x"
+        src_dir.mkdir(parents=True)
+        (src_dir / "transcript.en.srt").write_text(_SRT, encoding="utf-8")
+        info = _info("youtube", duration=None)
+        loaded = load(tmp_wiki, info, Corrections())
+        assert loaded.total_duration == pytest.approx(64.5)
+
+    def test_srt_applies_corrections(self, tmp_wiki: Path) -> None:
+        src_dir = tmp_wiki / "sources" / "yt-x"
+        src_dir.mkdir(parents=True)
+        (src_dir / "transcript.en.srt").write_text(_SRT, encoding="utf-8")
+        info = _info("youtube", duration=120)
+        cors = Corrections(corrections=[Correction(wrong="Fair-on", right="Theron")])
+        loaded = load(tmp_wiki, info, cors)
+        assert "Theron" in loaded.text_for_llm
+        assert "Fair-on" not in loaded.text_for_llm
+
+    def test_text_source(self, tmp_wiki: Path) -> None:
+        src_dir = tmp_wiki / "sources" / "txt-x"
+        src_dir.mkdir(parents=True)
+        (src_dir / "transcript.txt").write_text(
+            "Hello world.\nAnother line.\n", encoding="utf-8"
+        )
+        info = _info("text", duration=600, source_id="txt-x")
+        info.transcript_filename = "transcript.txt"
+        loaded = load(tmp_wiki, info, Corrections())
+        assert "Hello world." in loaded.text_for_llm
+        assert loaded.total_duration == pytest.approx(600.0)
+
+    def test_missing_transcript_raises(self, tmp_wiki: Path) -> None:
+        src_dir = tmp_wiki / "sources" / "yt-missing"
+        src_dir.mkdir(parents=True)
+        info = _info("youtube", duration=120, source_id="yt-missing")
+        with pytest.raises(TranscriptError):
+            load(tmp_wiki, info, Corrections())

--- a/tests/test_ytdlp.py
+++ b/tests/test_ytdlp.py
@@ -120,3 +120,18 @@ class TestFetch:
         with patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl):
             fetch("https://youtu.be/vd", tmp_path)
         assert "cookiesfrombrowser" not in captured_opts
+
+    def test_format_pins_permissive_selector(self, tmp_path: Path) -> None:
+        """Override yt-dlp's default `bv*+ba/b` to avoid format-selection failures.
+
+        Even with skip_download=True, yt-dlp validates format selection. The
+        default selector requires both video and audio streams and can fail
+        with 'Requested format is not available' on some videos.
+        """
+        info = {"id": "vfm", "title": "T", "duration": 10}
+        fake_ydl, captured_opts = make_fake_youtubedl(
+            info=info, subs={"vfm.en.srt": _SAMPLE_SRT}
+        )
+        with patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl):
+            fetch("https://youtu.be/vfm", tmp_path)
+        assert captured_opts["format"] == "bv*+ba/b/bv/ba/b"

--- a/tests/test_ytdlp.py
+++ b/tests/test_ytdlp.py
@@ -1,0 +1,145 @@
+"""Tests for ytdlp.py subprocess wrapper."""
+
+from __future__ import annotations
+
+import json
+import subprocess  # noqa: S404
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from auto_lorebook.ytdlp import (
+    NoSubtitlesError,
+    YtDlpError,
+    YtDlpNotFoundError,
+    fetch,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+_SAMPLE_SRT = (
+    "1\n"
+    "00:00:01,000 --> 00:00:02,000\n"
+    "hello\n"
+    "\n"
+    "2\n"
+    "00:00:03,000 --> 00:00:04,000\n"
+    "world\n"
+)
+
+
+def _fake_run_ok(
+    tmp_path: Path, video_id: str = "abc123"
+) -> Callable[..., subprocess.CompletedProcess[str]]:
+    """Build a patched subprocess.run that simulates a successful fetch."""
+    info = {"id": video_id, "title": "My Video", "duration": 123}
+
+    def side_effect(
+        cmd: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        # yt-dlp writes info.json and .en.srt into cwd (the target_dir)
+        (tmp_path / f"{video_id}.info.json").write_text(
+            json.dumps(info), encoding="utf-8"
+        )
+        (tmp_path / f"{video_id}.en.srt").write_text(_SAMPLE_SRT, encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    return side_effect
+
+
+class TestFetch:
+    def test_success(self, tmp_path: Path) -> None:
+        with patch(
+            "auto_lorebook.ytdlp.subprocess.run",
+            side_effect=_fake_run_ok(tmp_path, "vid_ok"),
+        ):
+            result = fetch("https://youtu.be/vid_ok", tmp_path)
+        assert result.video_id == "vid_ok"
+        assert result.title == "My Video"
+        assert result.duration == pytest.approx(123.0)
+        assert result.srt_path.exists()
+        assert result.srt_path.read_text(encoding="utf-8") == _SAMPLE_SRT
+
+    def test_yt_dlp_not_installed(self, tmp_path: Path) -> None:
+        with (
+            patch(
+                "auto_lorebook.ytdlp.subprocess.run",
+                side_effect=FileNotFoundError("yt-dlp"),
+            ),
+            pytest.raises(YtDlpNotFoundError),
+        ):
+            fetch("https://youtu.be/x", tmp_path)
+
+    def test_subprocess_nonzero_exit(self, tmp_path: Path) -> None:
+        with (
+            patch(
+                "auto_lorebook.ytdlp.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    [], 1, stdout="", stderr="ERROR: video unavailable"
+                ),
+            ),
+            pytest.raises(YtDlpError, match="video unavailable"),
+        ):
+            fetch("https://youtu.be/bad", tmp_path)
+
+    def test_no_subtitles_written(self, tmp_path: Path) -> None:
+        info = {"id": "v1", "title": "T", "duration": 10}
+
+        def side_effect(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            (tmp_path / "v1.info.json").write_text(json.dumps(info), encoding="utf-8")
+            # no .srt file
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with (
+            patch("auto_lorebook.ytdlp.subprocess.run", side_effect=side_effect),
+            pytest.raises(NoSubtitlesError),
+        ):
+            fetch("https://youtu.be/v1", tmp_path)
+
+    def test_info_json_missing(self, tmp_path: Path) -> None:
+        def side_effect(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with (
+            patch("auto_lorebook.ytdlp.subprocess.run", side_effect=side_effect),
+            pytest.raises(YtDlpError),
+        ):
+            fetch("https://youtu.be/nope", tmp_path)
+
+    def test_float_duration(self, tmp_path: Path) -> None:
+        info = {"id": "vf", "title": "T", "duration": 123.5}
+
+        def side_effect(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            (tmp_path / "vf.info.json").write_text(json.dumps(info), encoding="utf-8")
+            (tmp_path / "vf.en.srt").write_text(_SAMPLE_SRT, encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch("auto_lorebook.ytdlp.subprocess.run", side_effect=side_effect):
+            result = fetch("https://youtu.be/vf", tmp_path)
+        assert result.duration == pytest.approx(123.5)
+
+    def test_prefers_manual_subs_over_auto(self, tmp_path: Path) -> None:
+        info = {"id": "vm", "title": "T", "duration": 5}
+
+        def side_effect(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            (tmp_path / "vm.info.json").write_text(json.dumps(info), encoding="utf-8")
+            # yt-dlp writes both; wrapper prefers the non-auto one
+            (tmp_path / "vm.en.srt").write_text("manual", encoding="utf-8")
+            (tmp_path / "vm.en.auto.srt").write_text("auto", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch("auto_lorebook.ytdlp.subprocess.run", side_effect=side_effect):
+            result = fetch("https://youtu.be/vm", tmp_path)
+        assert result.srt_path.name == "vm.en.srt"

--- a/tests/test_ytdlp.py
+++ b/tests/test_ytdlp.py
@@ -1,23 +1,18 @@
-"""Tests for ytdlp.py subprocess wrapper."""
+"""Tests for ytdlp.py Python-API wrapper."""
 
 from __future__ import annotations
 
-import json
-import subprocess  # noqa: S404
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+import imageio_ffmpeg
 import pytest
+from yt_dlp.utils import DownloadError
 
-from auto_lorebook.ytdlp import (
-    NoSubtitlesError,
-    YtDlpError,
-    YtDlpNotFoundError,
-    fetch,
-)
+from auto_lorebook.ytdlp import NoSubtitlesError, YtDlpError, fetch
+from tests._ytdlp_fakes import make_fake_youtubedl
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -32,31 +27,13 @@ _SAMPLE_SRT = (
 )
 
 
-def _fake_run_ok(
-    tmp_path: Path, video_id: str = "abc123"
-) -> Callable[..., subprocess.CompletedProcess[str]]:
-    """Build a patched subprocess.run that simulates a successful fetch."""
-    info = {"id": video_id, "title": "My Video", "duration": 123}
-
-    def side_effect(
-        cmd: list[str], **_kwargs: object
-    ) -> subprocess.CompletedProcess[str]:
-        # yt-dlp writes info.json and .en.srt into cwd (the target_dir)
-        (tmp_path / f"{video_id}.info.json").write_text(
-            json.dumps(info), encoding="utf-8"
-        )
-        (tmp_path / f"{video_id}.en.srt").write_text(_SAMPLE_SRT, encoding="utf-8")
-        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
-    return side_effect
-
-
 class TestFetch:
     def test_success(self, tmp_path: Path) -> None:
-        with patch(
-            "auto_lorebook.ytdlp.subprocess.run",
-            side_effect=_fake_run_ok(tmp_path, "vid_ok"),
-        ):
+        info = {"id": "vid_ok", "title": "My Video", "duration": 123}
+        fake_ydl, _ = make_fake_youtubedl(
+            info=info, subs={"vid_ok.en.srt": _SAMPLE_SRT}
+        )
+        with patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl):
             result = fetch("https://youtu.be/vid_ok", tmp_path)
         assert result.video_id == "vid_ok"
         assert result.title == "My Video"
@@ -64,82 +41,64 @@ class TestFetch:
         assert result.srt_path.exists()
         assert result.srt_path.read_text(encoding="utf-8") == _SAMPLE_SRT
 
-    def test_yt_dlp_not_installed(self, tmp_path: Path) -> None:
+    def test_download_error_raises_ytdlp_error(self, tmp_path: Path) -> None:
+        fake_ydl, _ = make_fake_youtubedl(
+            info=None,
+            raises=DownloadError("ERROR: video unavailable"),
+        )
         with (
-            patch(
-                "auto_lorebook.ytdlp.subprocess.run",
-                side_effect=FileNotFoundError("yt-dlp"),
-            ),
-            pytest.raises(YtDlpNotFoundError),
-        ):
-            fetch("https://youtu.be/x", tmp_path)
-
-    def test_subprocess_nonzero_exit(self, tmp_path: Path) -> None:
-        with (
-            patch(
-                "auto_lorebook.ytdlp.subprocess.run",
-                return_value=subprocess.CompletedProcess(
-                    [], 1, stdout="", stderr="ERROR: video unavailable"
-                ),
-            ),
+            patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl),
             pytest.raises(YtDlpError, match="video unavailable"),
         ):
             fetch("https://youtu.be/bad", tmp_path)
 
+    def test_extract_info_returns_none_raises(self, tmp_path: Path) -> None:
+        fake_ydl, _ = make_fake_youtubedl(info=None)
+        with (
+            patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl),
+            pytest.raises(YtDlpError),
+        ):
+            fetch("https://youtu.be/x", tmp_path)
+
+    def test_extract_info_missing_fields_raises(self, tmp_path: Path) -> None:
+        fake_ydl, _ = make_fake_youtubedl(info={"id": "x"})  # no title/duration
+        with (
+            patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl),
+            pytest.raises(YtDlpError),
+        ):
+            fetch("https://youtu.be/x", tmp_path)
+
     def test_no_subtitles_written(self, tmp_path: Path) -> None:
         info = {"id": "v1", "title": "T", "duration": 10}
-
-        def side_effect(
-            cmd: list[str], **_kwargs: object
-        ) -> subprocess.CompletedProcess[str]:
-            (tmp_path / "v1.info.json").write_text(json.dumps(info), encoding="utf-8")
-            # no .srt file
-            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
+        fake_ydl, _ = make_fake_youtubedl(info=info)  # no subs written
         with (
-            patch("auto_lorebook.ytdlp.subprocess.run", side_effect=side_effect),
+            patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl),
             pytest.raises(NoSubtitlesError),
         ):
             fetch("https://youtu.be/v1", tmp_path)
 
-    def test_info_json_missing(self, tmp_path: Path) -> None:
-        def side_effect(
-            cmd: list[str], **_kwargs: object
-        ) -> subprocess.CompletedProcess[str]:
-            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
-        with (
-            patch("auto_lorebook.ytdlp.subprocess.run", side_effect=side_effect),
-            pytest.raises(YtDlpError),
-        ):
-            fetch("https://youtu.be/nope", tmp_path)
-
     def test_float_duration(self, tmp_path: Path) -> None:
         info = {"id": "vf", "title": "T", "duration": 123.5}
-
-        def side_effect(
-            cmd: list[str], **_kwargs: object
-        ) -> subprocess.CompletedProcess[str]:
-            (tmp_path / "vf.info.json").write_text(json.dumps(info), encoding="utf-8")
-            (tmp_path / "vf.en.srt").write_text(_SAMPLE_SRT, encoding="utf-8")
-            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
-        with patch("auto_lorebook.ytdlp.subprocess.run", side_effect=side_effect):
+        fake_ydl, _ = make_fake_youtubedl(info=info, subs={"vf.en.srt": _SAMPLE_SRT})
+        with patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl):
             result = fetch("https://youtu.be/vf", tmp_path)
         assert result.duration == pytest.approx(123.5)
 
     def test_prefers_manual_subs_over_auto(self, tmp_path: Path) -> None:
         info = {"id": "vm", "title": "T", "duration": 5}
-
-        def side_effect(
-            cmd: list[str], **_kwargs: object
-        ) -> subprocess.CompletedProcess[str]:
-            (tmp_path / "vm.info.json").write_text(json.dumps(info), encoding="utf-8")
-            # yt-dlp writes both; wrapper prefers the non-auto one
-            (tmp_path / "vm.en.srt").write_text("manual", encoding="utf-8")
-            (tmp_path / "vm.en.auto.srt").write_text("auto", encoding="utf-8")
-            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
-        with patch("auto_lorebook.ytdlp.subprocess.run", side_effect=side_effect):
+        fake_ydl, _ = make_fake_youtubedl(
+            info=info,
+            subs={"vm.en.srt": "manual", "vm.en.auto.srt": "auto"},
+        )
+        with patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl):
             result = fetch("https://youtu.be/vm", tmp_path)
         assert result.srt_path.name == "vm.en.srt"
+
+    def test_ydl_opts_include_bundled_ffmpeg(self, tmp_path: Path) -> None:
+        info = {"id": "vff", "title": "T", "duration": 10}
+        fake_ydl, captured_opts = make_fake_youtubedl(
+            info=info, subs={"vff.en.srt": _SAMPLE_SRT}
+        )
+        with patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl):
+            fetch("https://youtu.be/vff", tmp_path)
+        assert captured_opts["ffmpeg_location"] == imageio_ffmpeg.get_ffmpeg_exe()

--- a/tests/test_ytdlp.py
+++ b/tests/test_ytdlp.py
@@ -102,3 +102,21 @@ class TestFetch:
         with patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl):
             fetch("https://youtu.be/vff", tmp_path)
         assert captured_opts["ffmpeg_location"] == imageio_ffmpeg.get_ffmpeg_exe()
+
+    def test_cookies_from_browser_passed_through(self, tmp_path: Path) -> None:
+        info = {"id": "vc", "title": "T", "duration": 10}
+        fake_ydl, captured_opts = make_fake_youtubedl(
+            info=info, subs={"vc.en.srt": _SAMPLE_SRT}
+        )
+        with patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl):
+            fetch("https://youtu.be/vc", tmp_path, cookies_from_browser="firefox")
+        assert captured_opts["cookiesfrombrowser"] == ("firefox",)
+
+    def test_cookies_from_browser_omitted_by_default(self, tmp_path: Path) -> None:
+        info = {"id": "vd", "title": "T", "duration": 10}
+        fake_ydl, captured_opts = make_fake_youtubedl(
+            info=info, subs={"vd.en.srt": _SAMPLE_SRT}
+        )
+        with patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl):
+            fetch("https://youtu.be/vd", tmp_path)
+        assert "cookiesfrombrowser" not in captured_opts

--- a/tests/test_ytdlp.py
+++ b/tests/test_ytdlp.py
@@ -121,12 +121,13 @@ class TestFetch:
             fetch("https://youtu.be/vd", tmp_path)
         assert "cookiesfrombrowser" not in captured_opts
 
-    def test_format_pins_permissive_selector(self, tmp_path: Path) -> None:
-        """Override yt-dlp's default `bv*+ba/b` to avoid format-selection failures.
+    def test_ignore_no_formats_error_enabled(self, tmp_path: Path) -> None:
+        """Format-selection failures must not abort subtitle-only fetches.
 
-        Even with skip_download=True, yt-dlp validates format selection. The
-        default selector requires both video and audio streams and can fail
-        with 'Requested format is not available' on some videos.
+        Even with skip_download=True, yt-dlp runs format selection and aborts
+        when YouTube only exposes image formats (SABR/PO-Token gating).
+        Subtitles are written *before* that error, so making it non-fatal
+        keeps the SRT we actually want.
         """
         info = {"id": "vfm", "title": "T", "duration": 10}
         fake_ydl, captured_opts = make_fake_youtubedl(
@@ -134,4 +135,4 @@ class TestFetch:
         )
         with patch("auto_lorebook.ytdlp.YoutubeDL", fake_ydl):
             fetch("https://youtu.be/vfm", tmp_path)
-        assert captured_opts["format"] == "bv*+ba/b/bv/ba/b"
+        assert captured_opts["ignore_no_formats_error"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,15 @@ version = 1
 revision = 3
 requires-python = "==3.13.*"
 
+[options]
+exclude-newer = "2026-04-17T20:49:25.178177367Z"
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+defusedxml = { timestamp = "2026-04-23T20:49:25.178192926Z", span = "P1D" }
+ruff = { timestamp = "2026-04-22T20:49:25.178200442Z", span = "P2D" }
+ty = { timestamp = "2026-04-23T20:49:25.178201215Z", span = "P1D" }
+
 [[package]]
 name = "attrs"
 version = "26.1.0"
@@ -95,25 +104,25 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.4.4"
+version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/ec/bf5ae0a7e5ab57abe8aabdd0759c971883895d1a20c49ae99f8146840c3c/build-1.4.4.tar.gz", hash = "sha256:f832ae053061f3fb524af812dc94b8b84bac6880cd587630e3b5d91a6a9c1703", size = 89220, upload-time = "2026-04-22T20:53:44.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/16/4b272700dea44c1d2e8ca963ebb3c684efe22b3eba8cfa31c5fdb60de707/build-1.4.3.tar.gz", hash = "sha256:5aa4231ae0e807efdf1fd0623e07366eca2ab215921345a2e38acdd5d0fa0a74", size = 89314, upload-time = "2026-04-10T21:25:40.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/88/6764e7a109dd84294850741501145da90d13cdeac9d4e614929464a37420/build-1.4.4-py3-none-any.whl", hash = "sha256:8c3f48a6090b39edec1a273d2d57949aaf13723b01e02f9d518396887519f64d", size = 25921, upload-time = "2026-04-22T20:53:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/30/f169e1d8b2071beaf8b97088787e30662b1d8fb82f8c0941d14678c0cbf1/build-1.4.3-py3-none-any.whl", hash = "sha256:1bc22b19b383303de8f2c8554c9a32894a58d3f185fe3756b0b20d255bee9a38", size = 26171, upload-time = "2026-04-10T21:25:39.671Z" },
 ]
 
 [[package]]
 name = "certifi"
-version = "2026.4.22"
+version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]
@@ -127,8 +136,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
     { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
     { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
     { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
     { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
@@ -164,14 +171,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.3"
+version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
 ]
 
 [[package]]
@@ -246,22 +253,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
     { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
     { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
     { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
     { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
     { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
     { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
     { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
     { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
     { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
     { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
     { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
     { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
     { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
     { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
     { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
     { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
     { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
@@ -326,11 +329,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -415,28 +418,28 @@ wheels = [
 
 [[package]]
 name = "lxml"
-version = "6.1.0"
+version = "6.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/08/1217ca4043f55c3c92993b283a7dbfa456a2058d8b57bbb416cc96b6efff/lxml-6.0.4.tar.gz", hash = "sha256:4137516be2a90775f99d8ef80ec0283f8d78b5d8bd4630ff20163b72e7e9abf2", size = 4237780, upload-time = "2026-04-12T16:28:24.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689, upload-time = "2026-04-18T04:31:57.785Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892, upload-time = "2026-04-18T04:32:01.78Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489, upload-time = "2026-04-18T04:33:31.401Z" },
-    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162, upload-time = "2026-04-18T04:33:34.262Z" },
-    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247, upload-time = "2026-04-18T04:33:36.674Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042, upload-time = "2026-04-18T04:33:39.205Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304, upload-time = "2026-04-18T04:33:41.647Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578, upload-time = "2026-04-18T04:33:44.596Z" },
-    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209, upload-time = "2026-04-18T04:33:47.552Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365, upload-time = "2026-04-18T04:33:50.249Z" },
-    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654, upload-time = "2026-04-18T04:33:52.71Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326, upload-time = "2026-04-18T04:33:55.244Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879, upload-time = "2026-04-18T04:33:58.509Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048, upload-time = "2026-04-18T04:34:00.943Z" },
-    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241, upload-time = "2026-04-18T04:34:03.365Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f6/550a1ed9afde66e24bfcf9892446ea9779152df336062c6df0f7733151a2/lxml-6.0.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ecc3d55ed756ee6c3447748862a97e1f5392d2c5d7f474bace9382345e4fc274", size = 8559522, upload-time = "2026-04-12T16:24:51.563Z" },
+    { url = "https://files.pythonhosted.org/packages/11/93/3f687c14d2b4d24b60fe13fd5482c8853f82a10bb87f2b577123e342ed1a/lxml-6.0.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a7d5a627a368a0e861350ccc567a70ec675d2bc4d8b3b54f48995ae78d8d530e", size = 4617380, upload-time = "2026-04-12T16:24:54.042Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/ed/91e443366063d3fb7640ae2badd5d7b65be4095ac6d849788e39c043baae/lxml-6.0.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d385141b186cc39ebe4863c1e41936282c65df19b2d06a701dedc2a898877d6a", size = 4922791, upload-time = "2026-04-12T16:24:56.381Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4b/2243260b70974aca9ba0cc71bd668c0c3a79644d80ddcabbfbdb4b131848/lxml-6.0.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0132bb040e9bb5a199302e12bf942741defbc52922a2a06ce9ff7be0d0046483", size = 5080972, upload-time = "2026-04-12T16:24:58.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/c3/54c53c4f772341bc12331557f8b0882a426f53133926306cbe6d7f0ee7e4/lxml-6.0.4-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26aee5321e4aa1f07c9090a35f6ab8b703903fb415c6c823cfdb20ee0d779855", size = 4992236, upload-time = "2026-04-12T16:25:01.099Z" },
+    { url = "https://files.pythonhosted.org/packages/be/0f/416de42e22f287585abee610eb0d1c2638c9fe24cee7e15136e0b5e138f8/lxml-6.0.4-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b5652455de198ff76e02cfa57d5efc5f834fa45521aaf3fcc13d6b5a88bde23d", size = 5612398, upload-time = "2026-04-12T16:25:03.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/63/29a3fa79b8a182f5bd5b5bdcb6f625f49f08f41d60a26ca25482820a1b99/lxml-6.0.4-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:75842801fb48aea73f4c281b923a010dfb39bad75edf8ceb2198ec30c27f01cc", size = 5227480, upload-time = "2026-04-12T16:25:06.119Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4a/44d1843de599b1c6dbe578e4248c2f15e7fac90c5c86eb26775eaeac0fe0/lxml-6.0.4-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:94a1f74607a5a049ff6ff8de429fec922e643e32b5b08ec7a4fe49e8de76e17c", size = 5341001, upload-time = "2026-04-12T16:25:08.563Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/52/c8aebde49f169e4e3452e7756be35be1cb2903e30d961cb57aa65a27055f/lxml-6.0.4-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:173cc246d3d3b6d3b6491f0b3aaf22ebdf2eed616879482acad8bd84d73eb231", size = 4699105, upload-time = "2026-04-12T16:25:10.757Z" },
+    { url = "https://files.pythonhosted.org/packages/78/60/76fc3735c31c28b70220d99452fb72052e84b618693ca2524da96f0131d8/lxml-6.0.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f0f2ee1be1b72e9890da87e4e422f2f703ff4638fd5ec5383055db431e8e30e9", size = 5231095, upload-time = "2026-04-12T16:25:13.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/448f01c52110102f23df5f07b3f4fde57c8e13e497e182a743d125324c0b/lxml-6.0.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c51a274b7e8b9ce394c3f8b471eb0b23c1914eec64fdccf674e082daf72abf11", size = 5042411, upload-time = "2026-04-12T16:25:15.541Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/2a/90612a001fa4fa0ff0443ebb0256a542670fe35473734c559720293e7aff/lxml-6.0.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:210ea934cba1a1ec42f88c4190c4d5c67b2d14321a8faed9b39e8378198ff99d", size = 4768431, upload-time = "2026-04-12T16:25:17.581Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d8/572845a7d741c8a8ffeaf928185263e14d97fbd355de164677340951d7a5/lxml-6.0.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:14fe654a59eebe16368c51778caeb0c8fda6f897adcd9afe828d87d13b5d5e51", size = 5634972, upload-time = "2026-04-12T16:25:20.111Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/1d/392b8c9f8cf1d502bbec50dee137c7af3dd5def5e5cd84572fbf0ba0541c/lxml-6.0.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ec160a2b7e2b3cb71ec35010b19a1adea05785d19ba5c9c5f986b64b78fef564", size = 5222909, upload-time = "2026-04-12T16:25:22.243Z" },
+    { url = "https://files.pythonhosted.org/packages/21/ab/949fc96f825cf083612aee65d5a02eacc5eaeb2815561220e33e1e160677/lxml-6.0.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d305b86ef10b23cf3a6d62a2ad23fa296f76495183ee623f64d2600f65ffe09c", size = 5249096, upload-time = "2026-04-12T16:25:24.781Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e8/fbe44df79ede5ff760401cc3c49c4204f49f0f529cc6b27d0af7b63f5472/lxml-6.0.4-cp313-cp313-win32.whl", hash = "sha256:a2f31380aa9a9b52591e79f1c1d3ac907688fbeb9d883ba28be70f2eb5db2277", size = 3595808, upload-time = "2026-04-12T16:25:26.747Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/df/e873abb881092256520edf0d67d686e36f3c86b3cf289f01b6458272dede/lxml-6.0.4-cp313-cp313-win_amd64.whl", hash = "sha256:b8efa9f681f15043e497293d58a4a63199564b253ed2291887d92bb3f74f59ab", size = 3994635, upload-time = "2026-04-12T16:25:28.828Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a8/9c56c8914b9b18d89face5a7472445002baf309167f7af65d988842129fd/lxml-6.0.4-cp313-cp313-win_arm64.whl", hash = "sha256:905abe6a5888129be18f85f2aea51f0c9863fa0722fb8530dfbb687d2841d221", size = 3657374, upload-time = "2026-04-12T16:25:30.901Z" },
 ]
 
 [[package]]
@@ -642,11 +645,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.1.0"
+version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -867,27 +870,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.12"
+version = "0.15.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
-    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
-    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
-    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
-    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
-    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3,13 +3,13 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-04-17T20:49:25.178177367Z"
+exclude-newer = "2026-04-17T22:40:19.500112535Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-defusedxml = { timestamp = "2026-04-23T20:49:25.178192926Z", span = "P1D" }
-ruff = { timestamp = "2026-04-22T20:49:25.178200442Z", span = "P2D" }
-ty = { timestamp = "2026-04-23T20:49:25.178201215Z", span = "P1D" }
+defusedxml = { timestamp = "2026-04-23T22:40:19.5001276Z", span = "P1D" }
+ruff = { timestamp = "2026-04-22T22:40:19.500137184Z", span = "P2D" }
+ty = { timestamp = "2026-04-23T22:40:19.500137631Z", span = "P1D" }
 
 [[package]]
 name = "attrs"
@@ -25,8 +25,10 @@ name = "auto-lorebook"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },
+    { name = "imageio-ffmpeg" },
     { name = "pyyaml" },
     { name = "trio" },
+    { name = "yt-dlp" },
 ]
 
 [package.dev-dependencies]
@@ -54,8 +56,10 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1,<1" },
+    { name = "imageio-ffmpeg", specifier = ">=0.5.0" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "trio", specifier = ">=0.33.0,<1" },
+    { name = "yt-dlp", specifier = ">=2025.1.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -334,6 +338,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
 ]
 
 [[package]]
@@ -1022,4 +1040,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2026.3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/34/7c6b4e3f89cb6416d2cd7ab6dab141a1df97ab0fb22d15816db2c92148c9/yt_dlp-2026.3.17.tar.gz", hash = "sha256:ba7aa31d533f1ffccfe70e421596d7ca8ff0bf1398dc6bb658b7d9dec057d2c9", size = 3119221, upload-time = "2026-03-17T23:43:00.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/13/5093bcb954878e50f7217fd2ab94282b53934022e4e4a03265582da83bf5/yt_dlp-2026.3.17-py3-none-any.whl", hash = "sha256:32992db94303a8a5d211a183f2174834fe7f8c29d83ed2e7a324eae97a8f26d8", size = 3315134, upload-time = "2026-03-17T23:42:57.863Z" },
 ]


### PR DESCRIPTION
## Summary

This PR implements the core Stage 1 reading pipeline: automated transcript segmentation (Stage 1a) and per-segment claim extraction (Stage 1b). Together with supporting infrastructure, this enables end-to-end generation of draft wiki readings from raw transcripts via LLM.

## Key Changes

### Core Pipeline Stages
- **Stage 1a** (`stage1a.py`): Single LLM call to segment transcript into topic-bounded segments with speaker attribution, emitting a validated `Structure` artifact
- **Stage 1b** (`stage1b.py`): Parallelized per-segment claim extraction; each segment is summarized independently to produce `ReadingBullets` with anchored timestamps and locator-hint windows
- **Reading Pipeline** (`reading_pipeline.py`): High-level orchestration exposing `generate()`, `regenerate()`, and `approve()` entry points that wire Stages 1a/1b with downstream modules

### Data Models & Serialization
- **Structure** (`structure.py`): In-memory representation of segmented transcript with mechanical validation; YAML read/write with canonical `h:mm:ss` timestamp formatting
- **ReadingBullets** (`stage1b.py`): Keyed-by-segment-id output carrying extracted claims with anchor timestamps and locator hints for downstream planner/extractor
- **Reading** (`reading.py`): Markdown assembly with YAML frontmatter, interleaving segment headers with bullets, applying name corrections, and rendering uncertainty flags

### Supporting Infrastructure
- **OpenRouter Client** (`openrouter.py`): Thin stdlib-based HTTP wrapper over OpenRouter's `/chat/completions` endpoint with error classification (auth, rate-limit, transport, API)
- **Transcript Loading** (`transcript.py`): Flattens SRT cues to `[h:mm:ss] text` lines; applies transcription corrections before LLM input
- **SRT Parser** (`srt.py`): Tolerant parser handling BOM, CRLF, extra blanks; validates timestamps and cue ordering
- **yt-dlp Wrapper** (`ytdlp.py`): Fetches YouTube metadata and English SRT via bundled yt-dlp library (no external binary dependency)
- **Timestamp Utilities** (`timestamps.py`): Canonical `h:mm:ss` formatting and lenient parsing (accepts leading zeros, `mm:ss`, fractional seconds with `.` or `,`)
- **Gap Check** (`gap_check.py`): Deterministic heuristic to surface contiguous low-yield segment stretches (rules, breaks, silence, etc.) exceeding a threshold
- **LLM Helpers** (`llm_helpers.py`): Shared code-fence-tolerant JSON parsing and system-prompt assembly

### Command Layer
- **generate-reading**: Run Stage 1a + 1b from scratch
- **approve-reading**: Flip draft to approved and copy into wiki
- **regenerate-reading**: Re-run from structure or summarize stage, preserving corrections and selective bullets
- **ingest** (enhanced): Now supports YouTube URLs via bundled yt-dlp; added `--cookies-from-browser` flag for authenticated fetches

### Configuration & Credentials
- **Config** (`config.py`): Enhanced to support fallback credential file (`_read_credentials()`) when API key env var is unset; removed `openrouter/` prefix from model names (OpenRouter client handles routing)
- **Credentials File**: New `~/.auto-lorebook/credentials.yaml` support for storing API keys securely

### Testing
- Comprehensive test suites for all new modules: `test_stage1a.py`, `test_stage1b.py`, `test_reading_commands.py`, `test_structure.py`, `test_reading.py`, `test_openrouter.py`, `test_ytdlp.py`, `test_srt.py`, `test_transcript.py`, `test_gap_check.py`, `test_timestamps.py`
- End-to-end pipeline tests with mocked OpenRouter HTTP layer for deterministic execution
- Fake YoutubeDL factory (`_ytdlp_fakes.py

https://claude.ai/code/session_01PDqjRbne79m8zZqt5XvfjY