### PR TITLE
Implement Phase 2: entity scaffolding (entity_yaml + entities CLI)

### DIFF
--- a/docs/architecture/entity-model.md
+++ b/docs/architecture/entity-model.md
@@ -168,6 +168,10 @@ tool may cache the index at `.cache/entity-index.json`. The cache is
 never authoritative — it is rebuilt from YAMLs whenever any entity
 YAML changes.
 
+`auto-lorebook entities rebuild-index` is reserved for that future
+cache. Until a cache exists, it is a no-op that prints a status line —
+the in-memory index is rebuilt on every command run regardless.
+
 ## Global transcription corrections
 
 `.transcription-corrections.yaml` at the wiki root:

--- a/docs/getting-started/entities.md
+++ b/docs/getting-started/entities.md
@@ -1,0 +1,68 @@
+# Hand-creating entities
+
+Entity files normally appear automatically: when you approve a fact in
+the review loop (Phase 4), the tool creates the entity stub atomically
+on first approval. Hand-creation is a bootstrapping aid for seeding a
+fresh wiki with characters, locations, or other entities you already
+know about.
+
+The full schema is documented in
+[entity model](../architecture/entity-model.md). For bootstrapping you
+only need the four required keys.
+
+## Minimum viable stub
+
+Save as `<wiki>/<category>/<slug>.yaml`. Categories are the six
+directories under your wiki repo: `characters`, `locations`,
+`factions`, `events`, `items`, `concepts`.
+
+```yaml
+schema_version: 1
+entity: Aldara
+category: locations
+slug: aldara
+```
+
+Optional fields the tool will read if present:
+
+- `aliases` — list of `{name, added_by_ingest, added_at, source}` records.
+- `superseded_by` — `"<category>/<slug>"` if this entity was merged into
+  another. Hides it from the entity index.
+- `created_at`, `created_by_ingest`, `updated_at` — provenance fields
+  (left blank for hand-created entries).
+
+## Scaffolding command
+
+`entities new` writes a minimum stub for you. The slug is derived from
+the name (lowercase, spaces to hyphens, non-alphanumeric stripped) but
+can be overridden.
+
+```bash
+auto-lorebook entities new --category characters --name "King Theron"
+# created /path/to/wiki/characters/king-theron.yaml
+
+auto-lorebook entities new --category locations --name "Aldara" --slug aldara
+```
+
+The command refuses if the target file already exists; use
+`entities show` to inspect the existing file.
+
+## Verifying recognition
+
+The entity index is rebuilt from the filesystem on every command run.
+After hand-editing or scaffolding a stub, list it:
+
+```bash
+auto-lorebook entities list
+auto-lorebook entities list --category characters
+```
+
+Inspect a single entity by slug, canonical name, or alias:
+
+```bash
+auto-lorebook entities show theron
+auto-lorebook entities show "King Theron"
+```
+
+When you next run `ingest` or `configure-context`, the preamble shows
+the entity index and your hand-created stubs appear in it.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -84,9 +84,19 @@ Promote a per-source name correction to the global
 ## Entities
 
 ```bash
+auto-lorebook entities list [--category <cat>] [--created-by <ingest_id>]
+auto-lorebook entities show <slug-or-name>
+auto-lorebook entities new --category <cat> --name <name> [--slug <slug>]
 auto-lorebook entities rebuild-index
-auto-lorebook entities list [--created-by <ingest_id>]
 ```
+
+`list` prints a category/name/slug/alias-count table; filters compose.
+`show` resolves the query against slugs first, then canonical names
+(case-insensitive), then aliases. `new` writes a minimum-viable stub;
+slug defaults to a slugified `--name`. `rebuild-index` is a placeholder
+until an on-disk cache exists — today the in-memory index is rebuilt on
+every command anyway. See
+[hand-creating entities](../getting-started/entities.md).
 
 ```bash
 auto-lorebook reject-ingest <ingest_id>

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -6,17 +6,20 @@ implementation status.
 
 !!! info "Current status"
 
-    Phase 1 substantially landed. The reading pipeline is runnable end
-    to end against a real OpenRouter backend: `ingest` fetches
-    YouTube transcripts via `yt-dlp`, `generate-reading` runs Stage 1a
-    (structure + mechanical validation) and Stage 1b (per-segment
-    summarize, parallelized) to produce a draft `reading.md`, the
-    mechanical gap check surfaces low-yield stretches during review,
-    `approve-reading` flips the draft into the wiki, and
-    `regenerate-reading --from=structure|summarize [--segments]`
-    supports targeted re-runs. Remaining Phase 1 polish: live
+    Phase 1 substantially landed; the reading pipeline is runnable end
+    to end against a real OpenRouter backend (Stage 1a + 1b, gap
+    check, approve, targeted re-runs). Remaining Phase 1 polish: live
     end-to-end validation against a real source and tuning the 1a/1b
     prompts based on that run.
+
+    Phase 2 (entity scaffolding) landed: schema-validated entity YAML
+    read/write (`auto_lorebook.entity_yaml`), the existing in-memory
+    `EntityIndex` migrated onto it, and an `entities` subcommand
+    group (`list`, `show`, `new`, `rebuild-index`). Hand-creating
+    entities is documented at
+    [hand-creating entities](../getting-started/entities.md);
+    `entities rebuild-index` is a placeholder until a disk cache
+    materialises.
 
 ## Phase 1: Reading stage
 
@@ -72,7 +75,7 @@ fires at least once on real content and the warning is actionable.
 Total human review time for a two-hour source fits inside the
 10–20 min/hour target on a representative session.
 
-## Phase 2: Entity scaffolding
+## Phase 2: Entity scaffolding (landed)
 
 **Scope**
 
@@ -84,7 +87,11 @@ Total human review time for a two-hour source fits inside the
   are normally created via approved facts).
 
 **Exit criterion** — hand-create a few entities; tool lists them and
-exposes them to the next stage as an entity index.
+exposes them to the next stage as an entity index. ✓
+
+`entities rename` and `wiki list` / `wiki show` were spec'd alongside
+this phase but are deferred — `rename` to whenever a real need surfaces,
+`wiki *` to Phase 5/6 where they overlap with summary rendering.
 
 ## Phase 3: Planner
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
   - Getting started:
       - getting-started/installation.md
       - getting-started/first-ingest.md
+      - getting-started/entities.md
   - Architecture:
       - architecture/overview.md
       - architecture/repository-layout.md

--- a/src/auto_lorebook/cli.py
+++ b/src/auto_lorebook/cli.py
@@ -13,6 +13,7 @@ from auto_lorebook import __version__
 from auto_lorebook.commands import (
     approve_reading_cmd,
     configure_context_cmd,
+    entities_cmd,
     generate_reading_cmd,
     ingest_cmd,
     regenerate_reading_cmd,
@@ -100,6 +101,7 @@ def create_parser() -> argparse.ArgumentParser:
     generate_reading_cmd.add_parser(subparsers, common_parser)
     approve_reading_cmd.add_parser(subparsers, common_parser)
     regenerate_reading_cmd.add_parser(subparsers, common_parser)
+    entities_cmd.add_parser(subparsers, common_parser)
 
     return parser
 

--- a/src/auto_lorebook/commands/__init__.py
+++ b/src/auto_lorebook/commands/__init__.py
@@ -7,6 +7,7 @@ Each subcommand is defined in its own module and exports:
 
 from auto_lorebook.commands import approve_reading as approve_reading_cmd
 from auto_lorebook.commands import configure_context as configure_context_cmd
+from auto_lorebook.commands import entities as entities_cmd
 from auto_lorebook.commands import generate_reading as generate_reading_cmd
 from auto_lorebook.commands import ingest as ingest_cmd
 from auto_lorebook.commands import regenerate_reading as regenerate_reading_cmd
@@ -15,6 +16,7 @@ from auto_lorebook.commands import version as version_cmd
 __all__ = [
     "approve_reading_cmd",
     "configure_context_cmd",
+    "entities_cmd",
     "generate_reading_cmd",
     "ingest_cmd",
     "regenerate_reading_cmd",

--- a/src/auto_lorebook/commands/entities.py
+++ b/src/auto_lorebook/commands/entities.py
@@ -1,0 +1,230 @@
+"""auto-lorebook entities subcommand group.
+
+First nested subparser in the project: `entities <list|show|new|rebuild-index>`.
+Subcommands all dispatch through `run()`, branching on `args.entities_action`.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import entity_index, entity_yaml
+from auto_lorebook.timestamps import format_iso_now
+
+if TYPE_CHECKING:
+    import argparse
+
+    from auto_lorebook.entity_yaml import Entity
+
+_logger = logging.getLogger(__name__)
+
+_SLUG_STRIP_RE = re.compile(r"[^a-z0-9-]+")
+_SLUG_DASH_RE = re.compile(r"-+")
+
+
+def add_parser(
+    subparsers: argparse._SubParsersAction,
+    common_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Register the `entities` subcommand group."""
+    parser = subparsers.add_parser(
+        "entities",
+        parents=[common_parser],
+        help="List, show, or hand-create entities in the wiki",
+        description=(
+            "Inspect and bootstrap entities. Hand-creation is a "
+            "bootstrapping aid; the normal path is approval of facts "
+            "in the review loop (Phase 4)."
+        ),
+    )
+    sub = parser.add_subparsers(
+        dest="entities_action",
+        required=True,
+        help="entities subcommand",
+    )
+
+    p_list = sub.add_parser(
+        "list",
+        parents=[common_parser],
+        help="List entities in the wiki",
+    )
+    p_list.add_argument(
+        "--category",
+        choices=entity_yaml.CATEGORIES,
+        help="Filter by category",
+    )
+    p_list.add_argument(
+        "--created-by",
+        dest="created_by",
+        help="Filter by created_by_ingest",
+    )
+    p_list.set_defaults(func=run)
+
+    p_show = sub.add_parser(
+        "show",
+        parents=[common_parser],
+        help="Show one entity (resolved by slug, name, or alias)",
+    )
+    p_show.add_argument(
+        "query",
+        help="Entity slug, canonical name, or alias",
+    )
+    p_show.set_defaults(func=run)
+
+    p_new = sub.add_parser(
+        "new",
+        parents=[common_parser],
+        help="Hand-create a minimal entity stub",
+    )
+    p_new.add_argument(
+        "--category",
+        required=True,
+        choices=entity_yaml.CATEGORIES,
+    )
+    p_new.add_argument("--name", required=True, help="Canonical entity name")
+    p_new.add_argument(
+        "--slug",
+        default=None,
+        help="Optional slug; defaults to a slugified --name",
+    )
+    p_new.set_defaults(func=run)
+
+    p_rebuild = sub.add_parser(
+        "rebuild-index",
+        parents=[common_parser],
+        help="Rebuild the in-memory entity index (no cache yet; placeholder)",
+    )
+    p_rebuild.set_defaults(func=run)
+
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Dispatch to the matching `_run_*` based on `entities_action`."""
+    action = args.entities_action
+    cfg = cfg_mod.load_config()
+    wiki = cfg.wiki_repo_path
+
+    if action == "list":
+        return _run_list(args, wiki)
+    if action == "show":
+        return _run_show(args, wiki)
+    if action == "new":
+        return _run_new(args, wiki)
+    if action == "rebuild-index":
+        return _run_rebuild_index(wiki)
+    msg = f"unknown entities action: {action}"
+    raise ValueError(msg)
+
+
+def _run_list(args: argparse.Namespace, wiki) -> int:  # noqa: ANN001
+    entities = entity_yaml.scan(wiki)
+    if args.category:
+        entities = [e for e in entities if e.category == args.category]
+    if args.created_by:
+        entities = [e for e in entities if e.created_by_ingest == args.created_by]
+    if not entities:
+        print("(no entities)")  # noqa: T201
+        return 0
+
+    entities.sort(key=lambda e: (e.category, e.entity.casefold()))
+    # column widths
+    cat_w = max(len("CATEGORY"), *(len(e.category) for e in entities))
+    name_w = max(len("NAME"), *(len(e.entity) for e in entities))
+    slug_w = max(len("SLUG"), *(len(e.slug) for e in entities))
+    header = f"{'CATEGORY':<{cat_w}}  {'NAME':<{name_w}}  {'SLUG':<{slug_w}}  ALIASES"
+    print(header)  # noqa: T201
+    for e in entities:
+        print(  # noqa: T201
+            f"{e.category:<{cat_w}}  {e.entity:<{name_w}}  {e.slug:<{slug_w}}  "
+            f"{len(e.aliases)}"
+        )
+    return 0
+
+
+def _resolve(entities: list[Entity], query: str) -> list[Entity]:
+    """Return matches in resolution order: slug → name → alias."""
+    q_norm = entity_yaml.normalize_alias_name(query)
+    by_slug = [e for e in entities if e.slug == query]
+    if by_slug:
+        return by_slug
+    by_name = [e for e in entities if e.entity.casefold() == query.casefold()]
+    if by_name:
+        return by_name
+    return [
+        e
+        for e in entities
+        if any(entity_yaml.normalize_alias_name(a.name) == q_norm for a in e.aliases)
+    ]
+
+
+def _run_show(args: argparse.Namespace, wiki) -> int:  # noqa: ANN001
+    entities = entity_yaml.scan(wiki)
+    matches = _resolve(entities, args.query)
+    if not matches:
+        print(f"No entity matching {args.query!r}")  # noqa: T201
+        return 1
+    if len(matches) > 1:
+        print(f"Multiple matches for {args.query!r}:")  # noqa: T201
+        for e in matches:
+            print(f"  - {e.category}/{e.slug}  ({e.entity})")  # noqa: T201
+        return 1
+
+    e = matches[0]
+    print(f"entity:    {e.entity}")  # noqa: T201
+    print(f"category:  {e.category}")  # noqa: T201
+    print(f"slug:      {e.slug}")  # noqa: T201
+    if e.superseded_by:
+        print(f"superseded_by: {e.superseded_by}")  # noqa: T201
+    if e.created_by_ingest:
+        print(f"created_by_ingest: {e.created_by_ingest}")  # noqa: T201
+    if e.created_at:
+        print(f"created_at: {e.created_at}")  # noqa: T201
+    if e.aliases:
+        print("aliases:")  # noqa: T201
+        for a in e.aliases:
+            tag = f" ({a.source})" if a.source else ""
+            print(f"  - {a.name}{tag}")  # noqa: T201
+    else:
+        print("aliases: (none)")  # noqa: T201
+    print("facts: (no facts yet — populated in Phase 4)")  # noqa: T201
+    return 0
+
+
+def _slugify(name: str) -> str:
+    s = name.strip().casefold().replace(" ", "-")
+    s = _SLUG_STRIP_RE.sub("-", s)
+    return _SLUG_DASH_RE.sub("-", s).strip("-")
+
+
+def _run_new(args: argparse.Namespace, wiki) -> int:  # noqa: ANN001
+    slug = args.slug or _slugify(args.name)
+    if not slug:
+        print(f"error: could not derive a slug from {args.name!r}; pass --slug")  # noqa: T201
+        return 1
+    cat_dir = wiki / args.category
+    cat_dir.mkdir(parents=True, exist_ok=True)
+    target = cat_dir / f"{slug}.yaml"
+    if target.exists():
+        print(  # noqa: T201
+            f"error: {target} already exists; use `entities show {slug}` to inspect it"
+        )
+        return 1
+    e = entity_yaml.Entity(
+        entity=args.name,
+        category=args.category,
+        slug=slug,
+        created_at=format_iso_now(),
+    )
+    entity_yaml.write(e, target)
+    print(f"created {target}")  # noqa: T201
+    return 0
+
+
+def _run_rebuild_index(wiki) -> int:  # noqa: ANN001
+    entity_index.build(wiki)
+    print("(index rebuilt from filesystem; no cache in use)")  # noqa: T201
+    return 0

--- a/src/auto_lorebook/entity_index.py
+++ b/src/auto_lorebook/entity_index.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+from auto_lorebook import entity_yaml
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-import yaml
-
 _logger = logging.getLogger(__name__)
 
-_CATEGORIES = ("characters", "locations", "factions", "events", "items", "concepts")
+_CATEGORIES = entity_yaml.CATEGORIES
 
 
 @dataclass
@@ -57,24 +57,17 @@ class EntityIndex:
 def _load_entry(path: Path) -> EntityEntry | None:
     """Parse a single entity YAML; return None on error or if superseded."""
     try:
-        raw: Any = yaml.safe_load(path.read_text(encoding="utf-8"))
-    except Exception:  # noqa: BLE001
+        e = entity_yaml.read(path)
+    except entity_yaml.EntityError:
         _logger.warning("entity_index: could not parse %s; skipping", path)
         return None
-    if not isinstance(raw, dict):
+    if e.superseded_by is not None:
         return None
-    if raw.get("superseded_by") is not None:
-        return None
-    entity = raw.get("entity")
-    category = raw.get("category")
-    slug = raw.get("slug")
-    if not entity or not category or not slug:
-        _logger.warning("entity_index: missing required fields in %s; skipping", path)
-        return None
-    aliases_raw: list[Any] = raw.get("aliases") or []
-    aliases = [a["name"] for a in aliases_raw if isinstance(a, dict) and a.get("name")]
     return EntityEntry(
-        entity=str(entity), category=str(category), slug=str(slug), aliases=aliases
+        entity=e.entity,
+        category=e.category,
+        slug=e.slug,
+        aliases=[a.name for a in e.aliases],
     )
 
 

--- a/src/auto_lorebook/entity_yaml.py
+++ b/src/auto_lorebook/entity_yaml.py
@@ -1,0 +1,237 @@
+"""Entity YAML read/write with schema validation.
+
+Mirrors `info_yaml.py` shape; preserves unknown top-level keys on
+write-back so Phase 4 facts written by future code survive a Phase 2
+read→write round-trip.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from auto_lorebook._io import atomic_write_text
+from auto_lorebook.schema import SchemaVersionError, read_schema_version
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+_MAX_SCHEMA = 1
+
+# the six entity categories; mirrors `entity_index._CATEGORIES`
+CATEGORIES: tuple[str, ...] = (
+    "characters",
+    "locations",
+    "factions",
+    "events",
+    "items",
+    "concepts",
+)
+
+# top-level keys this module knows about; everything else lands in `Entity.extra`
+_KNOWN_KEYS = frozenset(
+    {
+        "schema_version",
+        "entity",
+        "category",
+        "slug",
+        "aliases",
+        "superseded_by",
+        "created_at",
+        "created_by_ingest",
+        "updated_at",
+        "facts",
+    },
+)
+
+
+class EntityError(ValueError):
+    """Raised when entity YAML is missing or malformed."""
+
+
+@dataclass
+class Alias:
+    """Single alias record on an entity.
+
+    See `docs/architecture/entity-model.md` for `source` enum values.
+    """
+
+    name: str
+    added_by_ingest: str | None = None
+    added_at: str | None = None
+    source: str | None = None
+
+
+@dataclass
+class Entity:
+    """In-memory representation of `<category>/<slug>.yaml`."""
+
+    entity: str
+    category: str
+    slug: str
+    aliases: list[Alias] = field(default_factory=list)
+    superseded_by: str | None = None
+    created_at: str | None = None
+    created_by_ingest: str | None = None
+    updated_at: str | None = None
+    # facts are kept as raw dicts in Phase 2; Phase 4 models them properly.
+    facts: list[dict[str, Any]] = field(default_factory=list)
+    # unrecognized top-level keys; preserved on write-back.
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def normalize_alias_name(name: str) -> str:
+    """Case-fold + whitespace-trim for dedup and lookup comparisons."""
+    return name.strip().casefold()
+
+
+def _alias_from_dict(data: Any) -> Alias | None:  # noqa: ANN401
+    if not isinstance(data, dict):
+        return None
+    name = data.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    return Alias(
+        name=name,
+        added_by_ingest=data.get("added_by_ingest") or None,
+        added_at=data.get("added_at") or None,
+        source=data.get("source") or None,
+    )
+
+
+def _alias_to_dict(alias: Alias) -> dict[str, Any]:
+    return {
+        "name": alias.name,
+        "added_by_ingest": alias.added_by_ingest,
+        "added_at": alias.added_at,
+        "source": alias.source,
+    }
+
+
+def _dedup_aliases(aliases: list[Alias]) -> list[Alias]:
+    """Drop later records sharing a normalized name with an earlier one."""
+    seen: set[str] = set()
+    out: list[Alias] = []
+    for a in aliases:
+        key = normalize_alias_name(a.name)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(a)
+    return out
+
+
+def _from_dict(data: dict[str, Any], file_label: str) -> Entity:
+    for required in ("entity", "category", "slug"):
+        if not data.get(required):
+            msg = f"{file_label}: missing required field {required!r}"
+            raise EntityError(msg)
+    category = str(data["category"])
+    if category not in CATEGORIES:
+        allowed = ", ".join(CATEGORIES)
+        msg = f"{file_label}: category {category!r} not one of: {allowed}"
+        raise EntityError(msg)
+
+    raw_aliases = data.get("aliases") or []
+    if not isinstance(raw_aliases, list):
+        msg = f"{file_label}: aliases must be a list"
+        raise EntityError(msg)
+    aliases: list[Alias] = []
+    for raw in raw_aliases:
+        a = _alias_from_dict(raw)
+        if a is not None:
+            aliases.append(a)
+    aliases = _dedup_aliases(aliases)
+
+    facts = data.get("facts") or []
+    if not isinstance(facts, list):
+        msg = f"{file_label}: facts must be a list"
+        raise EntityError(msg)
+
+    extra = {k: v for k, v in data.items() if k not in _KNOWN_KEYS}
+
+    return Entity(
+        entity=str(data["entity"]),
+        category=category,
+        slug=str(data["slug"]),
+        aliases=aliases,
+        superseded_by=data.get("superseded_by") or None,
+        created_at=data.get("created_at") or None,
+        created_by_ingest=data.get("created_by_ingest") or None,
+        updated_at=data.get("updated_at") or None,
+        facts=list(facts),
+        extra=extra,
+    )
+
+
+def _to_dict(entity: Entity) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "schema_version": 1,
+        "entity": entity.entity,
+        "category": entity.category,
+        "slug": entity.slug,
+        "aliases": [_alias_to_dict(a) for a in _dedup_aliases(entity.aliases)],
+        "superseded_by": entity.superseded_by,
+        "created_at": entity.created_at,
+        "created_by_ingest": entity.created_by_ingest,
+        "updated_at": entity.updated_at,
+        "facts": list(entity.facts),
+    }
+    # preserved keys appended after known ones; ignore any collisions
+    for k, v in entity.extra.items():
+        if k not in out:
+            out[k] = v
+    return out
+
+
+def read(path: Path) -> Entity:
+    """Read and validate an entity YAML.
+
+    :raises EntityError: missing file, non-mapping root, or invalid contents
+    """
+    if not path.exists():
+        msg = f"{path}: file not found"
+        raise EntityError(msg)
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        msg = f"{path}: expected a YAML mapping"
+        raise EntityError(msg)
+    try:
+        read_schema_version(raw, str(path), max_supported=_MAX_SCHEMA)
+    except SchemaVersionError as e:
+        raise EntityError(str(e)) from e
+    return _from_dict(raw, str(path))
+
+
+def write(entity: Entity, path: Path) -> None:
+    """Atomically write entity to path; schema_version always first key."""
+    text = yaml.safe_dump(
+        _to_dict(entity),
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    )
+    atomic_write_text(path, text)
+
+
+def scan(wiki_repo: Path) -> list[Entity]:
+    """Read every entity YAML under `wiki_repo`; skip malformed with warning.
+
+    Sorted by category (per `CATEGORIES` order), then slug.
+    """
+    out: list[Entity] = []
+    for cat in CATEGORIES:
+        cat_dir = wiki_repo / cat
+        if not cat_dir.is_dir():
+            continue
+        for yaml_path in sorted(cat_dir.glob("*.yaml")):
+            try:
+                out.append(read(yaml_path))
+            except EntityError:
+                _logger.warning("entity_yaml: could not parse %s; skipping", yaml_path)
+    return out

--- a/tests/test_entities_cmd.py
+++ b/tests/test_entities_cmd.py
@@ -1,0 +1,303 @@
+"""Tests for the `entities` subcommand group."""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from auto_lorebook.cli import create_parser
+from auto_lorebook.commands import entities_cmd
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def configured_wiki(tmp_wiki: Path, tmp_home: Path) -> Path:
+    """tmp_wiki + a config.yaml pointing at it."""
+    (tmp_home / "config.yaml").write_text(
+        f"schema_version: 1\nwiki_repo_path: {tmp_wiki}\n",
+        encoding="utf-8",
+    )
+    return tmp_wiki
+
+
+def _write_entity(
+    wiki: Path,
+    *,
+    category: str,
+    slug: str,
+    name: str,
+    aliases: list[str] | None = None,
+    created_by_ingest: str | None = None,
+    superseded_by: str | None = None,
+) -> None:
+    data: dict[str, object] = {
+        "schema_version": 1,
+        "entity": name,
+        "category": category,
+        "slug": slug,
+        "aliases": [{"name": a} for a in (aliases or [])],
+        "superseded_by": superseded_by,
+    }
+    if created_by_ingest is not None:
+        data["created_by_ingest"] = created_by_ingest
+    (wiki / category / f"{slug}.yaml").write_text(
+        yaml.safe_dump(data, sort_keys=False), encoding="utf-8"
+    )
+
+
+def _ns(action: str, **kwargs: object) -> argparse.Namespace:
+    base = {
+        "entities_action": action,
+        "category": None,
+        "created_by": None,
+        "query": None,
+        "name": None,
+        "slug": None,
+    }
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+class TestList:
+    def test_empty_wiki(
+        self,
+        configured_wiki: Path,  # noqa: ARG002
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = entities_cmd.run(_ns("list"))
+        assert rc == 0
+        assert "(no entities)" in capsys.readouterr().out
+
+    def test_lists_entities(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki, category="characters", slug="theron", name="Theron"
+        )
+        _write_entity(
+            configured_wiki, category="locations", slug="aldara", name="Aldara"
+        )
+        rc = entities_cmd.run(_ns("list"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "CATEGORY" in out
+        assert "Theron" in out
+        assert "Aldara" in out
+        # category-then-name sort: characters/Theron before locations/Aldara
+        assert out.index("Theron") < out.index("Aldara")
+
+    def test_filter_by_category(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki, category="characters", slug="theron", name="Theron"
+        )
+        _write_entity(
+            configured_wiki, category="locations", slug="aldara", name="Aldara"
+        )
+        rc = entities_cmd.run(_ns("list", category="characters"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Theron" in out
+        assert "Aldara" not in out
+
+    def test_filter_by_created_by(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki,
+            category="characters",
+            slug="alpha",
+            name="Alpha",
+            created_by_ingest="ingest-001",
+        )
+        _write_entity(
+            configured_wiki,
+            category="characters",
+            slug="beta",
+            name="Beta",
+            created_by_ingest="ingest-002",
+        )
+        rc = entities_cmd.run(_ns("list", created_by="ingest-001"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Alpha" in out
+        assert "Beta" not in out
+
+
+class TestShow:
+    def test_by_slug(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki,
+            category="characters",
+            slug="theron",
+            name="Theron",
+            aliases=["King Theron"],
+        )
+        rc = entities_cmd.run(_ns("show", query="theron"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "entity:    Theron" in out
+        assert "King Theron" in out
+        assert "no facts yet" in out
+
+    def test_by_name_case_insensitive(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki, category="characters", slug="theron", name="Theron"
+        )
+        rc = entities_cmd.run(_ns("show", query="THERON"))
+        assert rc == 0
+        assert "Theron" in capsys.readouterr().out
+
+    def test_by_alias(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki,
+            category="locations",
+            slug="aldara",
+            name="Aldara",
+            aliases=["Kingdom of Aldara"],
+        )
+        rc = entities_cmd.run(_ns("show", query="kingdom of aldara"))
+        assert rc == 0
+        assert "Aldara" in capsys.readouterr().out
+
+    def test_miss(
+        self,
+        configured_wiki: Path,  # noqa: ARG002
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = entities_cmd.run(_ns("show", query="nope"))
+        assert rc == 1
+        assert "No entity matching" in capsys.readouterr().out
+
+    def test_ambiguous(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki,
+            category="characters",
+            slug="aldara-c",
+            name="Aldara",
+        )
+        _write_entity(
+            configured_wiki,
+            category="locations",
+            slug="aldara-l",
+            name="Aldara",
+        )
+        rc = entities_cmd.run(_ns("show", query="Aldara"))
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Multiple matches" in out
+        assert "characters/aldara-c" in out
+        assert "locations/aldara-l" in out
+
+
+class TestNew:
+    def test_default_slug(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = entities_cmd.run(
+            _ns("new", category="characters", name="King Theron the Brave")
+        )
+        assert rc == 0
+        target = configured_wiki / "characters" / "king-theron-the-brave.yaml"
+        assert target.exists()
+        data = yaml.safe_load(target.read_text(encoding="utf-8"))
+        assert data["entity"] == "King Theron the Brave"
+        assert data["category"] == "characters"
+        assert data["slug"] == "king-theron-the-brave"
+        assert data["schema_version"] == 1
+        assert data["created_at"]
+        assert "created" in capsys.readouterr().out
+
+    def test_explicit_slug(self, configured_wiki: Path) -> None:
+        rc = entities_cmd.run(
+            _ns("new", category="locations", name="Aldara", slug="my-aldara")
+        )
+        assert rc == 0
+        assert (configured_wiki / "locations" / "my-aldara.yaml").exists()
+
+    def test_collision_refused(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki, category="characters", slug="theron", name="Theron"
+        )
+        rc = entities_cmd.run(
+            _ns("new", category="characters", name="Theron", slug="theron")
+        )
+        assert rc == 1
+        assert "already exists" in capsys.readouterr().out
+
+    def test_unslugifiable_name_rejected(
+        self,
+        configured_wiki: Path,  # noqa: ARG002
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = entities_cmd.run(_ns("new", category="characters", name="!!!"))
+        assert rc == 1
+        assert "could not derive a slug" in capsys.readouterr().out
+
+
+class TestRebuildIndex:
+    def test_smoke(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(configured_wiki, category="characters", slug="x", name="X")
+        rc = entities_cmd.run(_ns("rebuild-index"))
+        assert rc == 0
+        assert "no cache in use" in capsys.readouterr().out
+
+
+def test_argparse_requires_subaction() -> None:
+    parser = create_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["entities"])
+
+
+def test_argparse_routes_list() -> None:
+    parser = create_parser()
+    args = parser.parse_args(["entities", "list", "--category", "characters"])
+    assert args.entities_action == "list"
+    assert args.category == "characters"
+    assert args.func is entities_cmd.run

--- a/tests/test_entities_cmd.py
+++ b/tests/test_entities_cmd.py
@@ -59,7 +59,7 @@ def _write_entity(
 
 
 def _ns(action: str, **kwargs: object) -> argparse.Namespace:
-    base = {
+    base: dict[str, object] = {
         "entities_action": action,
         "category": None,
         "created_by": None,

--- a/tests/test_entity_index.py
+++ b/tests/test_entity_index.py
@@ -9,6 +9,8 @@ import yaml
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
 from auto_lorebook.entity_index import build
 
 
@@ -115,3 +117,19 @@ def test_render_deterministic(tmp_wiki: Path) -> None:
     r1 = build(tmp_wiki).render_for_preamble()
     r2 = build(tmp_wiki).render_for_preamble()
     assert r1 == r2
+
+
+def test_malformed_entity_skipped_with_warning(
+    tmp_wiki: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _write_entity(tmp_wiki, "characters", "good", "Good")
+    # missing schema_version: rejected by entity_yaml reader
+    (tmp_wiki / "characters" / "bad.yaml").write_text(
+        "entity: Bad\ncategory: characters\nslug: bad\n", encoding="utf-8"
+    )
+    with caplog.at_level("WARNING"):
+        idx = build(tmp_wiki)
+    rendered = idx.render_for_preamble()
+    assert "Good" in rendered
+    assert "Bad" not in rendered
+    assert any("could not parse" in r.message for r in caplog.records)

--- a/tests/test_entity_yaml.py
+++ b/tests/test_entity_yaml.py
@@ -1,0 +1,240 @@
+"""Tests for entity_yaml.py."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from auto_lorebook.entity_yaml import (
+    Alias,
+    Entity,
+    EntityError,
+    normalize_alias_name,
+    read,
+    write,
+)
+from auto_lorebook.schema import SchemaVersionError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_yaml(path: Path, data: dict[str, object]) -> None:
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _minimal_dict(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "schema_version": 1,
+        "entity": "Aldara",
+        "category": "locations",
+        "slug": "aldara",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_read_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(EntityError, match="file not found"):
+        read(tmp_path / "nope.yaml")
+
+
+def test_read_non_mapping_root(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    p.write_text("- just a list\n", encoding="utf-8")
+    with pytest.raises(EntityError, match="expected a YAML mapping"):
+        read(p)
+
+
+def test_read_missing_schema_version(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(p, {"entity": "X", "category": "characters", "slug": "x"})
+    with pytest.raises(EntityError, match="schema_version"):
+        read(p)
+
+
+def test_read_future_schema_version(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(p, _minimal_dict(schema_version=99))
+    with pytest.raises(EntityError):
+        read(p)
+
+
+def test_read_missing_required_field(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(p, {"schema_version": 1, "entity": "X", "category": "characters"})
+    with pytest.raises(EntityError, match="slug"):
+        read(p)
+
+
+def test_read_bad_category(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(p, _minimal_dict(category="weapons"))
+    with pytest.raises(EntityError, match="category"):
+        read(p)
+
+
+def test_read_bad_aliases_type(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(p, _minimal_dict(aliases="not a list"))
+    with pytest.raises(EntityError, match="aliases"):
+        read(p)
+
+
+def test_read_minimal_entity(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(p, _minimal_dict())
+    e = read(p)
+    assert e.entity == "Aldara"
+    assert e.category == "locations"
+    assert e.slug == "aldara"
+    assert e.aliases == []
+    assert e.facts == []
+    assert e.extra == {}
+
+
+def test_read_full_entity(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(
+        p,
+        _minimal_dict(
+            aliases=[
+                {
+                    "name": "Kingdom of Aldara",
+                    "added_by_ingest": "ingest-001",
+                    "added_at": "2026-01-16T14:32:11Z",
+                    "source": "hand-edited",
+                },
+            ],
+            superseded_by=None,
+            created_at="2026-01-16T14:32:11Z",
+            created_by_ingest="ingest-001",
+            updated_at="2026-02-03T19:14:55Z",
+            facts=[{"id": "aldara-f001", "text": "founded in the Second Age"}],
+        ),
+    )
+    e = read(p)
+    assert len(e.aliases) == 1
+    assert e.aliases[0].name == "Kingdom of Aldara"
+    assert e.aliases[0].source == "hand-edited"
+    assert e.created_by_ingest == "ingest-001"
+    assert e.facts[0]["id"] == "aldara-f001"
+
+
+def test_read_drops_malformed_alias(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(
+        p,
+        _minimal_dict(
+            aliases=[
+                {"name": "valid"},
+                "not-a-dict",
+                {"missing_name": True},
+                {"name": ""},
+            ],
+        ),
+    )
+    e = read(p)
+    assert [a.name for a in e.aliases] == ["valid"]
+
+
+def test_read_dedups_aliases_keeping_earliest(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(
+        p,
+        _minimal_dict(
+            aliases=[
+                {"name": "the Realm", "added_by_ingest": "ingest-A"},
+                {"name": "  the realm ", "added_by_ingest": "ingest-B"},
+                {"name": "THE REALM", "added_by_ingest": "ingest-C"},
+            ],
+        ),
+    )
+    e = read(p)
+    assert len(e.aliases) == 1
+    assert e.aliases[0].name == "the Realm"
+    assert e.aliases[0].added_by_ingest == "ingest-A"
+
+
+def test_read_preserves_unknown_keys(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(
+        p,
+        _minimal_dict(future_field={"foo": 1}, another_unknown=[1, 2, 3]),
+    )
+    e = read(p)
+    assert e.extra == {"future_field": {"foo": 1}, "another_unknown": [1, 2, 3]}
+
+
+def test_write_round_trip(tmp_path: Path) -> None:
+    src = Entity(
+        entity="Theron",
+        category="characters",
+        slug="theron",
+        aliases=[Alias(name="King Theron", source="hand-edited")],
+        created_at="2026-01-16T14:32:11Z",
+    )
+    p = tmp_path / "theron.yaml"
+    write(src, p)
+    got = read(p)
+    assert got.entity == "Theron"
+    assert got.aliases[0].name == "King Theron"
+
+
+def test_write_schema_version_first(tmp_path: Path) -> None:
+    e = Entity(entity="X", category="characters", slug="x")
+    p = tmp_path / "x.yaml"
+    write(e, p)
+    text = p.read_text(encoding="utf-8")
+    first_line = text.splitlines()[0]
+    assert first_line.startswith("schema_version:")
+
+
+def test_write_preserves_unknown_keys(tmp_path: Path) -> None:
+    e = Entity(
+        entity="X",
+        category="characters",
+        slug="x",
+        extra={"future_facts_v2": [{"a": 1}]},
+    )
+    p = tmp_path / "x.yaml"
+    write(e, p)
+    raw = yaml.safe_load(p.read_text(encoding="utf-8"))
+    assert raw["future_facts_v2"] == [{"a": 1}]
+    # round-trip stays preserved
+    got = read(p)
+    assert got.extra == {"future_facts_v2": [{"a": 1}]}
+
+
+def test_write_dedups_aliases(tmp_path: Path) -> None:
+    e = Entity(
+        entity="X",
+        category="characters",
+        slug="x",
+        aliases=[Alias(name="Foo"), Alias(name="foo"), Alias(name="FOO")],
+    )
+    p = tmp_path / "x.yaml"
+    write(e, p)
+    got = read(p)
+    assert len(got.aliases) == 1
+
+
+def test_write_atomic(tmp_path: Path) -> None:
+    e = Entity(entity="X", category="characters", slug="x")
+    nested = tmp_path / "deep" / "deeper"
+    p = nested / "x.yaml"
+    write(e, p)  # should create parents
+    assert p.exists()
+
+
+def test_normalize_alias_name_casefold_and_strip() -> None:
+    assert normalize_alias_name("  The Realm ") == "the realm"
+    assert normalize_alias_name("THE REALM") == "the realm"
+
+
+def test_schema_version_error_subclass() -> None:
+    # SchemaVersionError underlies our errors; this is just a sanity check
+    # that it's importable from where we expect.
+    assert issubclass(SchemaVersionError, ValueError)


### PR DESCRIPTION
Add schema-validated entity YAML read/write at
`auto_lorebook.entity_yaml`, mirroring the `info_yaml.py` pattern with
unknown-key preservation so Phase 4 facts written by future code
survive a Phase 2 round-trip. Migrate the existing in-memory
`EntityIndex` loader onto it so malformed files are rejected centrally.

Add the `entities` subcommand group (the first nested subparser in the
project): `list [--category] [--created-by]`, `show <slug-or-name>`
with slug→name→alias resolution, `new --category --name [--slug]`
scaffolding, and `rebuild-index` as a no-op placeholder until a disk
cache exists.

Document the hand-creation path in a new
`getting-started/entities.md`, refresh the CLI reference, note the
rebuild-index placeholder in the entity-model architecture doc, and
flip Phase 2 to landed in the roadmap.