### PR TITLE
Add Stage 3 extractor and Stage 4 review engine with CLI commands

### DIFF
--- a/docs/architecture/entity-model.md
+++ b/docs/architecture/entity-model.md
@@ -45,6 +45,7 @@ facts:
         source: reading-name-correction
     edited_by_human: false
     edited_at: null
+    text_source: null              # set to original LLM text when edited_by_human
     source_id: yt-abc123
     locator: "0:04:32-0:04:41"
     speaker: DM
@@ -103,6 +104,9 @@ facts:
 - **`corrections_applied`** — audit trail of substitutions, with
   source (`global-transcription-correction`, `reading-name-correction`,
   or `human-edit`).
+- **`text_source`** — when `edited_by_human` is true, the original
+  pre-edit `text` (post-corrections) is preserved here so the audit
+  trail isn't lost. `null` when the fact was approved without edits.
 - **`source_id`** — foreign key to `sources/<source_id>/info.yaml`.
 - **`locator`** — timestamp range in canonical `h:mm:ss-h:mm:ss`
   format for audio/video, or line range for text. See

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -25,8 +25,7 @@ implementation status.
     after `approve-reading`, writes `pending/<source_id>/plan.yaml`
     with no filesystem side effects (new entities and aliases are
     proposals only), supports multi-target routing per claim, and
-    exposes `plans list` / `plans show` for inspection. `replan` is
-    deferred to Phase 4.
+    exposes `plans list` / `plans show` for inspection.
 
     Phase 4 extractor landed: Stage 3 runs automatically after the
     planner, parallelised per `PlannedClaim`, with reduced preamble,
@@ -49,8 +48,19 @@ implementation status.
     the same session resolve as existing. `--auto-approve` provides
     non-interactive bulk approval (and explicitly *declines* alias
     suggestions) for CI. Ctrl-C leaves untouched proposal files in
-    place so the next invocation resumes. `replan` and
-    `reject-ingest` remain deferred within Phase 4.
+    place so the next invocation resumes.
+
+    Phase 4 closeout landed: `auto-lorebook replan <id>` discards
+    unreviewed proposals and re-runs planner + extractor against the
+    wiki's current entity state (so stubs created by earlier
+    approvals appear as existing); already-approved facts are
+    untouched. `auto-lorebook reject-ingest <id>` removes every fact
+    and alias tagged with the ingest, deletes empty stubs the ingest
+    itself created, and clears `pending/<id>/plan.yaml` and
+    `proposals/`. `<wiki>/sources/<id>/` and `pending/<id>/reading/`
+    are left untouched so a follow-up `regenerate-reading` /
+    `approve-reading` cleanly redoes the pipeline. **Phase 4 is
+    fully landed.**
 
 ## Phase 1: Reading stage
 
@@ -145,8 +155,8 @@ plan_, not files in the wiki. Aliases are proposed, not yet written.
 At least one planned claim in a representative session routes to
 multiple targets. ✓
 
-`replan` was spec'd alongside this phase but is deferred to Phase 4
-where the extractor + review loop give it something to discard.
+`replan` was spec'd alongside this phase but landed in Phase 4
+once the extractor + review loop gave it something to discard.
 
 ## Phase 4: Extractor + review
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -28,6 +28,19 @@ implementation status.
     exposes `plans list` / `plans show` for inspection. `replan` is
     deferred to Phase 4.
 
+    Phase 4 extractor landed: Stage 3 runs automatically after the
+    planner, parallelised per `PlannedClaim`, with reduced preamble,
+    windowed transcript per claim driven by `locator_hint`, mechanical
+    fallback to the parent-segment window with `hint_widened` logged,
+    claim-group dedup (one LLM call per claim, span copied to every
+    sibling target), and post-extraction substring verification.
+    Proposals land at `pending/<source_id>/proposals/<proposed_id>.yaml`
+    with provisional `proposed_id`s allocated single-threaded before
+    fan-out. The terminal review loop, atomic stub creation on first
+    approval, alias confirmation, in-memory index refresh,
+    per-fact append, edited-text handling, `replan`, and
+    `reject-ingest` remain deferred within Phase 4.
+
 ## Phase 1: Reading stage
 
 **Goal** — ingest a YouTube URL, gather context, produce a reviewable,

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -36,9 +36,20 @@ implementation status.
     sibling target), and post-extraction substring verification.
     Proposals land at `pending/<source_id>/proposals/<proposed_id>.yaml`
     with provisional `proposed_id`s allocated single-threaded before
-    fan-out. The terminal review loop, atomic stub creation on first
-    approval, alias confirmation, in-memory index refresh,
-    per-fact append, edited-text handling, `replan`, and
+    fan-out.
+
+    Phase 4 review loop also landed: `auto-lorebook review <id>` walks
+    each pending proposal, prompts approve / edit / reject / play, and
+    on approval atomically creates the entity stub (for proposed-new
+    entities) or appends a fact to the existing entity YAML.
+    Inline alias-confirmation sub-prompts merge planner-suggested
+    aliases as `stub-creation` (first-approval batch) or
+    `alias-confirmation` (later additions). The in-memory entity
+    index refreshes after each approval so siblings created earlier in
+    the same session resolve as existing. `--auto-approve` provides
+    non-interactive bulk approval (and explicitly *declines* alias
+    suggestions) for CI. Ctrl-C leaves untouched proposal files in
+    place so the next invocation resumes. `replan` and
     `reject-ingest` remain deferred within Phase 4.
 
 ## Phase 1: Reading stage

--- a/src/auto_lorebook/cli.py
+++ b/src/auto_lorebook/cli.py
@@ -18,6 +18,8 @@ from auto_lorebook.commands import (
     ingest_cmd,
     plans_cmd,
     regenerate_reading_cmd,
+    reject_ingest_cmd,
+    replan_cmd,
     review_cmd,
     version_cmd,
 )
@@ -106,6 +108,8 @@ def create_parser() -> argparse.ArgumentParser:
     entities_cmd.add_parser(subparsers, common_parser)
     plans_cmd.add_parser(subparsers, common_parser)
     review_cmd.add_parser(subparsers, common_parser)
+    replan_cmd.add_parser(subparsers, common_parser)
+    reject_ingest_cmd.add_parser(subparsers, common_parser)
 
     return parser
 

--- a/src/auto_lorebook/cli.py
+++ b/src/auto_lorebook/cli.py
@@ -18,6 +18,7 @@ from auto_lorebook.commands import (
     ingest_cmd,
     plans_cmd,
     regenerate_reading_cmd,
+    review_cmd,
     version_cmd,
 )
 
@@ -104,6 +105,7 @@ def create_parser() -> argparse.ArgumentParser:
     regenerate_reading_cmd.add_parser(subparsers, common_parser)
     entities_cmd.add_parser(subparsers, common_parser)
     plans_cmd.add_parser(subparsers, common_parser)
+    review_cmd.add_parser(subparsers, common_parser)
 
     return parser
 

--- a/src/auto_lorebook/commands/__init__.py
+++ b/src/auto_lorebook/commands/__init__.py
@@ -12,6 +12,7 @@ from auto_lorebook.commands import generate_reading as generate_reading_cmd
 from auto_lorebook.commands import ingest as ingest_cmd
 from auto_lorebook.commands import plans as plans_cmd
 from auto_lorebook.commands import regenerate_reading as regenerate_reading_cmd
+from auto_lorebook.commands import review as review_cmd
 from auto_lorebook.commands import version as version_cmd
 
 __all__ = [
@@ -22,5 +23,6 @@ __all__ = [
     "ingest_cmd",
     "plans_cmd",
     "regenerate_reading_cmd",
+    "review_cmd",
     "version_cmd",
 ]

--- a/src/auto_lorebook/commands/__init__.py
+++ b/src/auto_lorebook/commands/__init__.py
@@ -12,6 +12,8 @@ from auto_lorebook.commands import generate_reading as generate_reading_cmd
 from auto_lorebook.commands import ingest as ingest_cmd
 from auto_lorebook.commands import plans as plans_cmd
 from auto_lorebook.commands import regenerate_reading as regenerate_reading_cmd
+from auto_lorebook.commands import reject_ingest as reject_ingest_cmd
+from auto_lorebook.commands import replan as replan_cmd
 from auto_lorebook.commands import review as review_cmd
 from auto_lorebook.commands import version as version_cmd
 
@@ -23,6 +25,8 @@ __all__ = [
     "ingest_cmd",
     "plans_cmd",
     "regenerate_reading_cmd",
+    "reject_ingest_cmd",
+    "replan_cmd",
     "review_cmd",
     "version_cmd",
 ]

--- a/src/auto_lorebook/commands/approve_reading.py
+++ b/src/auto_lorebook/commands/approve_reading.py
@@ -58,4 +58,17 @@ def run(args: argparse.Namespace) -> int:
         return 1
 
     print(f"Plan: {plan_result.plan_path}")  # noqa: T201
+
+    try:
+        extract_result = pipeline.extract(cfg, args.source_id)
+    except pipeline.ReadingPipelineError as e:
+        _logger.error("extractor failed: %s", e)
+        return 1
+
+    n = len(extract_result.proposals)
+    flagged = extract_result.flagged_count
+    print(  # noqa: T201
+        f"Extracted {n} proposal(s) ({flagged} flagged) → "
+        f"{extract_result.proposals_dir}"
+    )
     return 0

--- a/src/auto_lorebook/commands/entities.py
+++ b/src/auto_lorebook/commands/entities.py
@@ -7,11 +7,11 @@ Subcommands all dispatch through `run()`, branching on `args.entities_action`.
 from __future__ import annotations
 
 import logging
-import re
 from typing import TYPE_CHECKING
 
 from auto_lorebook import config as cfg_mod
 from auto_lorebook import entity_index, entity_yaml
+from auto_lorebook.entity_yaml import slugify
 from auto_lorebook.timestamps import format_iso_now
 
 if TYPE_CHECKING:
@@ -20,9 +20,6 @@ if TYPE_CHECKING:
     from auto_lorebook.entity_yaml import Entity
 
 _logger = logging.getLogger(__name__)
-
-_SLUG_STRIP_RE = re.compile(r"[^a-z0-9-]+")
-_SLUG_DASH_RE = re.compile(r"-+")
 
 
 def add_parser(
@@ -194,14 +191,8 @@ def _run_show(args: argparse.Namespace, wiki) -> int:  # noqa: ANN001
     return 0
 
 
-def _slugify(name: str) -> str:
-    s = name.strip().casefold().replace(" ", "-")
-    s = _SLUG_STRIP_RE.sub("-", s)
-    return _SLUG_DASH_RE.sub("-", s).strip("-")
-
-
 def _run_new(args: argparse.Namespace, wiki) -> int:  # noqa: ANN001
-    slug = args.slug or _slugify(args.name)
+    slug = args.slug or slugify(args.name)
     if not slug:
         print(f"error: could not derive a slug from {args.name!r}; pass --slug")  # noqa: T201
         return 1

--- a/src/auto_lorebook/commands/reject_ingest.py
+++ b/src/auto_lorebook/commands/reject_ingest.py
@@ -1,0 +1,103 @@
+"""auto-lorebook reject-ingest subcommand.
+
+Removes every fact and alias tagged with the given ingest, deletes any
+entity stub the ingest itself created and that is now empty of facts,
+and clears the pending pipeline artifacts (`plan.yaml` + `proposals/`).
+Leaves `<wiki>/sources/<source_id>/` and `pending/<id>/reading/` alone
+so the user can re-run the pipeline from `approve-reading` or
+`regenerate-reading` if desired.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import ingest_cleanup
+from auto_lorebook.interactive import _is_interactive
+
+if TYPE_CHECKING:
+    import argparse
+
+_logger = logging.getLogger(__name__)
+
+
+def add_parser(
+    subparsers: argparse._SubParsersAction,
+    common_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Register the reject-ingest subcommand."""
+    parser = subparsers.add_parser(
+        "reject-ingest",
+        parents=[common_parser],
+        help="Undo all of one ingest's contributions",
+        description=(
+            "Removes facts and aliases tagged with this ingest from every "
+            "entity YAML, deletes empty stubs the ingest itself created, "
+            "and clears pending plan + proposals. Source files and "
+            "reading-stage artifacts are left untouched."
+        ),
+    )
+    parser.add_argument("source_id", help="Source/ingest ID (e.g. yt-abc12345678)")
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt (required for non-interactive runs).",
+    )
+    parser.set_defaults(func=run)
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the reject-ingest command."""
+    try:
+        cfg = cfg_mod.load_config()
+    except cfg_mod.ConfigError as e:
+        _logger.error("%s", e)
+        return 1
+
+    if not args.yes and not _is_interactive():
+        _logger.error("Refusing to reject-ingest non-interactively without --yes.")
+        return 1
+
+    previewed = ingest_cleanup.preview(cfg, args.source_id)
+    if (
+        previewed.facts_removed == 0
+        and previewed.aliases_removed == 0
+        and previewed.stubs_deleted == 0
+    ):
+        # Still clean pending/ if it exists; otherwise nothing to do.
+        actual = ingest_cleanup.reject_ingest(cfg, args.source_id)
+        print(  # noqa: T201
+            f"Nothing to reject for {args.source_id!r}; "
+            "no facts, aliases, or stubs match."
+        )
+        _ = actual  # pending may have been cleaned; counts already zero
+        return 0
+
+    if not args.yes:
+        prompt = (
+            f"Reject ingest {args.source_id!r}? This removes "
+            f"{previewed.facts_removed} fact(s), "
+            f"{previewed.aliases_removed} alias(es); "
+            f"deletes {previewed.stubs_deleted} stub(s). [y/N] "
+        )
+        try:
+            answer = input(prompt).strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()  # noqa: T201
+            return 130
+        if answer not in {"y", "yes"}:
+            print("Cancelled; no changes made.")  # noqa: T201
+            return 0
+
+    result = ingest_cleanup.reject_ingest(cfg, args.source_id)
+    print(  # noqa: T201
+        f"Rejected ingest {args.source_id!r}: "
+        f"removed {result.facts_removed} facts, "
+        f"{result.aliases_removed} aliases; "
+        f"deleted {result.stubs_deleted} stub(s); "
+        f"modified {result.entities_modified} entit(ies)."
+    )
+    return 0

--- a/src/auto_lorebook/commands/replan.py
+++ b/src/auto_lorebook/commands/replan.py
@@ -1,0 +1,73 @@
+"""auto-lorebook replan subcommand.
+
+Discards unreviewed proposals from the current run and re-runs the
+planner + extractor against the wiki's current entity state. Already-
+approved facts in entity YAMLs are unaffected; stubs created by
+earlier approvals are visible to the new plan because
+`pipeline.extract` rebuilds the in-memory `EntityIndex` from disk.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import reading_pipeline as pipeline
+
+if TYPE_CHECKING:
+    import argparse
+
+_logger = logging.getLogger(__name__)
+
+
+def add_parser(
+    subparsers: argparse._SubParsersAction,
+    common_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Register the replan subcommand."""
+    parser = subparsers.add_parser(
+        "replan",
+        parents=[common_parser],
+        help="Discard unreviewed proposals; re-run planner + extractor",
+        description=(
+            "Discards every unreviewed proposal under "
+            "pending/<source_id>/proposals/, re-invokes the planner "
+            "(which sees any entity stubs created by approvals earlier "
+            "in this ingest), and re-runs the extractor. Already-"
+            "approved facts in entity YAMLs are unaffected."
+        ),
+    )
+    parser.add_argument("source_id", help="Source/ingest ID (e.g. yt-abc12345678)")
+    parser.set_defaults(func=run)
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the replan command."""
+    try:
+        cfg = cfg_mod.load_config()
+    except cfg_mod.ConfigError as e:
+        _logger.error("%s", e)
+        return 1
+
+    try:
+        plan_result = pipeline.plan(cfg, args.source_id)
+    except pipeline.ReadingPipelineError as e:
+        _logger.error("planner failed: %s", e)
+        return 1
+
+    try:
+        extract_result = pipeline.extract(cfg, args.source_id)
+    except pipeline.ReadingPipelineError as e:
+        _logger.error("extractor failed: %s", e)
+        return 1
+
+    n = len(extract_result.proposals)
+    flagged = extract_result.flagged_count
+    print(f"Replanned: {plan_result.plan_path}")  # noqa: T201
+    print(  # noqa: T201
+        f"Extracted {n} proposal(s) ({flagged} flagged) → "
+        f"{extract_result.proposals_dir}"
+    )
+    return 0

--- a/src/auto_lorebook/commands/review.py
+++ b/src/auto_lorebook/commands/review.py
@@ -145,11 +145,11 @@ class InteractiveReviewer:
             if choice in {"r", "reject"}:
                 return RejectDecision()
             if choice in {"e", "edit"}:
-                new_text = input(f"  current: {view.proposal.text}\n  edited: ").strip()
-                if not new_text:
-                    print("  (empty edit; re-prompting)")  # noqa: T201
+                edits = self._gather_edits(view)
+                if edits.is_noop():
+                    print("  (no edits; re-prompting)")  # noqa: T201
                     continue
-                return EditDecision(new_text=new_text)
+                return edits
             if choice in {"p", "play"}:
                 _print_play(view)
                 continue
@@ -170,6 +170,23 @@ class InteractiveReviewer:
             if raw in {"n", "no", ""}:
                 return False
             print("  please answer y or n")  # noqa: T201
+
+    def _gather_edits(self, view: ProposalView) -> EditDecision:
+        """Walk each editable field; blank input keeps the current value."""
+        p = view.proposal
+        print("  Edit (Enter to keep current value):")  # noqa: T201
+        new_text = _prompt_optional("text", p.text)
+        new_speaker = _prompt_optional("speaker", p.speaker)
+        new_status = _prompt_status(p.status)
+        new_status_reason = _prompt_optional("status_reason", p.status_reason or "")
+        new_section = _prompt_optional("section", p.section)
+        return EditDecision(
+            new_text=new_text,
+            new_speaker=new_speaker,
+            new_status=new_status,
+            new_status_reason=new_status_reason,
+            new_section=new_section,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -254,3 +271,37 @@ def _print_play(view: ProposalView) -> None:
         print(f"  → {url}")  # noqa: T201
     else:
         print("  (no source URL for this proposal)")  # noqa: T201
+
+
+# ---------------------------------------------------------------------------
+# Edit prompts
+# ---------------------------------------------------------------------------
+
+
+_VALID_STATUSES = ("authoritative", "trustworthy", "hearsay", "disproven")
+
+
+def _prompt_optional(label: str, current: str) -> str | None:
+    """Prompt with `current` shown as default; blank → None (keep)."""
+    try:
+        raw = input(f"    {label} [{current}]: ")
+    except EOFError:
+        return None
+    raw = raw.strip()
+    return raw or None
+
+
+def _prompt_status(current: str) -> str | None:
+    """Prompt for a valid status; re-prompt on unknown; blank → keep."""
+    options = "/".join(_VALID_STATUSES)
+    while True:
+        try:
+            raw = input(f"    status [{current}] ({options}): ")
+        except EOFError:
+            return None
+        raw = raw.strip()
+        if not raw:
+            return None
+        if raw in _VALID_STATUSES:
+            return raw
+        print(f"    must be one of: {options}")  # noqa: T201

--- a/src/auto_lorebook/commands/review.py
+++ b/src/auto_lorebook/commands/review.py
@@ -1,0 +1,256 @@
+"""auto-lorebook review subcommand.
+
+Walks each `pending/<source_id>/proposals/<proposed_id>.yaml` and
+prompts for `[a]pprove / [e]dit / [r]eject / [p]lay`. On approval (with
+optional alias confirmations) appends a fact to the target entity's
+YAML, atomically creating the stub on first approval for proposed-new
+entities. Resume on Ctrl-C: untouched proposal files remain.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import reading as reading_mod
+from auto_lorebook import review as review_mod
+from auto_lorebook.interactive import _is_interactive
+from auto_lorebook.review import (
+    ApproveDecision,
+    Decision,
+    EditDecision,
+    ProposalView,
+    RejectDecision,
+)
+from auto_lorebook.timestamps import TimestampError, parse_locator_hint
+
+if TYPE_CHECKING:
+    import argparse
+
+_logger = logging.getLogger(__name__)
+
+_SEP = "─" * 68
+
+
+def add_parser(
+    subparsers: argparse._SubParsersAction,
+    common_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Register the review subcommand."""
+    parser = subparsers.add_parser(
+        "review",
+        parents=[common_parser],
+        help="Walk pending proposals; approve/edit/reject each",
+        description=(
+            "Reviews extracted proposals one at a time. On approval the fact "
+            "is appended to the target entity's YAML (creating a new stub "
+            "atomically for proposed-new entities). Ctrl-C leaves remaining "
+            "proposals on disk for the next invocation to resume."
+        ),
+    )
+    parser.add_argument("source_id", help="Source/ingest ID (e.g. yt-abc12345678)")
+    parser.add_argument(
+        "--auto-approve",
+        action="store_true",
+        help=(
+            "Approve every proposal without prompting AND decline every "
+            "alias suggestion. Aliases are suggestions, not pre-approvals — "
+            "this flag does NOT add suggested aliases. Use it for non-"
+            "interactive environments (CI, scripted runs)."
+        ),
+    )
+    parser.set_defaults(func=run)
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the review command."""
+    try:
+        cfg = cfg_mod.load_config()
+    except cfg_mod.ConfigError as e:
+        _logger.error("%s", e)
+        return 1
+
+    if not args.auto_approve and not _is_interactive():
+        _logger.error("Refusing to review non-interactively without --auto-approve.")
+        return 1
+
+    reviewer: review_mod.Reviewer = (
+        AutoApproveReviewer() if args.auto_approve else InteractiveReviewer()
+    )
+
+    try:
+        result = review_mod.run(cfg=cfg, source_id=args.source_id, reviewer=reviewer)
+    except review_mod.ReviewError as e:
+        _logger.error("%s", e)
+        return 1
+    except KeyboardInterrupt:
+        print(  # noqa: T201
+            f"\nInterrupted; resume with: auto-lorebook review {args.source_id}"
+        )
+        return 130
+
+    total = result.approved + result.edited + result.rejected
+    if total == 0 and result.remaining == 0:
+        print(  # noqa: T201
+            f"Nothing to review for {args.source_id!r}; either run "
+            f"`approve-reading` or this ingest is fully reviewed."
+        )
+        return 0
+    print(  # noqa: T201
+        f"Reviewed {total}: approved={result.approved} "
+        f"edited={result.edited} rejected={result.rejected}"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Reviewer implementations
+# ---------------------------------------------------------------------------
+
+
+class AutoApproveReviewer:
+    """Approves everything; declines every alias suggestion."""
+
+    by_label = "auto-approve"
+
+    def decide(self, view: ProposalView) -> Decision:  # noqa: ARG002
+        return ApproveDecision()
+
+    def confirm_alias(self, entity: str, mention: str) -> bool:  # noqa: ARG002
+        return False
+
+
+class InteractiveReviewer:
+    """Renders the spec'd display and prompts for the next action."""
+
+    by_label = "human-review"
+
+    def decide(self, view: ProposalView) -> Decision:
+        _render(view)
+        while True:
+            try:
+                choice = (
+                    input("[a]pprove  [e]dit  [r]eject  [p]lay (open URL)\n> ")
+                    .strip()
+                    .lower()
+                )
+            except EOFError:
+                # No more stdin (non-interactive harness w/o --auto-approve);
+                # treat as reject so we don't loop forever.
+                return RejectDecision()
+            if choice in {"a", "approve"}:
+                return ApproveDecision()
+            if choice in {"r", "reject"}:
+                return RejectDecision()
+            if choice in {"e", "edit"}:
+                new_text = input(f"  current: {view.proposal.text}\n  edited: ").strip()
+                if not new_text:
+                    print("  (empty edit; re-prompting)")  # noqa: T201
+                    continue
+                return EditDecision(new_text=new_text)
+            if choice in {"p", "play"}:
+                _print_play(view)
+                continue
+            print(f"  unknown choice {choice!r}; try a/e/r/p")  # noqa: T201
+
+    def confirm_alias(self, entity: str, mention: str) -> bool:
+        while True:
+            try:
+                raw = (
+                    input(f'  Add "{mention}" as alias for {entity}? [y/n] ')
+                    .strip()
+                    .lower()
+                )
+            except EOFError:
+                return False
+            if raw in {"y", "yes"}:
+                return True
+            if raw in {"n", "no", ""}:
+                return False
+            print("  please answer y or n")  # noqa: T201
+
+
+# ---------------------------------------------------------------------------
+# Display
+# ---------------------------------------------------------------------------
+
+
+def _render(view: ProposalView) -> None:
+    p = view.proposal
+    print(  # noqa: T201
+        f"\n─── Proposal {view.proposal_index} of {view.proposal_total}  ·  "
+        f"Claim group {p.claim_group_id} "
+        f"({view.group_position} of {view.group_size} targets) {_SEP[:8]}"
+    )
+    print(_target_line(view))  # noqa: T201
+    if view.matched_via:
+        print(f"  Matched via: {view.matched_via}")  # noqa: T201
+    if p.extractor_flagged:
+        print(f"  Flagged: {p.flag_reason or 'extractor flagged this proposal'}")  # noqa: T201
+    if p.hint_widened:
+        print("  Hint widened to parent segment")  # noqa: T201
+    print(f"Section: {p.section}")  # noqa: T201
+    print()  # noqa: T201
+    print(f"Proposed text:\n  {p.text!r}")  # noqa: T201
+    print(f"\nRaw transcript:\n  {p.raw_transcript_span!r}")  # noqa: T201
+    if p.corrections_applied:
+        print("\nCorrections applied:")  # noqa: T201
+        for c in p.corrections_applied:
+            print(f'  • "{c.from_}" → "{c.to}"  ({c.source})')  # noqa: T201
+    print()  # noqa: T201
+    print(f"Source: {view.source_title or view.proposal.source_id}")  # noqa: T201
+    print(f"Locator: {p.locator}  → {_play_url(view) or '(no source URL)'}")  # noqa: T201
+    print(f"Speaker: {p.speaker}")  # noqa: T201
+    status_line = f"Status: {p.status}"
+    if p.status_reason:
+        status_line += f"  ({p.status_reason})"
+    print(status_line)  # noqa: T201
+    if p.session_date:
+        print(f"Session date: {p.session_date}")  # noqa: T201
+    if p.context_before or p.context_after:
+        print("\nContext:")  # noqa: T201
+        if p.context_before:
+            print(f"  Before: {p.context_before!r}")  # noqa: T201
+        if p.context_after:
+            print(f"  After:  {p.context_after!r}")  # noqa: T201
+    if p.claim_group_siblings:
+        print("\nAlso routes to:")  # noqa: T201
+        for s in p.claim_group_siblings:
+            print(f"  → {s.entity}  ({s.proposed_id})")  # noqa: T201
+    print()  # noqa: T201
+
+
+def _target_line(view: ProposalView) -> str:
+    if view.is_new_entity:
+        cat = view.new_entity_category or "?"
+        if view.created_earlier_in_session:
+            return (
+                f"Target entity: {view.proposal.target_entity} ({cat})\n"
+                f"  Created earlier in this review session"
+            )
+        return (
+            f"Target entity: {view.proposal.target_entity} "
+            f"(NEW — {cat}, will be created on approval)"
+        )
+    return f"Target entity: {view.proposal.target_entity} (existing)"
+
+
+def _play_url(view: ProposalView) -> str | None:
+    """Return a URL with the start timestamp tacked on, or None."""
+    if not view.source_url:
+        return None
+    try:
+        start_seconds, _ = parse_locator_hint(view.proposal.locator)
+    except TimestampError:
+        return view.source_url
+    return reading_mod.linkify_timestamp(view.source_url, start_seconds)
+
+
+def _print_play(view: ProposalView) -> None:
+    url = _play_url(view)
+    if url:
+        print(f"  → {url}")  # noqa: T201
+    else:
+        print("  (no source URL for this proposal)")  # noqa: T201

--- a/src/auto_lorebook/entity_index.py
+++ b/src/auto_lorebook/entity_index.py
@@ -32,6 +32,20 @@ class EntityIndex:
     def __init__(self, entries: list[EntityEntry]) -> None:
         self._entries = entries
 
+    def lookup(self, name: str) -> EntityEntry | None:
+        """Resolve a canonical entity name (case-insensitive) to its entry.
+
+        Aliases are not consulted — this is canonical-name only. Returns
+        ``None`` when no match is found.
+        """
+        key = name.strip().casefold()
+        if not key:
+            return None
+        for e in self._entries:
+            if e.entity.casefold() == key:
+                return e
+        return None
+
     def render_for_preamble(self) -> str:
         """Render grouped, sorted entity list for preamble inclusion."""
         by_cat: dict[str, list[EntityEntry]] = {}

--- a/src/auto_lorebook/entity_yaml.py
+++ b/src/auto_lorebook/entity_yaml.py
@@ -8,6 +8,7 @@ read→write round-trip.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -88,6 +89,17 @@ class Entity:
 def normalize_alias_name(name: str) -> str:
     """Case-fold + whitespace-trim for dedup and lookup comparisons."""
     return name.strip().casefold()
+
+
+_SLUG_STRIP_RE = re.compile(r"[^a-z0-9-]+")
+_SLUG_DASH_RE = re.compile(r"-+")
+
+
+def slugify(name: str) -> str:
+    """Canonical slug for an entity name. Empty input → empty string."""
+    s = name.strip().casefold().replace(" ", "-")
+    s = _SLUG_STRIP_RE.sub("-", s)
+    return _SLUG_DASH_RE.sub("-", s).strip("-")
 
 
 def _alias_from_dict(data: Any) -> Alias | None:  # noqa: ANN401

--- a/src/auto_lorebook/ingest_cleanup.py
+++ b/src/auto_lorebook/ingest_cleanup.py
@@ -1,0 +1,147 @@
+"""Phase 4 cleanup: undo all of one ingest's contributions.
+
+`reject_ingest(cfg, source_id)` walks every entity YAML in the wiki,
+removes facts whose `created_by_ingest` matches and aliases whose
+`added_by_ingest` matches, deletes entity stubs that the ingest itself
+created and that are now empty of facts, and removes pipeline
+artifacts under `pending/<source_id>/` (plan + proposals).
+
+Decisions:
+
+- Stub deletion criterion is empty-facts AND
+  `entity.created_by_ingest == source_id`. Aliases are ignored — an
+  entity can be referenced via alias from another ingest's fact, and
+  we shouldn't delete a still-referenced stub.
+- `<wiki>/sources/<source_id>/` is left alone. Transcript, info.yaml,
+  and the approved reading.md stay; re-running `approve-reading`
+  overwrites reading.md cleanly.
+- `pending/<source_id>/reading/` (Stage 1a/1b artifacts) is left
+  alone, so a follow-up `replan` or `regenerate-reading` still works.
+- Facts/aliases without an ingest tag (hand-edited) are kept.
+- Each `entity_yaml.write` is atomic; the walk is not. A crash
+  mid-walk leaves a partial cleanup; re-running is idempotent.
+
+`preview` is a read-only dry-run that returns the same `RejectResult`
+counts the actual run would produce, used by the CLI's confirmation
+prompt.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from auto_lorebook import entity_yaml
+from auto_lorebook import reading_pipeline as pipeline_mod
+from auto_lorebook.timestamps import format_iso_now
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from auto_lorebook.config import Config
+    from auto_lorebook.entity_yaml import Entity
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RejectResult:
+    """Counters returned by `preview` and `reject_ingest`."""
+
+    facts_removed: int = 0
+    aliases_removed: int = 0
+    stubs_deleted: int = 0
+    entities_modified: int = 0
+
+
+@dataclass(frozen=True)
+class _Plan:
+    """What `reject_ingest` would do for one entity. Used by both paths."""
+
+    facts_dropped: int
+    aliases_dropped: int
+    delete_stub: bool
+    kept_facts: list[dict]
+    kept_aliases: list[entity_yaml.Alias]
+
+
+def _plan_for(entity: Entity, source_id: str) -> _Plan:
+    kept_facts = [f for f in entity.facts if f.get("created_by_ingest") != source_id]
+    kept_aliases = [a for a in entity.aliases if a.added_by_ingest != source_id]
+    facts_dropped = len(entity.facts) - len(kept_facts)
+    aliases_dropped = len(entity.aliases) - len(kept_aliases)
+    delete_stub = not kept_facts and entity.created_by_ingest == source_id
+    return _Plan(
+        facts_dropped=facts_dropped,
+        aliases_dropped=aliases_dropped,
+        delete_stub=delete_stub,
+        kept_facts=kept_facts,
+        kept_aliases=kept_aliases,
+    )
+
+
+def _walk_entity_paths(wiki_repo: Path) -> list[Path]:
+    paths: list[Path] = []
+    for cat in entity_yaml.CATEGORIES:
+        cat_dir = wiki_repo / cat
+        if not cat_dir.is_dir():
+            continue
+        paths.extend(sorted(cat_dir.glob("*.yaml")))
+    return paths
+
+
+def preview(cfg: Config, source_id: str) -> RejectResult:
+    """Read-only count of what `reject_ingest` would change."""
+    result = RejectResult()
+    for path in _walk_entity_paths(cfg.wiki_repo_path):
+        try:
+            entity = entity_yaml.read(path)
+        except entity_yaml.EntityError:
+            continue
+        plan = _plan_for(entity, source_id)
+        result.facts_removed += plan.facts_dropped
+        result.aliases_removed += plan.aliases_dropped
+        if plan.delete_stub:
+            result.stubs_deleted += 1
+        elif plan.facts_dropped or plan.aliases_dropped:
+            result.entities_modified += 1
+    return result
+
+
+def reject_ingest(cfg: Config, source_id: str) -> RejectResult:
+    """Remove `source_id`'s contributions from every entity; clean pending."""
+    result = RejectResult()
+    for path in _walk_entity_paths(cfg.wiki_repo_path):
+        try:
+            entity = entity_yaml.read(path)
+        except entity_yaml.EntityError:
+            _logger.warning("reject_ingest: could not parse %s; skipping", path)
+            continue
+        plan = _plan_for(entity, source_id)
+        if plan.delete_stub:
+            path.unlink()
+            result.stubs_deleted += 1
+            result.facts_removed += plan.facts_dropped
+            result.aliases_removed += plan.aliases_dropped
+            continue
+        if not plan.facts_dropped and not plan.aliases_dropped:
+            continue
+        entity.facts = plan.kept_facts
+        entity.aliases = plan.kept_aliases
+        entity.updated_at = format_iso_now()
+        entity_yaml.write(entity, path)
+        result.entities_modified += 1
+        result.facts_removed += plan.facts_dropped
+        result.aliases_removed += plan.aliases_dropped
+
+    # Pipeline artifacts: drop plan.yaml + proposals/. Leave reading/
+    # alone so replan / regenerate-reading still work after a partial
+    # reset.
+    plan_path = pipeline_mod.pending_plan_path(source_id)
+    plan_path.unlink(missing_ok=True)
+    proposals_dir = pipeline_mod.pending_proposals_dir(source_id)
+    if proposals_dir.exists():
+        shutil.rmtree(proposals_dir)
+    return result

--- a/src/auto_lorebook/proposal_yaml.py
+++ b/src/auto_lorebook/proposal_yaml.py
@@ -1,0 +1,260 @@
+"""Stage 3 `proposals/<proposal_id>.yaml`: schema, read/write.
+
+Mirrors `plan_yaml.py` shape. Each proposal is one file under
+``pending/<source_id>/proposals/`` representing a single fact's worth of
+located transcript span, awaiting human review.
+
+For ``proposal_type == "new_entity_with_facts"`` the ``target_entity``
+field carries the *proposed* (not-yet-canonical) name from the plan;
+the entity stub is created atomically on first approval (Phase 4 review
+loop, future PR).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from auto_lorebook._io import atomic_write_text
+from auto_lorebook.schema import SchemaVersionError, read_schema_version
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_MAX_SCHEMA = 1
+
+PROPOSAL_TYPES = frozenset({"new_fact", "new_entity_with_facts"})
+CORRECTION_SOURCES = frozenset({
+    "global-transcription-correction",
+    "reading-name-correction",
+})
+
+
+class ProposalError(ValueError):
+    """proposal yaml is missing or malformed on read."""
+
+
+@dataclass(frozen=True)
+class Correction:
+    """One correction applied between raw transcript span and clean text."""
+
+    from_: str  # YAML key is `from`; renamed to avoid Python keyword
+    to: str
+    source: str  # ∈ CORRECTION_SOURCES
+
+
+@dataclass(frozen=True)
+class Sibling:
+    """One sibling entry in `claim_group_siblings`."""
+
+    entity: str
+    proposed_id: str
+
+
+@dataclass(frozen=True)
+class Proposal:
+    """One proposed fact awaiting human review."""
+
+    proposal_type: str  # ∈ PROPOSAL_TYPES
+    target_entity: str
+    proposed_id: str
+    claim_group_id: str
+    text: str
+    raw_transcript_span: str
+    text_corrects_transcript: bool
+    source_id: str
+    locator: str
+    speaker: str
+    reading_section: str
+    reading_bullet_index: int
+    status: str
+    session_date: str
+    section: str
+    context_before: str
+    context_after: str
+    claim_group_siblings: list[Sibling] = field(default_factory=list)
+    corrections_applied: list[Correction] = field(default_factory=list)
+    status_reason: str | None = None
+    hint_widened: bool = False
+    extractor_flagged: bool = False
+    flag_reason: str | None = None
+
+
+# ------------- to_dict ----------------------------------------------------
+
+
+def _correction_to_dict(c: Correction) -> dict[str, Any]:
+    return {"from": c.from_, "to": c.to, "source": c.source}
+
+
+def _sibling_to_dict(s: Sibling) -> dict[str, Any]:
+    return {"entity": s.entity, "proposed_id": s.proposed_id}
+
+
+def _to_dict(p: Proposal) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "schema_version": _MAX_SCHEMA,
+        "proposal_type": p.proposal_type,
+        "target_entity": p.target_entity,
+        "proposed_id": p.proposed_id,
+        "claim_group_id": p.claim_group_id,
+        "claim_group_siblings": [_sibling_to_dict(s) for s in p.claim_group_siblings],
+        "text": p.text,
+        "raw_transcript_span": p.raw_transcript_span,
+        "text_corrects_transcript": p.text_corrects_transcript,
+        "corrections_applied": [_correction_to_dict(c) for c in p.corrections_applied],
+        "source_id": p.source_id,
+        "locator": p.locator,
+        "speaker": p.speaker,
+        "status": p.status,
+    }
+    if p.status_reason is not None:
+        out["status_reason"] = p.status_reason
+    out.update({
+        "session_date": p.session_date,
+        "section": p.section,
+        "reading_section": p.reading_section,
+        "reading_bullet_index": p.reading_bullet_index,
+        "context_before": p.context_before,
+        "context_after": p.context_after,
+    })
+    if p.hint_widened:
+        out["hint_widened"] = True
+    if p.extractor_flagged:
+        out["extractor_flagged"] = True
+    if p.flag_reason is not None:
+        out["flag_reason"] = p.flag_reason
+    return out
+
+
+# ------------- parse_* ----------------------------------------------------
+
+
+def parse_correction(raw: dict[str, Any]) -> Correction:
+    if not isinstance(raw, dict):
+        msg = f"corrections_applied: expected mapping, got {type(raw).__name__}"
+        raise ProposalError(msg)
+    from_val = raw.get("from")
+    to_val = raw.get("to")
+    source_val = raw.get("source")
+    if not isinstance(from_val, str) or not from_val:
+        msg = "corrections_applied: missing 'from'"
+        raise ProposalError(msg)
+    if not isinstance(to_val, str) or not to_val:
+        msg = "corrections_applied: missing 'to'"
+        raise ProposalError(msg)
+    if not isinstance(source_val, str) or source_val not in CORRECTION_SOURCES:
+        msg = (
+            f"corrections_applied: source must be one of "
+            f"{sorted(CORRECTION_SOURCES)}, got {source_val!r}"
+        )
+        raise ProposalError(msg)
+    return Correction(from_=from_val, to=to_val, source=source_val)
+
+
+def parse_sibling(raw: dict[str, Any]) -> Sibling:
+    if not isinstance(raw, dict):
+        msg = f"claim_group_siblings: expected mapping, got {type(raw).__name__}"
+        raise ProposalError(msg)
+    entity = str(raw.get("entity") or "").strip()
+    proposed_id = str(raw.get("proposed_id") or "").strip()
+    if not entity:
+        msg = "claim_group_siblings: empty entity"
+        raise ProposalError(msg)
+    if not proposed_id:
+        msg = "claim_group_siblings: empty proposed_id"
+        raise ProposalError(msg)
+    return Sibling(entity=entity, proposed_id=proposed_id)
+
+
+def _required_str(raw: dict[str, Any], key: str) -> str:
+    val = raw.get(key)
+    if not isinstance(val, str) or not val:
+        msg = f"missing required string field {key!r}"
+        raise ProposalError(msg)
+    return val
+
+
+def parse_proposal(raw: dict[str, Any]) -> Proposal:
+    if not isinstance(raw, dict):
+        msg = f"proposal: expected mapping, got {type(raw).__name__}"
+        raise ProposalError(msg)
+    proposal_type = _required_str(raw, "proposal_type")
+    if proposal_type not in PROPOSAL_TYPES:
+        msg = (
+            f"proposal_type must be one of {sorted(PROPOSAL_TYPES)}, "
+            f"got {proposal_type!r}"
+        )
+        raise ProposalError(msg)
+    bullet_idx = raw.get("reading_bullet_index")
+    if not isinstance(bullet_idx, int) or bullet_idx < 0:
+        msg = f"reading_bullet_index must be non-negative int, got {bullet_idx!r}"
+        raise ProposalError(msg)
+    return Proposal(
+        proposal_type=proposal_type,
+        target_entity=_required_str(raw, "target_entity"),
+        proposed_id=_required_str(raw, "proposed_id"),
+        claim_group_id=_required_str(raw, "claim_group_id"),
+        claim_group_siblings=[
+            parse_sibling(s) for s in (raw.get("claim_group_siblings") or [])
+        ],
+        text=str(raw.get("text") or ""),
+        raw_transcript_span=str(raw.get("raw_transcript_span") or ""),
+        text_corrects_transcript=bool(raw.get("text_corrects_transcript")),
+        corrections_applied=[
+            parse_correction(c) for c in (raw.get("corrections_applied") or [])
+        ],
+        source_id=_required_str(raw, "source_id"),
+        locator=_required_str(raw, "locator"),
+        speaker=str(raw.get("speaker") or ""),
+        reading_section=str(raw.get("reading_section") or ""),
+        reading_bullet_index=bullet_idx,
+        status=str(raw.get("status") or ""),
+        status_reason=(raw.get("status_reason") or None),
+        session_date=str(raw.get("session_date") or ""),
+        section=str(raw.get("section") or ""),
+        context_before=str(raw.get("context_before") or ""),
+        context_after=str(raw.get("context_after") or ""),
+        hint_widened=bool(raw.get("hint_widened")),
+        extractor_flagged=bool(raw.get("extractor_flagged")),
+        flag_reason=(raw.get("flag_reason") or None),
+    )
+
+
+# ------------- read / write ----------------------------------------------
+
+
+def read(path: Path) -> Proposal:
+    """Read and parse a proposal yaml.
+
+    :raises ProposalError: missing / malformed / unsupported schema
+    """
+    if not path.exists():
+        msg = f"{path}: file not found"
+        raise ProposalError(msg)
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        msg = f"{path}: expected a YAML mapping"
+        raise ProposalError(msg)
+    try:
+        read_schema_version(raw, str(path), max_supported=_MAX_SCHEMA)
+    except SchemaVersionError as e:
+        raise ProposalError(str(e)) from e
+    try:
+        return parse_proposal(raw)
+    except ProposalError as e:
+        msg = f"{path}: {e}"
+        raise ProposalError(msg) from e
+
+
+def write(proposal: Proposal, path: Path) -> None:
+    """Atomically write a proposal yaml."""
+    text = yaml.safe_dump(
+        _to_dict(proposal),
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    )
+    atomic_write_text(path, text)

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -8,6 +8,7 @@ this module handles the wiring between stages.
 from __future__ import annotations
 
 import logging
+import shutil
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -18,14 +19,17 @@ from auto_lorebook import (
 from auto_lorebook import (
     entity_index as entity_index_mod,
 )
+from auto_lorebook import entity_yaml as entity_yaml_mod
 from auto_lorebook import gap_check as gap_check_mod
 from auto_lorebook import info_yaml as info_yaml_mod
 from auto_lorebook import plan_yaml as plan_yaml_mod
 from auto_lorebook import preamble as preamble_mod
+from auto_lorebook import proposal_yaml as proposal_yaml_mod
 from auto_lorebook import reading as reading_mod
 from auto_lorebook import stage1a as stage1a_mod
 from auto_lorebook import stage1b as stage1b_mod
 from auto_lorebook import stage2 as stage2_mod
+from auto_lorebook import stage3 as stage3_mod
 from auto_lorebook import structure as structure_mod
 from auto_lorebook import transcript as transcript_mod
 from auto_lorebook import wiki_context as wiki_context_mod
@@ -37,6 +41,7 @@ if TYPE_CHECKING:
     from auto_lorebook.gap_check import GapWarning
     from auto_lorebook.info_yaml import Info
     from auto_lorebook.plan_yaml import Plan
+    from auto_lorebook.proposal_yaml import Proposal
 
 _logger = logging.getLogger(__name__)
 
@@ -61,6 +66,15 @@ class PlanResult:
 
     plan_path: Path
     plan: Plan
+
+
+@dataclass
+class ExtractResult:
+    """Proposals written by a Stage 3 run."""
+
+    proposals_dir: Path
+    proposals: list[Proposal]
+    flagged_count: int
 
 
 def generate(cfg: cfg_mod.Config, source_id: str) -> GenerateResult:
@@ -122,6 +136,15 @@ def pending_bullets_path(source_id: str) -> Path:
 def pending_plan_path(source_id: str) -> Path:
     """Plan artifact path. Sibling to the `reading/` subdir."""
     return cfg_mod.config_dir() / "pending" / source_id / "plan.yaml"
+
+
+def pending_proposals_dir(source_id: str) -> Path:
+    """Stage 3 proposal directory. Sibling to `plan.yaml`."""
+    return cfg_mod.config_dir() / "pending" / source_id / "proposals"
+
+
+def pending_proposal_path(source_id: str, proposal_id: str) -> Path:
+    return pending_proposals_dir(source_id) / f"{proposal_id}.yaml"
 
 
 def plan(cfg: cfg_mod.Config, source_id: str) -> PlanResult:
@@ -204,6 +227,127 @@ def plan(cfg: cfg_mod.Config, source_id: str) -> PlanResult:
     plan_path = pending_plan_path(source_id)
     plan_yaml_mod.write(result_plan, plan_path)
     return PlanResult(plan_path=plan_path, plan=result_plan)
+
+
+def extract(cfg: cfg_mod.Config, source_id: str) -> ExtractResult:
+    """Run Stage 3 against an existing plan and write proposal yamls.
+
+    :raises ReadingPipelineError: missing plan, plain-text source, or
+        Stage 3 failure (bad LLM output, schema violation).
+    """
+    wiki_repo = cfg.wiki_repo_path
+    plan_path = pending_plan_path(source_id)
+    if not plan_path.exists():
+        msg = f"No plan at {plan_path}. Run `approve-reading {source_id}` first."
+        raise ReadingPipelineError(msg)
+    try:
+        plan_obj = plan_yaml_mod.read(plan_path)
+    except plan_yaml_mod.PlanError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    structure_path = pending_structure_path(source_id)
+    if not structure_path.exists():
+        msg = (
+            f"No structure.yaml for {source_id!r}; run `regenerate-reading` "
+            "to repopulate."
+        )
+        raise ReadingPipelineError(msg)
+    try:
+        structure = structure_mod.read(structure_path)
+    except structure_mod.StructureError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    info_path = wiki_repo / "sources" / source_id / "info.yaml"
+    try:
+        info = info_yaml_mod.read(info_path)
+    except info_yaml_mod.InfoError as e:
+        raise ReadingPipelineError(str(e)) from e
+    cors = corrections_mod.read(wiki_repo / ".transcription-corrections.yaml")
+    wc = wiki_context_mod.read(wiki_repo / ".wiki-context.yaml")
+    idx = entity_index_mod.build(wiki_repo)
+    try:
+        loaded = transcript_mod.load(wiki_repo, info, cors)
+    except transcript_mod.TranscriptError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    p = preamble_mod.assemble(info, wc, cors, idx, reduced=True)
+    try:
+        p.check_budget(
+            context_window=cfg.models.primary_context_window,
+            budget_fraction=cfg.preamble.budget_fraction,
+        )
+    except preamble_mod.PreambleTooLargeError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    existing_fact_counts, existing_slugs = _collect_existing_target_metadata(
+        wiki_repo, plan_obj, idx
+    )
+
+    client = _build_client(cfg)
+    model = cfg.models.extractor or cfg.models.primary
+
+    try:
+        proposals = stage3_mod.run(
+            plan=plan_obj,
+            transcript=loaded,
+            structure=structure,
+            info=info,
+            preamble_text=p.text,
+            source_id=source_id,
+            client=client,
+            model=model,
+            existing_fact_counts=existing_fact_counts,
+            existing_slugs=existing_slugs,
+        )
+    except stage3_mod.Stage3Error as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    proposals_dir = pending_proposals_dir(source_id)
+    # Wipe + recreate: approved facts already live in entity YAMLs, so
+    # the proposals dir holds only un-reviewed work — wiping loses
+    # nothing authoritative. Review-loop PR will own per-proposal lifecycle.
+    if proposals_dir.exists():
+        shutil.rmtree(proposals_dir)
+    proposals_dir.mkdir(parents=True, exist_ok=True)
+    for proposal in proposals:
+        proposal_yaml_mod.write(
+            proposal, pending_proposal_path(source_id, proposal.proposed_id)
+        )
+    flagged = sum(1 for p in proposals if p.extractor_flagged)
+    return ExtractResult(
+        proposals_dir=proposals_dir,
+        proposals=proposals,
+        flagged_count=flagged,
+    )
+
+
+def _collect_existing_target_metadata(
+    wiki_repo: Path,
+    plan_obj: Plan,
+    idx: entity_index_mod.EntityIndex,
+) -> tuple[dict[str, int], dict[str, str]]:
+    """Per-target fact counts and slugs for entities resolving to disk."""
+    fact_counts: dict[str, int] = {}
+    slugs: dict[str, str] = {}
+    for claim in plan_obj.planned_claims:
+        for target in claim.targets:
+            if target.entity in fact_counts:
+                continue
+            if target.entity_state == "new":
+                continue
+            entry = idx.lookup(target.entity)
+            if entry is None:
+                # planner said "existing" but we can't resolve — treat as new
+                # so allocation still works deterministically
+                continue
+            entity_path = wiki_repo / entry.category / f"{entry.slug}.yaml"
+            try:
+                entity = entity_yaml_mod.read(entity_path)
+            except entity_yaml_mod.EntityError:
+                continue
+            fact_counts[target.entity] = len(entity.facts)
+            slugs[target.entity] = entity.slug
+    return fact_counts, slugs
 
 
 def _run_full(cfg: cfg_mod.Config, source_id: str) -> GenerateResult:

--- a/src/auto_lorebook/review.py
+++ b/src/auto_lorebook/review.py
@@ -54,9 +54,33 @@ class ApproveDecision:
 
 @dataclass(frozen=True)
 class EditDecision:
-    """Approve with edited text. `text_source` will retain the original."""
+    """Approve with one or more field overrides.
 
-    new_text: str
+    Fields default to ``None`` meaning "keep the original value". A
+    non-None ``new_text`` triggers ``edited_by_human=True`` and stashes
+    the original in ``text_source``; the other overrides change the
+    fact value silently (status changes are reflected in
+    ``status_history``).
+    """
+
+    new_text: str | None = None
+    new_speaker: str | None = None
+    new_status: str | None = None
+    new_status_reason: str | None = None
+    new_section: str | None = None
+
+    def is_noop(self) -> bool:
+        """Return True when no field override is set."""
+        return all(
+            v is None
+            for v in (
+                self.new_text,
+                self.new_speaker,
+                self.new_status,
+                self.new_status_reason,
+                self.new_section,
+            )
+        )
 
 
 @dataclass(frozen=True)
@@ -180,17 +204,29 @@ def _category_for_new(plan: Plan, target_entity: str) -> str | None:
 def proposal_to_fact_dict(
     proposal: Proposal,
     *,
-    edited_text: str | None,
+    edits: EditDecision | None,
     ingest_id: str,
     by_label: str,
 ) -> dict[str, Any]:
     """Build the dict appended to `entity.facts`.
 
-    `edited_text=None` means approve as-is. Non-None means human edited.
+    ``edits=None`` means approve as-is. A non-None ``edits.new_text``
+    triggers ``edited_by_human=True`` + ``text_source``; speaker /
+    status / status_reason / section overrides change the recorded
+    value (and ``status_history`` reflects the *final* status).
     """
     now = format_iso_now()
-    text = edited_text if edited_text is not None else proposal.text
+    edited_text = edits.new_text if edits else None
     edited_by_human = edited_text is not None
+    text = edited_text if edited_text is not None else proposal.text
+    speaker = edits.new_speaker if edits and edits.new_speaker else proposal.speaker
+    status = edits.new_status if edits and edits.new_status else proposal.status
+    status_reason = (
+        edits.new_status_reason
+        if edits and edits.new_status_reason is not None
+        else proposal.status_reason
+    )
+    section = edits.new_section if edits and edits.new_section else proposal.section
     return {
         "id": proposal.proposed_id,
         "text": text,
@@ -206,22 +242,22 @@ def proposal_to_fact_dict(
         "text_source": proposal.text if edited_by_human else None,
         "source_id": proposal.source_id,
         "locator": proposal.locator,
-        "speaker": proposal.speaker,
-        "status": proposal.status,
-        "status_reason": proposal.status_reason,
+        "speaker": speaker,
+        "status": status,
+        "status_reason": status_reason,
         "status_history": [
             {
-                "status": proposal.status,
+                "status": status,
                 "at": now,
                 "by": by_label,
-                "reason": proposal.status_reason,
+                "reason": status_reason,
             },
         ],
         "session_date": proposal.session_date,
         "approved_at": now,
         "created_by_ingest": ingest_id,
         "claim_group_id": proposal.claim_group_id,
-        "section": proposal.section,
+        "section": section,
     }
 
 
@@ -277,7 +313,7 @@ def _approve(
     proposal: Proposal,
     proposal_path: Path,
     *,
-    edited_text: str | None,
+    edits: EditDecision | None,
     confirmed_aliases: list[str],
     by_label: str,
 ) -> bool:
@@ -286,7 +322,7 @@ def _approve(
     now = format_iso_now()
     fact = proposal_to_fact_dict(
         proposal,
-        edited_text=edited_text,
+        edits=edits,
         ingest_id=ctx.source_id,
         by_label=by_label,
     )
@@ -472,7 +508,7 @@ def run(
             except KeyboardInterrupt:
                 result.remaining = total - (i - 1)
                 raise
-        edited_text = decision.new_text if isinstance(decision, EditDecision) else None
+        edits = decision if isinstance(decision, EditDecision) else None
         proposal_path = reading_pipeline.pending_proposal_path(
             source_id, proposal.proposed_id
         )
@@ -480,7 +516,7 @@ def run(
             ctx,
             proposal,
             proposal_path,
-            edited_text=edited_text,
+            edits=edits,
             confirmed_aliases=confirmed,
             by_label=reviewer.by_label,
         )

--- a/src/auto_lorebook/review.py
+++ b/src/auto_lorebook/review.py
@@ -1,0 +1,492 @@
+"""Stage 4 (review) engine: walk proposals, mutate entity YAMLs.
+
+Pure-logic module. No `input()` calls. Display + prompt I/O lives in
+`commands/review.py` and is injected via the `Reviewer` protocol. Tests
+script a `Reviewer` to drive the engine deterministically.
+
+Walk order is authoritative from the plan: we iterate
+`plan.planned_claims` then `claim.targets`, looking up each
+`(claim_group_id, target_entity)` against the on-disk proposal files.
+This preserves the spec's "siblings shown contiguously, transcript
+order across groups" no matter how proposed_id slugs sort
+lexicographically.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import (
+    entity_index as entity_index_mod,
+)
+from auto_lorebook import entity_yaml as entity_yaml_mod
+from auto_lorebook import info_yaml as info_yaml_mod
+from auto_lorebook import plan_yaml as plan_yaml_mod
+from auto_lorebook import proposal_yaml as proposal_yaml_mod
+from auto_lorebook import reading_pipeline
+from auto_lorebook.entity_yaml import Alias, Entity, normalize_alias_name
+from auto_lorebook.timestamps import format_iso_now
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from auto_lorebook.info_yaml import Info
+    from auto_lorebook.plan_yaml import Plan
+    from auto_lorebook.proposal_yaml import Proposal
+
+_logger = logging.getLogger(__name__)
+
+
+class ReviewError(RuntimeError):
+    """Raised for unrecoverable engine failures."""
+
+
+# ------------- decisions / reviewer protocol -----------------------------
+
+
+@dataclass(frozen=True)
+class ApproveDecision:
+    """Approve as-is."""
+
+
+@dataclass(frozen=True)
+class EditDecision:
+    """Approve with edited text. `text_source` will retain the original."""
+
+    new_text: str
+
+
+@dataclass(frozen=True)
+class RejectDecision:
+    """Discard the proposal."""
+
+
+Decision = ApproveDecision | EditDecision | RejectDecision
+
+
+@dataclass(frozen=True)
+class ProposalView:
+    """All display-relevant data for one proposal."""
+
+    proposal: Proposal
+    proposal_index: int  # 1-of-N across this run
+    proposal_total: int
+    group_position: int  # 1-of-K within claim group
+    group_size: int
+    is_new_entity: bool
+    new_entity_category: str | None
+    created_earlier_in_session: bool
+    suggested_aliases: tuple[str, ...]
+    matched_via: str | None
+    source_url: str | None
+    source_title: str | None
+
+
+class Reviewer(Protocol):
+    """Decision-maker injected into `run`. Tests script this directly."""
+
+    @property
+    def by_label(self) -> str:
+        """Recorded as `status_history[].by` on approved facts."""
+        ...
+
+    def decide(self, view: ProposalView) -> Decision: ...
+
+    def confirm_alias(self, entity: str, mention: str) -> bool: ...
+
+
+@dataclass
+class ReviewResult:
+    approved: int = 0
+    edited: int = 0
+    rejected: int = 0
+    remaining: int = 0  # > 0 only after KeyboardInterrupt
+
+
+# ------------- ordering / lookup helpers ---------------------------------
+
+
+def sorted_proposals(plan: Plan, source_id: str) -> list[Proposal]:
+    """Walk plan in order; yield proposals still on disk."""
+    proposals_dir = reading_pipeline.pending_proposals_dir(source_id)
+    if not proposals_dir.is_dir():
+        return []
+    by_key: dict[tuple[str, str], Proposal] = {}
+    for path in sorted(proposals_dir.glob("*.yaml")):
+        try:
+            p = proposal_yaml_mod.read(path)
+        except proposal_yaml_mod.ProposalError:
+            _logger.warning("review: could not parse %s; skipping", path)
+            continue
+        by_key[p.claim_group_id, p.target_entity] = p
+
+    out: list[Proposal] = []
+    for claim in plan.planned_claims:
+        for target in claim.targets:
+            key = (claim.claim_group_id, target.entity)
+            p = by_key.pop(key, None)
+            if p is not None:
+                out.append(p)
+    # Any proposal whose plan-key didn't match (orphan) gets appended
+    # deterministically by file order so we never silently drop work.
+    out.extend(by_key[key] for key in sorted(by_key))
+    return out
+
+
+def _suggested_aliases_for(plan: Plan, proposal: Proposal) -> tuple[str, ...]:
+    """Union of planner-suggested aliases for this proposal's target entity."""
+    seen: dict[str, None] = {}  # ordered set
+    if proposal.proposal_type == "new_entity_with_facts":
+        for n in plan.new_entities:
+            if n.name == proposal.target_entity:
+                for alias in n.aliases_suggested:
+                    seen[alias] = None
+    for r in plan.entity_resolutions:
+        if proposal.target_entity in {r.matched_entity, r.proposed_entity_name}:
+            for alias in r.suggested_aliases_to_add:
+                seen[alias] = None
+    return tuple(seen.keys())
+
+
+def _matched_via_for(plan: Plan, proposal: Proposal) -> str | None:
+    """Join `mention` strings from existing-entity resolutions; None if no match."""
+    if proposal.proposal_type != "new_fact":
+        return None
+    mentions = [
+        r.mention
+        for r in plan.entity_resolutions
+        if r.resolution == "existing"
+        and r.matched_entity == proposal.target_entity
+        and r.mention
+    ]
+    if not mentions:
+        return None
+    return " / ".join(f'"{m}"' for m in mentions)
+
+
+def _category_for_new(plan: Plan, target_entity: str) -> str | None:
+    for n in plan.new_entities:
+        if n.name == target_entity:
+            return n.category
+    return None
+
+
+# ------------- fact dict builder -----------------------------------------
+
+
+def proposal_to_fact_dict(
+    proposal: Proposal,
+    *,
+    edited_text: str | None,
+    ingest_id: str,
+    by_label: str,
+) -> dict[str, Any]:
+    """Build the dict appended to `entity.facts`.
+
+    `edited_text=None` means approve as-is. Non-None means human edited.
+    """
+    now = format_iso_now()
+    text = edited_text if edited_text is not None else proposal.text
+    edited_by_human = edited_text is not None
+    return {
+        "id": proposal.proposed_id,
+        "text": text,
+        "raw_transcript_span": proposal.raw_transcript_span,
+        "text_corrects_transcript": proposal.text_corrects_transcript
+        or edited_by_human,
+        "corrections_applied": [
+            {"from": c.from_, "to": c.to, "source": c.source}
+            for c in proposal.corrections_applied
+        ],
+        "edited_by_human": edited_by_human,
+        "edited_at": now if edited_by_human else None,
+        "text_source": proposal.text if edited_by_human else None,
+        "source_id": proposal.source_id,
+        "locator": proposal.locator,
+        "speaker": proposal.speaker,
+        "status": proposal.status,
+        "status_reason": proposal.status_reason,
+        "status_history": [
+            {
+                "status": proposal.status,
+                "at": now,
+                "by": by_label,
+                "reason": proposal.status_reason,
+            },
+        ],
+        "session_date": proposal.session_date,
+        "approved_at": now,
+        "created_by_ingest": ingest_id,
+        "claim_group_id": proposal.claim_group_id,
+        "section": proposal.section,
+    }
+
+
+# ------------- approval mechanics ----------------------------------------
+
+
+@dataclass
+class _ApprovalContext:
+    """Mutable state shared across the loop."""
+
+    cfg: cfg_mod.Config
+    source_id: str
+    info: Info
+    plan: Plan
+    index: entity_index_mod.EntityIndex
+    merged_aliases: set[tuple[str, str]] = field(default_factory=set)
+
+
+def _resolve_entity_path(
+    ctx: _ApprovalContext, proposal: Proposal
+) -> tuple[Path, str, str]:
+    """Return (path, slug, category) for the proposal's target entity.
+
+    The slug must agree with the slug Stage 3 used when generating
+    `proposed_id`. Both go through `entity_yaml.slugify`, so they can't
+    drift in practice — guarded by the integration test.
+    """
+    if proposal.proposal_type == "new_entity_with_facts":
+        category = _category_for_new(ctx.plan, proposal.target_entity)
+        if category is None:
+            msg = (
+                f"proposal {proposal.proposed_id}: target {proposal.target_entity!r} "
+                f"is new but missing from plan.new_entities"
+            )
+            raise ReviewError(msg)
+        slug = entity_yaml_mod.slugify(proposal.target_entity)
+        path = ctx.cfg.wiki_repo_path / category / f"{slug}.yaml"
+        return path, slug, category
+
+    entry = ctx.index.lookup(proposal.target_entity)
+    if entry is None:
+        msg = (
+            f"proposal {proposal.proposed_id}: target {proposal.target_entity!r} "
+            f"is marked existing but not found in entity index"
+        )
+        raise ReviewError(msg)
+    path = ctx.cfg.wiki_repo_path / entry.category / f"{entry.slug}.yaml"
+    return path, entry.slug, entry.category
+
+
+def _approve(
+    ctx: _ApprovalContext,
+    proposal: Proposal,
+    proposal_path: Path,
+    *,
+    edited_text: str | None,
+    confirmed_aliases: list[str],
+    by_label: str,
+) -> bool:
+    """Return True if a fact was appended (False if idempotent skip)."""
+    path, slug, category = _resolve_entity_path(ctx, proposal)
+    now = format_iso_now()
+    fact = proposal_to_fact_dict(
+        proposal,
+        edited_text=edited_text,
+        ingest_id=ctx.source_id,
+        by_label=by_label,
+    )
+
+    if path.exists():
+        entity = entity_yaml_mod.read(path)
+        # idempotent guard: same proposed_id already approved
+        if any(f.get("id") == proposal.proposed_id for f in entity.facts):
+            _logger.info(
+                "review: fact %s already in %s; skipping append",
+                proposal.proposed_id,
+                path,
+            )
+            proposal_path.unlink(missing_ok=True)
+            return False
+        for alias in confirmed_aliases:
+            entity.aliases.append(
+                Alias(
+                    name=alias,
+                    added_by_ingest=ctx.source_id,
+                    added_at=now,
+                    source="alias-confirmation",
+                ),
+            )
+        entity.facts.append(fact)
+        entity.updated_at = now
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        entity = Entity(
+            entity=proposal.target_entity,
+            category=category,
+            slug=slug,
+            aliases=[
+                Alias(
+                    name=alias,
+                    added_by_ingest=ctx.source_id,
+                    added_at=now,
+                    source="stub-creation",
+                )
+                for alias in confirmed_aliases
+            ],
+            created_at=now,
+            created_by_ingest=ctx.source_id,
+            updated_at=now,
+            facts=[fact],
+        )
+    entity_yaml_mod.write(entity, path)
+    proposal_path.unlink(missing_ok=True)
+    # refresh in-memory index so siblings later in the loop see this entity
+    ctx.index = entity_index_mod.build(ctx.cfg.wiki_repo_path)
+    # record merged aliases so sibling prompts skip them
+    target_key = proposal.target_entity.casefold()
+    for alias in confirmed_aliases:
+        ctx.merged_aliases.add((target_key, normalize_alias_name(alias)))
+    return True
+
+
+def _reject(proposal_path: Path) -> None:
+    proposal_path.unlink(missing_ok=True)
+
+
+# ------------- main loop -------------------------------------------------
+
+
+def _build_view(
+    ctx: _ApprovalContext,
+    proposal: Proposal,
+    *,
+    proposal_index: int,
+    proposal_total: int,
+    group_position: int,
+    group_size: int,
+) -> ProposalView:
+    is_new = proposal.proposal_type == "new_entity_with_facts"
+    category = _category_for_new(ctx.plan, proposal.target_entity) if is_new else None
+    suggested = _suggested_aliases_for(ctx.plan, proposal)
+    target_key = proposal.target_entity.casefold()
+    suggested = tuple(
+        a
+        for a in suggested
+        if (target_key, normalize_alias_name(a)) not in ctx.merged_aliases
+    )
+    matched_via = _matched_via_for(ctx.plan, proposal)
+    # "created earlier in session": entity exists on disk and was created
+    # by this same ingest run.
+    created_earlier = False
+    if is_new:
+        existing_entry = ctx.index.lookup(proposal.target_entity)
+        if existing_entry is not None:
+            entity_path = (
+                ctx.cfg.wiki_repo_path
+                / existing_entry.category
+                / f"{existing_entry.slug}.yaml"
+            )
+            try:
+                existing = entity_yaml_mod.read(entity_path)
+                if existing.created_by_ingest == ctx.source_id:
+                    created_earlier = True
+            except entity_yaml_mod.EntityError:
+                pass
+    return ProposalView(
+        proposal=proposal,
+        proposal_index=proposal_index,
+        proposal_total=proposal_total,
+        group_position=group_position,
+        group_size=group_size,
+        is_new_entity=is_new,
+        new_entity_category=category,
+        created_earlier_in_session=created_earlier,
+        suggested_aliases=suggested,
+        matched_via=matched_via,
+        source_url=ctx.info.source_url,
+        source_title=ctx.info.title,
+    )
+
+
+def run(
+    *,
+    cfg: cfg_mod.Config,
+    source_id: str,
+    reviewer: Reviewer,
+) -> ReviewResult:
+    """Walk pending proposals; mutate entity YAMLs; return counts.
+
+    KeyboardInterrupt from `reviewer.decide` propagates after marking
+    the not-yet-decided proposals as `remaining`.
+    """
+    wiki_repo = cfg.wiki_repo_path
+    info_path = wiki_repo / "sources" / source_id / "info.yaml"
+    info = info_yaml_mod.read(info_path)
+    plan_path = reading_pipeline.pending_plan_path(source_id)
+    if not plan_path.exists():
+        msg = f"No plan at {plan_path}; run `approve-reading {source_id}` first."
+        raise ReviewError(msg)
+    plan = plan_yaml_mod.read(plan_path)
+    index = entity_index_mod.build(wiki_repo)
+    ctx = _ApprovalContext(
+        cfg=cfg, source_id=source_id, info=info, plan=plan, index=index
+    )
+
+    ordered = sorted_proposals(plan, source_id)
+    if not ordered:
+        return ReviewResult()
+
+    # claim-group sizes for "K of M" header
+    group_sizes: dict[str, int] = {}
+    for p in ordered:
+        group_sizes[p.claim_group_id] = group_sizes.get(p.claim_group_id, 0) + 1
+    group_seen: dict[str, int] = {}
+
+    result = ReviewResult()
+    total = len(ordered)
+    for i, proposal in enumerate(ordered, start=1):
+        group_seen[proposal.claim_group_id] = (
+            group_seen.get(proposal.claim_group_id, 0) + 1
+        )
+        view = _build_view(
+            ctx,
+            proposal,
+            proposal_index=i,
+            proposal_total=total,
+            group_position=group_seen[proposal.claim_group_id],
+            group_size=group_sizes[proposal.claim_group_id],
+        )
+        try:
+            decision = reviewer.decide(view)
+        except KeyboardInterrupt:
+            result.remaining = total - (i - 1)
+            raise
+        if isinstance(decision, RejectDecision):
+            proposal_path = reading_pipeline.pending_proposal_path(
+                source_id, proposal.proposed_id
+            )
+            _reject(proposal_path)
+            result.rejected += 1
+            continue
+        # approve / edit: gather alias confirmations
+        confirmed: list[str] = []
+        for alias in view.suggested_aliases:
+            try:
+                if reviewer.confirm_alias(proposal.target_entity, alias):
+                    confirmed.append(alias)
+            except KeyboardInterrupt:
+                result.remaining = total - (i - 1)
+                raise
+        edited_text = decision.new_text if isinstance(decision, EditDecision) else None
+        proposal_path = reading_pipeline.pending_proposal_path(
+            source_id, proposal.proposed_id
+        )
+        appended = _approve(
+            ctx,
+            proposal,
+            proposal_path,
+            edited_text=edited_text,
+            confirmed_aliases=confirmed,
+            by_label=reviewer.by_label,
+        )
+        if appended:
+            if isinstance(decision, EditDecision):
+                result.edited += 1
+            else:
+                result.approved += 1
+    return result

--- a/src/auto_lorebook/stage1a.py
+++ b/src/auto_lorebook/stage1a.py
@@ -6,6 +6,7 @@ Emits a `Structure` validated by `structure.validate`.
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from auto_lorebook import structure as structure_mod
@@ -18,6 +19,13 @@ if TYPE_CHECKING:
     from auto_lorebook.transcript import LoadedTranscript
 
 _logger = logging.getLogger(__name__)
+
+# When the LLM ends the last segment a few seconds shy of the
+# transcript's total duration (cue-boundary rounding, trailing
+# music/credits/silence), extend the last segment to cover the gap so
+# `structure.validate`'s strict 1s tolerance still catches real
+# coverage drops.
+_TAIL_CLAMP_THRESHOLD_SECONDS = 30.0
 
 _TASK_INSTRUCTIONS = """\
 You are segmenting an actual-play or lore transcript into a structured
@@ -110,6 +118,7 @@ def run(
         source_id=source_id,
         generated_at=format_iso_now(),
     )
+    structure = _clamp_tail(structure, transcript.total_duration)
 
     try:
         structure_mod.validate(structure, transcript.total_duration)
@@ -117,6 +126,25 @@ def run(
         msg = f"Stage 1a mechanical validation failed: {e}"
         raise Stage1aError(msg) from e
 
+    return structure
+
+
+def _clamp_tail(structure: Structure, total_duration: float) -> Structure:
+    """Extend last segment to total_duration when the gap is benign.
+
+    Cue-boundary rounding and trailing music/credits routinely leave a
+    few seconds of slack; extending is mechanically correct (no claims
+    to lose). Gaps beyond the threshold mean the model dropped real
+    content and should still fail validate.
+    """
+    if not structure.segments:
+        return structure
+    last = structure.segments[-1]
+    gap = total_duration - last.end
+    if 0 < gap <= _TAIL_CLAMP_THRESHOLD_SECONDS:
+        clamped_last = replace(last, end=total_duration)
+        new_segments = [*structure.segments[:-1], clamped_last]
+        return replace(structure, segments=new_segments)
     return structure
 
 

--- a/src/auto_lorebook/stage3.py
+++ b/src/auto_lorebook/stage3.py
@@ -216,8 +216,12 @@ def _parse_extracted_span(payload: dict[str, Any], *, context: str) -> _Extracte
         try:
             corrections.append(proposal_yaml_mod.parse_correction(entry))
         except proposal_yaml_mod.ProposalError as e:
-            msg = f"{context}: {e}"
-            raise Stage3Error(msg) from e
+            # LLM output quality issue — drop the malformed entry rather than
+            # killing the whole proposal. Disk reads stay strict via
+            # `proposal_yaml.read`.
+            _logger.warning(
+                "%s: dropping malformed correction %r: %s", context, entry, e
+            )
     return _ExtractedSpan(
         text=text,
         raw_transcript_span=raw_span,
@@ -361,6 +365,14 @@ def _build_proposals(
     return out
 
 
+_EMPTY_EXTRACTED = _ExtractedSpan(
+    text="",
+    raw_transcript_span="",
+    text_corrects_transcript=False,
+    corrections=(),
+)
+
+
 def _build_flagged_proposals(
     *,
     claim: PlannedClaim,
@@ -445,8 +457,31 @@ def _extract_one(
     try:
         payload = parse_json_object(resp.text, context)
     except ValueError as e:
-        raise Stage3Error(str(e)) from e
-    extracted = _parse_extracted_span(payload, context=context)
+        # LLM emitted unparseable JSON. Don't kill the whole run — flag the
+        # claim so the reviewer sees it and can edit/reject.
+        _logger.warning("%s: malformed JSON; flagging claim group: %s", context, e)
+        return _build_flagged_proposals(
+            claim=claim,
+            allocations=allocations,
+            extracted=_EMPTY_EXTRACTED,
+            info=info,
+            source_id=source_id,
+            flag_reason=f"Stage 3 LLM returned unparseable JSON: {e}",
+        )
+    try:
+        extracted = _parse_extracted_span(payload, context=context)
+    except Stage3Error as e:
+        # Schema-level degeneracy (missing raw_transcript_span / text). Same
+        # treatment: flag and continue so other claim groups land their work.
+        _logger.warning("%s: schema violation; flagging claim group: %s", context, e)
+        return _build_flagged_proposals(
+            claim=claim,
+            allocations=allocations,
+            extracted=_EMPTY_EXTRACTED,
+            info=info,
+            source_id=source_id,
+            flag_reason=f"Stage 3 LLM output missing required fields: {e}",
+        )
 
     # Try to anchor in the hint window first.
     located = _locate_span_in_cues(transcript, hint_cues, extracted.raw_transcript_span)

--- a/src/auto_lorebook/stage3.py
+++ b/src/auto_lorebook/stage3.py
@@ -1,0 +1,545 @@
+"""Stage 3: Extractor.
+
+Locates the verbatim transcript span for each planned claim. One LLM
+call per `PlannedClaim` (not per target — siblings share the located
+span via claim-group dedup). The LLM is asked only for the literal span
+plus the corrected text and any applied corrections; locator, context,
+speaker, and section are derived mechanically from the plan, the
+transcript cues, and the source `Info`.
+
+No filesystem side effects in this module — orchestration writes the
+proposal files via :func:`auto_lorebook.proposal_yaml.write`.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from auto_lorebook import entity_yaml as entity_yaml_mod
+from auto_lorebook import proposal_yaml as proposal_yaml_mod
+from auto_lorebook import transcript as transcript_mod
+from auto_lorebook.llm_helpers import build_system_prompt, parse_json_object
+from auto_lorebook.proposal_yaml import (
+    Correction,
+    Proposal,
+    Sibling,
+)
+from auto_lorebook.timestamps import (
+    TimestampError,
+    format_timestamp,
+    parse_locator_hint,
+    parse_timestamp,
+)
+
+if TYPE_CHECKING:
+    from auto_lorebook.info_yaml import Info
+    from auto_lorebook.openrouter import OpenRouterClient
+    from auto_lorebook.plan_yaml import Plan, PlannedClaim
+    from auto_lorebook.structure import Segment, Structure
+    from auto_lorebook.transcript import LoadedTranscript
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_CONCURRENCY = 4
+
+_READING_SECTION_PREFIX_RE = re.compile(
+    r"^\s*\[(?P<start>[0-9:,.]+)\s*-\s*(?P<end>[0-9:,.]+)\]"
+)
+
+_TASK_INSTRUCTIONS = """\
+You locate the verbatim transcript span for ONE planned claim from an
+already-approved wiki reading. The user message gives you the bullet
+text plus a windowed slice of the raw transcript covering the claim's
+locator hint. Find the cleanest contiguous span in that window that
+states the claim, return it verbatim, and report any
+transcription/name corrections applied to produce the cleaned `text`.
+
+Emit a single JSON object:
+
+{
+  "text": "<corrected, human-readable claim>",
+  "raw_transcript_span": "<literal substring of the transcript window>",
+  "text_corrects_transcript": true | false,
+  "corrections_applied": [
+    {
+      "from": "<token in raw_transcript_span>",
+      "to":   "<replacement in text>",
+      "source": "global-transcription-correction" | "reading-name-correction"
+    }
+  ]
+}
+
+Hard rules:
+- `raw_transcript_span` MUST be a literal substring of the transcript
+  window. Do NOT paraphrase, fix grammar, or remove filler.
+- `text` differs from `raw_transcript_span` only via the listed
+  corrections. No rewriting.
+- Use ONE contiguous span. If the claim is not present in a single
+  contiguous run, emit your best attempt and the substring check will
+  flag it.
+- `corrections_applied[].source` MUST be one of the two literal strings
+  shown above. Use `global-transcription-correction` for substitutions
+  driven by `.transcription-corrections.yaml`, and
+  `reading-name-correction` for the reading's `name_corrections` map.
+- If no corrections were applied, emit `corrections_applied: []` and
+  `text_corrects_transcript: false`.
+
+Emit ONLY the JSON object. No prose, no code fences, no commentary.
+"""
+
+
+class Stage3Error(RuntimeError):
+    """Stage 3 failed: bad LLM output, schema violation, or unanchorable input."""
+
+
+@dataclass(frozen=True)
+class _Allocation:
+    """Pre-allocated id and sibling list for one target of a claim."""
+
+    proposed_id: str
+    siblings: tuple[Sibling, ...]
+
+
+def find_segment_for_reading_section(
+    structure: Structure, reading_section: str, *, tolerance: float = 1.0
+) -> Segment | None:
+    """Match `[h:mm:ss-h:mm:ss] ...` prefix against `structure.segments[*].start`."""
+    m = _READING_SECTION_PREFIX_RE.match(reading_section)
+    if not m:
+        return None
+    try:
+        start = parse_timestamp(m.group("start"))
+    except TimestampError:
+        return None
+    for seg in structure.segments:
+        if abs(seg.start - start) <= tolerance:
+            return seg
+    return None
+
+
+def allocate_proposed_ids(
+    plan: Plan,
+    *,
+    existing_fact_counts: dict[str, int],
+    existing_slugs: dict[str, str],
+) -> dict[str, list[_Allocation]]:
+    """Assign `proposed_id` to every target of every claim, single-threaded.
+
+    Returns a map keyed by `claim_group_id` of allocations parallel to
+    each claim's `targets` list. Sibling lists exclude self.
+    """
+    counters: dict[str, int] = {}
+    per_claim_ids: dict[str, list[tuple[str, str]]] = {}  # cg_id -> [(entity, id)]
+    for claim in plan.planned_claims:
+        ids: list[tuple[str, str]] = []
+        for target in claim.targets:
+            slug = existing_slugs.get(
+                target.entity, entity_yaml_mod.slugify(target.entity)
+            )
+            if not slug:
+                msg = (
+                    f"cannot derive slug for target entity {target.entity!r}; "
+                    f"entity_yaml.slugify returned empty"
+                )
+                raise Stage3Error(msg)
+            base = counters.get(
+                target.entity, existing_fact_counts.get(target.entity, 0)
+            )
+            n = base + 1
+            counters[target.entity] = n
+            ids.append((target.entity, f"{slug}-f{n:03d}"))
+        per_claim_ids[claim.claim_group_id] = ids
+
+    allocations: dict[str, list[_Allocation]] = {}
+    for claim in plan.planned_claims:
+        ids = per_claim_ids[claim.claim_group_id]
+        per_target: list[_Allocation] = []
+        for i, (_entity, pid) in enumerate(ids):
+            siblings = tuple(
+                Sibling(entity=e, proposed_id=p)
+                for j, (e, p) in enumerate(ids)
+                if j != i
+            )
+            per_target.append(_Allocation(proposed_id=pid, siblings=siblings))
+        allocations[claim.claim_group_id] = per_target
+    return allocations
+
+
+def _build_user(claim: PlannedClaim, window_text: str) -> str:
+    bullet_lines = [
+        f"Claim group: {claim.claim_group_id}",
+        f"Reading section: {claim.reading_section}",
+        f"Bullet (from approved reading): {claim.targets[0].entity}",
+        "",
+        "Bullet text being located:",
+        f"  {claim.reading_section}  bullet[{claim.reading_bullet_index}]",
+        "",
+        f"Locator hint: {claim.locator_hint}",
+        "",
+        "Transcript window (locate the span inside this slice):",
+        "",
+        window_text.rstrip() or "(empty window)",
+    ]
+    return "\n".join(bullet_lines)
+
+
+@dataclass(frozen=True)
+class _ExtractedSpan:
+    """LLM-derived span before mechanical assembly."""
+
+    text: str
+    raw_transcript_span: str
+    text_corrects_transcript: bool
+    corrections: tuple[Correction, ...]
+
+
+def _parse_extracted_span(payload: dict[str, Any], *, context: str) -> _ExtractedSpan:
+    raw_span = payload.get("raw_transcript_span")
+    text = payload.get("text")
+    if not isinstance(raw_span, str) or not raw_span:
+        msg = f"{context}: missing raw_transcript_span"
+        raise Stage3Error(msg)
+    if not isinstance(text, str) or not text:
+        msg = f"{context}: missing text"
+        raise Stage3Error(msg)
+    text_corrects = bool(payload.get("text_corrects_transcript"))
+    corrections_raw = payload.get("corrections_applied") or []
+    if not isinstance(corrections_raw, list):
+        msg = f"{context}: corrections_applied must be a list"
+        raise Stage3Error(msg)
+    corrections: list[Correction] = []
+    for entry in corrections_raw:
+        try:
+            corrections.append(proposal_yaml_mod.parse_correction(entry))
+        except proposal_yaml_mod.ProposalError as e:
+            msg = f"{context}: {e}"
+            raise Stage3Error(msg) from e
+    return _ExtractedSpan(
+        text=text,
+        raw_transcript_span=raw_span,
+        text_corrects_transcript=text_corrects,
+        corrections=tuple(corrections),
+    )
+
+
+@dataclass(frozen=True)
+class _LocatedSpan:
+    """Result of mechanical span location in the transcript."""
+
+    locator: str
+    context_before: str
+    context_after: str
+
+
+def _locate_span_in_cues(
+    transcript: LoadedTranscript,
+    cues: list[Any],
+    raw_span: str,
+) -> _LocatedSpan | None:
+    """Find `raw_span` in the rendered cue text and derive locator + context.
+
+    Returns None if `raw_span` is not a substring of the rendered window.
+    """
+    if not cues:
+        return None
+    rendered = "\n".join(c.text for c in cues)
+    if raw_span not in rendered:
+        return None
+
+    # Find the cue range that contains the span by walking offsets.
+    offset = 0
+    starts: list[int] = []
+    for c in cues:
+        starts.append(offset)
+        offset += len(c.text) + 1  # +1 for the join newline
+    span_start = rendered.index(raw_span)
+    span_end = span_start + len(raw_span)
+
+    first_idx = 0
+    for i, s in enumerate(starts):
+        next_s = starts[i + 1] if i + 1 < len(starts) else len(rendered) + 1
+        if s <= span_start < next_s:
+            first_idx = i
+            break
+
+    last_idx = first_idx
+    for i in range(first_idx, len(starts)):
+        s = starts[i]
+        next_s = starts[i + 1] if i + 1 < len(starts) else len(rendered) + 1
+        if s < span_end <= next_s:
+            last_idx = i
+            break
+        last_idx = i
+
+    first_cue = cues[first_idx]
+    last_cue = cues[last_idx]
+    locator_start = first_cue.start
+    if last_idx + 1 < len(cues):
+        locator_end = cues[last_idx + 1].start
+    elif transcript.cues is not None and last_cue is transcript.cues[-1]:
+        locator_end = transcript.total_duration
+    else:
+        # last cue of window but not of transcript: peek next cue in transcript
+        all_cues = transcript.cues or ()
+        try:
+            global_idx = all_cues.index(last_cue)
+            locator_end = (
+                all_cues[global_idx + 1].start
+                if global_idx + 1 < len(all_cues)
+                else transcript.total_duration
+            )
+        except ValueError:
+            locator_end = last_cue.end
+
+    locator = f"{format_timestamp(locator_start)}-{format_timestamp(locator_end)}"
+    all_cues = transcript.cues or ()
+    try:
+        global_first = all_cues.index(first_cue)
+        global_last = all_cues.index(last_cue)
+    except ValueError:
+        global_first = global_last = -1
+    context_before = all_cues[global_first - 1].text if global_first > 0 else ""
+    context_after = (
+        all_cues[global_last + 1].text
+        if global_last >= 0 and global_last + 1 < len(all_cues)
+        else ""
+    )
+    return _LocatedSpan(
+        locator=locator,
+        context_before=context_before,
+        context_after=context_after,
+    )
+
+
+def _build_proposals(
+    *,
+    claim: PlannedClaim,
+    allocations: list[_Allocation],
+    extracted: _ExtractedSpan,
+    located: _LocatedSpan,
+    info: Info,
+    source_id: str,
+    hint_widened: bool,
+) -> list[Proposal]:
+    out: list[Proposal] = []
+    session_date = info.session_date or ""
+    for target, alloc in zip(claim.targets, allocations, strict=True):
+        proposal_type = (
+            "new_entity_with_facts" if target.entity_state == "new" else "new_fact"
+        )
+        out.append(
+            Proposal(
+                proposal_type=proposal_type,
+                target_entity=target.entity,
+                proposed_id=alloc.proposed_id,
+                claim_group_id=claim.claim_group_id,
+                claim_group_siblings=list(alloc.siblings),
+                text=extracted.text,
+                raw_transcript_span=extracted.raw_transcript_span,
+                text_corrects_transcript=extracted.text_corrects_transcript,
+                corrections_applied=list(extracted.corrections),
+                source_id=source_id,
+                locator=located.locator,
+                speaker=claim.proposed_speaker,
+                reading_section=claim.reading_section,
+                reading_bullet_index=claim.reading_bullet_index,
+                status=claim.proposed_status,
+                status_reason=claim.proposed_status_reason,
+                session_date=session_date,
+                section=target.proposed_section,
+                context_before=located.context_before,
+                context_after=located.context_after,
+                hint_widened=hint_widened,
+                extractor_flagged=False,
+                flag_reason=None,
+            )
+        )
+    return out
+
+
+def _build_flagged_proposals(
+    *,
+    claim: PlannedClaim,
+    allocations: list[_Allocation],
+    extracted: _ExtractedSpan,
+    info: Info,
+    source_id: str,
+    flag_reason: str,
+) -> list[Proposal]:
+    """Emit one flagged proposal per target when the span can't be anchored."""
+    out: list[Proposal] = []
+    session_date = info.session_date or ""
+    for target, alloc in zip(claim.targets, allocations, strict=True):
+        proposal_type = (
+            "new_entity_with_facts" if target.entity_state == "new" else "new_fact"
+        )
+        out.append(
+            Proposal(
+                proposal_type=proposal_type,
+                target_entity=target.entity,
+                proposed_id=alloc.proposed_id,
+                claim_group_id=claim.claim_group_id,
+                claim_group_siblings=list(alloc.siblings),
+                text=extracted.text,
+                raw_transcript_span=extracted.raw_transcript_span,
+                text_corrects_transcript=extracted.text_corrects_transcript,
+                corrections_applied=list(extracted.corrections),
+                source_id=source_id,
+                locator=claim.locator_hint,
+                speaker=claim.proposed_speaker,
+                reading_section=claim.reading_section,
+                reading_bullet_index=claim.reading_bullet_index,
+                status=claim.proposed_status,
+                status_reason=claim.proposed_status_reason,
+                session_date=session_date,
+                section=target.proposed_section,
+                context_before="",
+                context_after="",
+                hint_widened=False,
+                extractor_flagged=True,
+                flag_reason=flag_reason,
+            )
+        )
+    return out
+
+
+def _extract_one(
+    *,
+    claim: PlannedClaim,
+    allocations: list[_Allocation],
+    transcript: LoadedTranscript,
+    structure: Structure,
+    info: Info,
+    preamble_text: str,
+    source_id: str,
+    client: OpenRouterClient,
+    model: str,
+) -> list[Proposal]:
+    """Run one LLM call per claim group; emit one Proposal per target."""
+    try:
+        hint_start, hint_end = parse_locator_hint(claim.locator_hint)
+    except TimestampError as e:
+        msg = f"claim {claim.claim_group_id}: bad locator_hint: {e}"
+        raise Stage3Error(msg) from e
+    hint_text, hint_cues = transcript_mod.transcript_window(
+        transcript, hint_start, hint_end
+    )
+
+    messages = [
+        {
+            "role": "system",
+            "content": build_system_prompt(preamble_text, _TASK_INSTRUCTIONS),
+        },
+        {"role": "user", "content": _build_user(claim, hint_text)},
+    ]
+    resp = client.complete(
+        messages,
+        model=model,
+        response_format={"type": "json_object"},
+    )
+    context = f"Stage 3 / {claim.claim_group_id}"
+    try:
+        payload = parse_json_object(resp.text, context)
+    except ValueError as e:
+        raise Stage3Error(str(e)) from e
+    extracted = _parse_extracted_span(payload, context=context)
+
+    # Try to anchor in the hint window first.
+    located = _locate_span_in_cues(transcript, hint_cues, extracted.raw_transcript_span)
+    hint_widened = False
+    if located is None:
+        # Mechanical retry against the parent segment's window — no 2nd LLM call.
+        segment = find_segment_for_reading_section(structure, claim.reading_section)
+        if segment is not None:
+            seg_text, seg_cues = transcript_mod.transcript_window(
+                transcript, segment.start, segment.end
+            )
+            seg_located = _locate_span_in_cues(
+                transcript, seg_cues, extracted.raw_transcript_span
+            )
+            if seg_located is not None:
+                located = seg_located
+                hint_widened = True
+                _ = seg_text  # keep for symmetry / future debugging
+
+    if located is None:
+        return _build_flagged_proposals(
+            claim=claim,
+            allocations=allocations,
+            extracted=extracted,
+            info=info,
+            source_id=source_id,
+            flag_reason=(
+                "raw_transcript_span not found in hint window or parent segment"
+            ),
+        )
+
+    return _build_proposals(
+        claim=claim,
+        allocations=allocations,
+        extracted=extracted,
+        located=located,
+        info=info,
+        source_id=source_id,
+        hint_widened=hint_widened,
+    )
+
+
+def run(
+    *,
+    plan: Plan,
+    transcript: LoadedTranscript,
+    structure: Structure,
+    info: Info,
+    preamble_text: str,
+    source_id: str,
+    client: OpenRouterClient,
+    model: str,
+    existing_fact_counts: dict[str, int],
+    existing_slugs: dict[str, str],
+    max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+) -> list[Proposal]:
+    """Run Stage 3 against an approved plan and produce a list of Proposals.
+
+    :raises Stage3Error: on bad LLM JSON, schema violation, or
+        unanchorable input (e.g. plain-text transcript). A merely-
+        unlocatable span yields a ``extractor_flagged=True`` proposal,
+        not an exception.
+    """
+    if transcript.cues is None:
+        msg = "Stage 3 needs SRT timestamps; this source is plain text"
+        raise Stage3Error(msg)
+    if not plan.planned_claims:
+        return []
+
+    allocations = allocate_proposed_ids(
+        plan,
+        existing_fact_counts=existing_fact_counts,
+        existing_slugs=existing_slugs,
+    )
+
+    results: list[list[Proposal]] = [[] for _ in plan.planned_claims]
+    with ThreadPoolExecutor(max_workers=max_concurrency) as ex:
+        futures = {
+            ex.submit(
+                _extract_one,
+                claim=claim,
+                allocations=allocations[claim.claim_group_id],
+                transcript=transcript,
+                structure=structure,
+                info=info,
+                preamble_text=preamble_text,
+                source_id=source_id,
+                client=client,
+                model=model,
+            ): i
+            for i, claim in enumerate(plan.planned_claims)
+        }
+        for future, i in futures.items():
+            results[i] = future.result()
+
+    return [p for batch in results for p in batch]

--- a/src/auto_lorebook/timestamps.py
+++ b/src/auto_lorebook/timestamps.py
@@ -73,3 +73,24 @@ def parse_timestamp(text: str) -> float:
         raise TimestampError(msg)
 
     return h * 3_600 + m * 60 + s
+
+
+def parse_locator_hint(text: str) -> tuple[float, float]:
+    """Parse `h:mm:ss-h:mm:ss` (or lenient variants) to `(start, end)` seconds.
+
+    :raises TimestampError: empty, missing dash, malformed, or end < start
+    """
+    raw = text.strip()
+    if not raw:
+        msg = "empty locator hint"
+        raise TimestampError(msg)
+    if "-" not in raw:
+        msg = f"locator hint missing '-': {text!r}"
+        raise TimestampError(msg)
+    left, right = raw.rsplit("-", 1)
+    start = parse_timestamp(left)
+    end = parse_timestamp(right)
+    if end < start:
+        msg = f"locator hint end < start: {text!r}"
+        raise TimestampError(msg)
+    return start, end

--- a/src/auto_lorebook/transcript.py
+++ b/src/auto_lorebook/transcript.py
@@ -2,7 +2,8 @@
 
 SRT cues are flattened to `[h:mm:ss] text` lines. Plain-text sources are
 returned verbatim. `.transcription-corrections.yaml` literal
-substitutions are applied before returning.
+substitutions are applied per-cue (or per-string for plain text) before
+returning, so `cue.text` and `text_for_llm` agree exactly.
 """
 
 from __future__ import annotations
@@ -10,6 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from auto_lorebook.srt import Cue
 from auto_lorebook.srt import parse as parse_srt
 from auto_lorebook.timestamps import format_timestamp
 
@@ -26,10 +28,15 @@ class TranscriptError(ValueError):
 
 @dataclass(frozen=True)
 class LoadedTranscript:
-    """Flattened transcript + duration for a source."""
+    """Flattened transcript + duration for a source.
+
+    `cues` is populated for SRT sources and `None` for plain text. When
+    populated, every `cue.text` is a literal substring of `text_for_llm`.
+    """
 
     text_for_llm: str
     total_duration: float
+    cues: tuple[Cue, ...] | None = None
 
 
 def apply_corrections(text: str, corrections: Corrections) -> str:
@@ -38,6 +45,15 @@ def apply_corrections(text: str, corrections: Corrections) -> str:
     for c in corrections.corrections:
         out = out.replace(c.wrong, c.right)
     return out
+
+
+def _correct_cue(cue: Cue, corrections: Corrections) -> Cue:
+    return Cue(
+        index=cue.index,
+        start=cue.start,
+        end=cue.end,
+        text=apply_corrections(cue.text, corrections),
+    )
 
 
 def load(
@@ -54,16 +70,30 @@ def load(
 
     raw = path.read_text(encoding="utf-8")
     if info.source_type in {"srt", "youtube"} or fname.endswith(".srt"):
-        text, duration = _render_srt(raw)
-    else:
-        text = raw
-        duration = float(info.duration_seconds or 0)
+        cues = tuple(_correct_cue(c, corrections) for c in parse_srt(raw))
+        text = _render_cues(cues)
+        duration = cues[-1].end if cues else 0.0
+        if info.duration_seconds is not None:
+            duration = float(info.duration_seconds)
+        return LoadedTranscript(text_for_llm=text, total_duration=duration, cues=cues)
 
-    if info.duration_seconds is not None:
-        duration = float(info.duration_seconds)
+    corrected = apply_corrections(raw, corrections)
+    duration = float(info.duration_seconds or 0)
+    return LoadedTranscript(text_for_llm=corrected, total_duration=duration, cues=None)
 
-    corrected = apply_corrections(text, corrections)
-    return LoadedTranscript(text_for_llm=corrected, total_duration=duration)
+
+def transcript_window(
+    transcript: LoadedTranscript, start: float, end: float
+) -> tuple[str, list[Cue]]:
+    """Return rendered `[h:mm:ss] text` lines and cues whose start ∈ `[start, end)`.
+
+    :raises TranscriptError: when transcript has no cues (plain text)
+    """
+    if transcript.cues is None:
+        msg = "transcript has no cues; window requires SRT-derived transcript"
+        raise TranscriptError(msg)
+    kept = [c for c in transcript.cues if start <= c.start < end]
+    return _render_cues(tuple(kept)), kept
 
 
 def _default_filename(source_type: str) -> str:
@@ -74,10 +104,7 @@ def _default_filename(source_type: str) -> str:
     return "transcript.txt"
 
 
-def _render_srt(raw: str) -> tuple[str, float]:
-    cues = parse_srt(raw)
+def _render_cues(cues: tuple[Cue, ...]) -> str:
     if not cues:
-        return "", 0.0
-    lines = [f"[{format_timestamp(c.start)}] {c.text}" for c in cues]
-    duration = cues[-1].end
-    return "\n".join(lines) + "\n", duration
+        return ""
+    return "\n".join(f"[{format_timestamp(c.start)}] {c.text}" for c in cues) + "\n"

--- a/tests/test_entity_index.py
+++ b/tests/test_entity_index.py
@@ -119,6 +119,42 @@ def test_render_deterministic(tmp_wiki: Path) -> None:
     assert r1 == r2
 
 
+# ---------------------------------------------------------------------------
+# Lookup
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_by_canonical_name(tmp_wiki: Path) -> None:
+    _write_entity(tmp_wiki, "locations", "aldara", "Aldara")
+    idx = build(tmp_wiki)
+    entry = idx.lookup("Aldara")
+    assert entry is not None
+    assert entry.entity == "Aldara"
+    assert entry.category == "locations"
+    assert entry.slug == "aldara"
+
+
+def test_lookup_case_insensitive(tmp_wiki: Path) -> None:
+    _write_entity(tmp_wiki, "locations", "aldara", "Aldara")
+    idx = build(tmp_wiki)
+    assert idx.lookup("aldara") is not None
+    assert idx.lookup("ALDARA") is not None
+    assert idx.lookup("  Aldara  ") is not None
+
+
+def test_lookup_unknown_returns_none(tmp_wiki: Path) -> None:
+    _write_entity(tmp_wiki, "locations", "aldara", "Aldara")
+    idx = build(tmp_wiki)
+    assert idx.lookup("Theron") is None
+
+
+def test_lookup_does_not_match_aliases(tmp_wiki: Path) -> None:
+    """`lookup` is canonical-name only; alias resolution is a separate path."""
+    _write_entity(tmp_wiki, "locations", "aldara", "Aldara", aliases=["the Realm"])
+    idx = build(tmp_wiki)
+    assert idx.lookup("the Realm") is None
+
+
 def test_malformed_entity_skipped_with_warning(
     tmp_wiki: Path, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_entity_yaml.py
+++ b/tests/test_entity_yaml.py
@@ -13,6 +13,7 @@ from auto_lorebook.entity_yaml import (
     EntityError,
     normalize_alias_name,
     read,
+    slugify,
     write,
 )
 from auto_lorebook.schema import SchemaVersionError
@@ -238,3 +239,24 @@ def test_schema_version_error_subclass() -> None:
     # SchemaVersionError underlies our errors; this is just a sanity check
     # that it's importable from where we expect.
     assert issubclass(SchemaVersionError, ValueError)
+
+
+def test_slugify_basic() -> None:
+    assert slugify("Aldara") == "aldara"
+    assert slugify("War of the Dusk") == "war-of-the-dusk"
+
+
+def test_slugify_punctuation_collapsed() -> None:
+    assert slugify("Théron's Sword!") == "th-ron-s-sword"
+    assert slugify("--Multi  Spaces--") == "multi-spaces"
+
+
+def test_slugify_empty_or_pure_punctuation() -> None:
+    assert not slugify("")
+    assert not slugify("   ")
+    assert not slugify("???")
+
+
+def test_slugify_idempotent() -> None:
+    once = slugify("The Second Age")
+    assert slugify(once) == once

--- a/tests/test_ingest_cleanup.py
+++ b/tests/test_ingest_cleanup.py
@@ -1,0 +1,452 @@
+"""Tests for ingest_cleanup.py — Phase 4 reject-ingest engine."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import entity_yaml, reading_pipeline
+from auto_lorebook.entity_yaml import Alias, Entity
+from auto_lorebook.ingest_cleanup import RejectResult, preview, reject_ingest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cfg(
+    tmp_path: Path, tmp_wiki: Path, monkeypatch: pytest.MonkeyPatch
+) -> cfg_mod.Config:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    return cfg_mod.Config(wiki_repo_path=tmp_wiki)
+
+
+def _fact(
+    fact_id: str,
+    *,
+    ingest: str = "yt-x",
+    text: str = "A fact.",
+) -> dict:
+    return {
+        "id": fact_id,
+        "text": text,
+        "raw_transcript_span": text,
+        "text_corrects_transcript": False,
+        "corrections_applied": [],
+        "edited_by_human": False,
+        "source_id": "yt-x",
+        "locator": "0:00:01-0:00:02",
+        "speaker": "DM",
+        "status": "authoritative",
+        "session_date": "2026-04-15",
+        "approved_at": "2026-04-20T00:00:00Z",
+        "created_by_ingest": ingest,
+        "claim_group_id": "cg-001",
+        "section": "founding",
+    }
+
+
+def _write_entity(
+    wiki: Path,
+    *,
+    name: str,
+    category: str,
+    slug: str,
+    created_by_ingest: str | None = "yt-x",
+    facts: list[dict] | None = None,
+    aliases: list[Alias] | None = None,
+) -> Path:
+    e = Entity(
+        entity=name,
+        category=category,
+        slug=slug,
+        created_at="2026-04-20T00:00:00Z",
+        created_by_ingest=created_by_ingest,
+        updated_at="2026-04-20T00:00:00Z",
+        facts=facts or [],
+        aliases=aliases or [],
+    )
+    path = wiki / category / f"{slug}.yaml"
+    entity_yaml.write(e, path)
+    return path
+
+
+def _write_pending(home: Path, source_id: str) -> tuple[Path, Path, Path]:
+    """Materialise plan.yaml, proposals/, and reading/ for a source."""
+    pending_root = home / "pending" / source_id
+    plan_path = pending_root / "plan.yaml"
+    proposals_dir = pending_root / "proposals"
+    reading_dir = pending_root / "reading"
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    plan_path.write_text(
+        yaml.safe_dump({
+            "schema_version": 1,
+            "source_id": source_id,
+            "planned_at": "2026-04-20T00:00:00Z",
+            "entity_resolutions": [],
+            "new_entities": [],
+            "planned_claims": [],
+            "unresolved": [],
+        }),
+        encoding="utf-8",
+    )
+    proposals_dir.mkdir(parents=True, exist_ok=True)
+    (proposals_dir / "stub.yaml").write_text("placeholder", encoding="utf-8")
+    reading_dir.mkdir(parents=True, exist_ok=True)
+    (reading_dir / "structure.yaml").write_text("placeholder", encoding="utf-8")
+    return plan_path, proposals_dir, reading_dir
+
+
+# ---------------------------------------------------------------------------
+# Engine: facts / aliases / stub deletion
+# ---------------------------------------------------------------------------
+
+
+class TestFactRemoval:
+    def test_removes_matching_facts(self, cfg: cfg_mod.Config) -> None:
+        path = _write_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="other-ingest",
+            facts=[
+                _fact("aldara-f001", ingest="yt-x"),
+                _fact("aldara-f002", ingest="other-ingest"),
+            ],
+        )
+        result = reject_ingest(cfg, "yt-x")
+        assert result.facts_removed == 1
+        assert result.entities_modified == 1
+        assert result.stubs_deleted == 0
+        e = entity_yaml.read(path)
+        assert [f["id"] for f in e.facts] == ["aldara-f002"]
+
+
+class TestAliasRemoval:
+    def test_removes_matching_aliases(self, cfg: cfg_mod.Config) -> None:
+        path = _write_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="other-ingest",
+            facts=[_fact("aldara-f001", ingest="other-ingest")],
+            aliases=[
+                Alias(
+                    name="the Realm",
+                    added_by_ingest="yt-x",
+                    added_at="2026-04-20T00:00:00Z",
+                    source="alias-confirmation",
+                ),
+                Alias(
+                    name="Aldaran",
+                    added_by_ingest="other-ingest",
+                    added_at="2026-04-20T00:00:00Z",
+                    source="alias-confirmation",
+                ),
+            ],
+        )
+        result = reject_ingest(cfg, "yt-x")
+        assert result.aliases_removed == 1
+        assert result.entities_modified == 1
+        e = entity_yaml.read(path)
+        assert [a.name for a in e.aliases] == ["Aldaran"]
+
+
+class TestStubDeletion:
+    def test_deletes_stub_when_facts_empty_and_created_by_ingest_matches(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        path = _write_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="yt-x",
+            facts=[_fact("aldara-f001", ingest="yt-x")],
+        )
+        result = reject_ingest(cfg, "yt-x")
+        assert result.stubs_deleted == 1
+        assert result.facts_removed == 1
+        assert not path.exists()
+
+    def test_keeps_stub_when_created_by_differs(self, cfg: cfg_mod.Config) -> None:
+        # Pre-existing entity, all facts happen to be from yt-x.
+        path = _write_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="other-ingest",
+            facts=[_fact("aldara-f001", ingest="yt-x")],
+        )
+        result = reject_ingest(cfg, "yt-x")
+        assert result.stubs_deleted == 0
+        assert result.facts_removed == 1
+        assert path.exists()
+        e = entity_yaml.read(path)
+        assert e.facts == []
+
+    def test_keeps_stub_when_other_ingest_facts_remain(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        # Created by yt-x but a later ingest also added facts.
+        path = _write_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="yt-x",
+            facts=[
+                _fact("aldara-f001", ingest="yt-x"),
+                _fact("aldara-f002", ingest="other-ingest"),
+            ],
+        )
+        result = reject_ingest(cfg, "yt-x")
+        assert result.stubs_deleted == 0
+        assert result.facts_removed == 1
+        assert path.exists()
+        e = entity_yaml.read(path)
+        assert [f["id"] for f in e.facts] == ["aldara-f002"]
+
+
+class TestMixedFacts:
+    def test_only_target_ingest_facts_removed(self, cfg: cfg_mod.Config) -> None:
+        path = _write_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="other-ingest",
+            facts=[
+                _fact("aldara-f001", ingest="yt-x"),
+                _fact("aldara-f002", ingest="other-ingest"),
+                _fact("aldara-f003", ingest="yt-x"),
+            ],
+        )
+        result = reject_ingest(cfg, "yt-x")
+        assert result.facts_removed == 2
+        e = entity_yaml.read(path)
+        assert [f["id"] for f in e.facts] == ["aldara-f002"]
+
+
+class TestAliasOnlyChange:
+    def test_alias_only_change_bumps_modified_and_updated_at(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        path = _write_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="other-ingest",
+            facts=[_fact("aldara-f001", ingest="other-ingest")],
+            aliases=[
+                Alias(
+                    name="the Realm",
+                    added_by_ingest="yt-x",
+                    added_at="2026-04-20T00:00:00Z",
+                    source="alias-confirmation",
+                ),
+            ],
+        )
+        before = entity_yaml.read(path).updated_at
+        result = reject_ingest(cfg, "yt-x")
+        assert result.aliases_removed == 1
+        assert result.facts_removed == 0
+        assert result.entities_modified == 1
+        after = entity_yaml.read(path).updated_at
+        assert after != before
+        assert after is not None
+
+
+class TestHandEdited:
+    def test_fact_without_ingest_tag_kept(self, cfg: cfg_mod.Config) -> None:
+        # Hand-edited fact: no `created_by_ingest` field.
+        f = _fact("aldara-f001", ingest="yt-x")
+        f.pop("created_by_ingest")
+        path = _write_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="other-ingest",
+            facts=[f],
+        )
+        result = reject_ingest(cfg, "yt-x")
+        assert result.facts_removed == 0
+        e = entity_yaml.read(path)
+        assert len(e.facts) == 1
+
+    def test_alias_without_ingest_tag_kept(self, cfg: cfg_mod.Config) -> None:
+        path = _write_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="other-ingest",
+            facts=[_fact("aldara-f001", ingest="other-ingest")],
+            aliases=[
+                Alias(
+                    name="the Realm",
+                    added_by_ingest=None,
+                    added_at="2026-04-20T00:00:00Z",
+                    source="hand-edited",
+                ),
+            ],
+        )
+        result = reject_ingest(cfg, "yt-x")
+        assert result.aliases_removed == 0
+        e = entity_yaml.read(path)
+        assert len(e.aliases) == 1
+
+
+# ---------------------------------------------------------------------------
+# Engine: pending cleanup + sources untouched
+# ---------------------------------------------------------------------------
+
+
+class TestPendingCleanup:
+    def test_drops_plan_and_proposals_keeps_reading(self, cfg: cfg_mod.Config) -> None:
+        home = cfg_mod.config_dir()
+        plan_path, proposals_dir, reading_dir = _write_pending(home, "yt-x")
+        reject_ingest(cfg, "yt-x")
+        assert not plan_path.exists()
+        assert not proposals_dir.exists()
+        assert reading_dir.exists()
+        assert (reading_dir / "structure.yaml").exists()
+
+    def test_sources_dir_untouched(self, cfg: cfg_mod.Config) -> None:
+        src = cfg.wiki_repo_path / "sources" / "yt-x"
+        src.mkdir(parents=True)
+        (src / "info.yaml").write_text("placeholder", encoding="utf-8")
+        (src / "transcript.en.srt").write_text("placeholder", encoding="utf-8")
+        reject_ingest(cfg, "yt-x")
+        assert (src / "info.yaml").exists()
+        assert (src / "transcript.en.srt").exists()
+
+
+# ---------------------------------------------------------------------------
+# Engine: idempotency, empty wiki, malformed YAML
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_second_call_returns_zeros(self, cfg: cfg_mod.Config) -> None:
+        _write_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="yt-x",
+            facts=[_fact("aldara-f001", ingest="yt-x")],
+        )
+        first = reject_ingest(cfg, "yt-x")
+        assert first.stubs_deleted == 1
+        second = reject_ingest(cfg, "yt-x")
+        assert second == RejectResult()
+
+
+class TestEmptyWiki:
+    def test_returns_zeros(self, cfg: cfg_mod.Config) -> None:
+        result = reject_ingest(cfg, "yt-x")
+        assert result == RejectResult()
+
+
+class TestMalformed:
+    def test_skipped_with_warning(
+        self, cfg: cfg_mod.Config, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _write_entity(
+            cfg.wiki_repo_path,
+            name="Good",
+            category="locations",
+            slug="good",
+            created_by_ingest="yt-x",
+            facts=[_fact("good-f001", ingest="yt-x")],
+        )
+        # Malformed entity in the same dir: no schema_version
+        (cfg.wiki_repo_path / "locations" / "bad.yaml").write_text(
+            "entity: Bad\ncategory: locations\nslug: bad\n",
+            encoding="utf-8",
+        )
+        with caplog.at_level("WARNING"):
+            result = reject_ingest(cfg, "yt-x")
+        # Good entity still cleaned up
+        assert result.stubs_deleted == 1
+        assert any("could not parse" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Preview matches actual run
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewMatches:
+    def test_preview_matches_reject_counts(self, cfg: cfg_mod.Config) -> None:
+        # Several entities with mixed ingests
+        _write_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="yt-x",
+            facts=[
+                _fact("aldara-f001", ingest="yt-x"),
+                _fact("aldara-f002", ingest="yt-x"),
+            ],
+        )
+        _write_entity(
+            cfg.wiki_repo_path,
+            name="Theron",
+            category="characters",
+            slug="theron",
+            created_by_ingest="other",
+            facts=[
+                _fact("theron-f001", ingest="other"),
+                _fact("theron-f002", ingest="yt-x"),
+            ],
+            aliases=[
+                Alias(
+                    name="the King",
+                    added_by_ingest="yt-x",
+                    added_at="2026-04-20T00:00:00Z",
+                    source="alias-confirmation",
+                ),
+            ],
+        )
+        previewed = preview(cfg, "yt-x")
+        actual = reject_ingest(cfg, "yt-x")
+        assert previewed == actual
+        assert actual.stubs_deleted == 1
+        assert actual.facts_removed == 3
+        assert actual.aliases_removed == 1
+        assert actual.entities_modified == 1
+
+
+class TestProposalsDirAbsent:
+    def test_runs_clean_when_no_pending(self, cfg: cfg_mod.Config) -> None:
+        # Just an entity, no pending dir
+        _write_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="yt-x",
+            facts=[_fact("aldara-f001", ingest="yt-x")],
+        )
+        result = reject_ingest(cfg, "yt-x")
+        assert result.stubs_deleted == 1
+        # No exception; pending paths just don't exist.
+        assert not reading_pipeline.pending_plan_path("yt-x").exists()

--- a/tests/test_proposal_yaml.py
+++ b/tests/test_proposal_yaml.py
@@ -1,0 +1,260 @@
+"""Tests for proposal_yaml.py — Stage 3 proposal read/write."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+from auto_lorebook.proposal_yaml import (
+    Correction,
+    Proposal,
+    ProposalError,
+    Sibling,
+    read,
+    write,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _full_proposal(**overrides: Any) -> Proposal:  # noqa: ANN401
+    base = Proposal(
+        proposal_type="new_fact",
+        target_entity="Aldara",
+        proposed_id="aldara-f004",
+        claim_group_id="cg-001",
+        claim_group_siblings=[
+            Sibling(entity="Theron", proposed_id="theron-f011"),
+            Sibling(entity="Second Age", proposed_id="second-age-f001"),
+        ],
+        text="Theron's grandfather founded Aldara in the Second Age.",
+        raw_transcript_span=(
+            "Fair-on's grandfather founded all-dara in the Second Age."
+        ),
+        text_corrects_transcript=True,
+        corrections_applied=[
+            Correction(
+                from_="Fair-on",
+                to="Theron",
+                source="global-transcription-correction",
+            ),
+            Correction(
+                from_="all-dara",
+                to="Aldara",
+                source="reading-name-correction",
+            ),
+        ],
+        source_id="yt-abc123",
+        locator="0:04:32-0:04:41",
+        speaker="DM",
+        reading_section="[4:30-8:00] Founding of Aldara",
+        reading_bullet_index=0,
+        status="authoritative",
+        session_date="2026-01-15",
+        section="founding",
+        context_before="So let's talk about the founding of Aldara.",
+        context_after="And that's why the Theron name matters so much now.",
+    )
+    return dataclasses.replace(base, **overrides)
+
+
+class TestRoundTrip:
+    def test_full_round_trip(self, tmp_path: Path) -> None:
+        path = tmp_path / "p.yaml"
+        original = _full_proposal()
+        write(original, path)
+        loaded = read(path)
+        assert loaded == original
+
+    def test_schema_version_first_key(self, tmp_path: Path) -> None:
+        path = tmp_path / "p.yaml"
+        write(_full_proposal(), path)
+        text = path.read_text(encoding="utf-8")
+        assert text.startswith("schema_version: 1")
+
+    def test_from_field_yaml_key_is_from(self, tmp_path: Path) -> None:
+        """`Correction.from_` must serialise to YAML key `from`, not `from_`."""
+        path = tmp_path / "p.yaml"
+        write(_full_proposal(), path)
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        applied = raw["corrections_applied"]
+        assert "from" in applied[0]
+        assert "from_" not in applied[0]
+        assert applied[0]["from"] == "Fair-on"
+
+    def test_from_yaml_key_round_trips(self, tmp_path: Path) -> None:
+        """Read a hand-written `from: X` and confirm it lands on Correction.from_."""
+        path = tmp_path / "p.yaml"
+        data = {
+            "schema_version": 1,
+            "proposal_type": "new_fact",
+            "target_entity": "Aldara",
+            "proposed_id": "aldara-f001",
+            "claim_group_id": "cg-001",
+            "claim_group_siblings": [],
+            "text": "x",
+            "raw_transcript_span": "x",
+            "text_corrects_transcript": False,
+            "corrections_applied": [
+                {"from": "X", "to": "Y", "source": "reading-name-correction"},
+            ],
+            "source_id": "yt-x",
+            "locator": "0:00:01-0:00:02",
+            "speaker": "DM",
+            "status": "authoritative",
+            "session_date": "2026-01-15",
+            "section": "founding",
+            "reading_section": "[0:00-1:00] s",
+            "reading_bullet_index": 0,
+            "context_before": "",
+            "context_after": "",
+        }
+        path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+        loaded = read(path)
+        assert loaded.corrections_applied[0].from_ == "X"
+        assert loaded.corrections_applied[0].to == "Y"
+
+
+class TestOptionalFields:
+    def test_hint_widened_omitted_when_false(self, tmp_path: Path) -> None:
+        path = tmp_path / "p.yaml"
+        write(_full_proposal(hint_widened=False), path)
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert "hint_widened" not in raw
+
+    def test_hint_widened_written_when_true(self, tmp_path: Path) -> None:
+        path = tmp_path / "p.yaml"
+        write(_full_proposal(hint_widened=True), path)
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert raw["hint_widened"] is True
+
+    def test_extractor_flagged_omitted_when_false(self, tmp_path: Path) -> None:
+        path = tmp_path / "p.yaml"
+        write(_full_proposal(), path)
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert "extractor_flagged" not in raw
+        assert "flag_reason" not in raw
+
+    def test_status_reason_omitted_when_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "p.yaml"
+        write(_full_proposal(), path)
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert "status_reason" not in raw
+
+
+class TestValidation:
+    def test_unknown_proposal_type_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "p.yaml"
+        path.write_text(
+            yaml.safe_dump({
+                "schema_version": 1,
+                "proposal_type": "weird",
+                "target_entity": "x",
+                "proposed_id": "x-f001",
+                "claim_group_id": "cg-001",
+                "claim_group_siblings": [],
+                "text": "x",
+                "raw_transcript_span": "x",
+                "text_corrects_transcript": False,
+                "corrections_applied": [],
+                "source_id": "yt-x",
+                "locator": "0:00:01-0:00:02",
+                "speaker": "DM",
+                "status": "authoritative",
+                "session_date": "2026-01-15",
+                "section": "x",
+                "reading_section": "x",
+                "reading_bullet_index": 0,
+                "context_before": "",
+                "context_after": "",
+            }),
+            encoding="utf-8",
+        )
+        with pytest.raises(ProposalError, match="proposal_type"):
+            read(path)
+
+    def test_unknown_correction_source_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "p.yaml"
+        data = {
+            "schema_version": 1,
+            "proposal_type": "new_fact",
+            "target_entity": "Aldara",
+            "proposed_id": "aldara-f001",
+            "claim_group_id": "cg-001",
+            "claim_group_siblings": [],
+            "text": "x",
+            "raw_transcript_span": "x",
+            "text_corrects_transcript": True,
+            "corrections_applied": [
+                {"from": "X", "to": "Y", "source": "made-up-source"},
+            ],
+            "source_id": "yt-x",
+            "locator": "0:00:01-0:00:02",
+            "speaker": "DM",
+            "status": "authoritative",
+            "session_date": "2026-01-15",
+            "section": "x",
+            "reading_section": "x",
+            "reading_bullet_index": 0,
+            "context_before": "",
+            "context_after": "",
+        }
+        path.write_text(yaml.safe_dump(data), encoding="utf-8")
+        with pytest.raises(ProposalError, match="source"):
+            read(path)
+
+    def test_missing_correction_from_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "p.yaml"
+        data = {
+            "schema_version": 1,
+            "proposal_type": "new_fact",
+            "target_entity": "Aldara",
+            "proposed_id": "aldara-f001",
+            "claim_group_id": "cg-001",
+            "claim_group_siblings": [],
+            "text": "x",
+            "raw_transcript_span": "x",
+            "text_corrects_transcript": True,
+            "corrections_applied": [
+                {"to": "Y", "source": "reading-name-correction"},
+            ],
+            "source_id": "yt-x",
+            "locator": "0:00:01-0:00:02",
+            "speaker": "DM",
+            "status": "authoritative",
+            "session_date": "2026-01-15",
+            "section": "x",
+            "reading_section": "x",
+            "reading_bullet_index": 0,
+            "context_before": "",
+            "context_after": "",
+        }
+        path.write_text(yaml.safe_dump(data), encoding="utf-8")
+        with pytest.raises(ProposalError, match="from"):
+            read(path)
+
+    def test_missing_required_field_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "p.yaml"
+        path.write_text(
+            yaml.safe_dump({"schema_version": 1, "proposal_type": "new_fact"}),
+            encoding="utf-8",
+        )
+        with pytest.raises(ProposalError):
+            read(path)
+
+    def test_bad_schema_version_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "p.yaml"
+        path.write_text(
+            yaml.safe_dump({"schema_version": 99, "proposal_type": "new_fact"}),
+            encoding="utf-8",
+        )
+        with pytest.raises(ProposalError):
+            read(path)
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ProposalError, match="file not found"):
+            read(tmp_path / "nope.yaml")

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -98,7 +98,7 @@ def _stub_plan_payload() -> str:
                 "reading_section": "[0:02:00-0:10:00] Founding of Aldara",
                 "reading_bullet_index": 0,
                 "locator": "0:02:30",
-                "locator_hint": "0:02:20-0:02:45",
+                "locator_hint": "0:02:00-0:02:30",
                 "proposed_speaker": "DM",
                 "proposed_status": "authoritative",
                 "proposed_status_reason": None,
@@ -123,6 +123,15 @@ def _stub_plan_payload() -> str:
     })
 
 
+def _stub_extractor_payload() -> str:
+    return json.dumps({
+        "text": "King Theron founded Aldara in the Second Age.",
+        "raw_transcript_span": "King Theron founded Aldara in the Second Age.",
+        "text_corrects_transcript": False,
+        "corrections_applied": [],
+    })
+
+
 def _wire_client_responses(client_mock: MagicMock) -> None:
     """Route client.complete by message content (structure / 1b / planner)."""
 
@@ -138,6 +147,8 @@ def _wire_client_responses(client_mock: MagicMock) -> None:
             text = _stub_structure_payload()
         elif "routing claim bullets" in system_text:
             text = _stub_plan_payload()
+        elif "locate the verbatim transcript span" in system_text:
+            text = _stub_extractor_payload()
         else:
             # stage 1b: find which segment id is in user_text
             for seg_id in ("seg-001", "seg-002"):
@@ -318,6 +329,37 @@ class TestApproveReading:
         _write_user_config(tmp_home, ingested_wiki)
         rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678"))
         assert rc == 1
+
+    def test_writes_proposals_via_stage3(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678"))
+
+        assert rc == 0
+        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        assert proposals_dir.is_dir()
+        # multi-target plan claim → two proposal files (Aldara, Second Age)
+        files = sorted(proposals_dir.glob("*.yaml"))
+        assert len(files) == 2
+        names = {f.name for f in files}
+        assert "aldara-f001.yaml" in names
+        assert "second-age-f001.yaml" in names
+        out = capsys.readouterr().out
+        assert "Extracted 2 proposal" in out
+        assert "(0 flagged)" in out
 
 
 class TestRegenerateReading:

--- a/tests/test_reject_ingest_cmd.py
+++ b/tests/test_reject_ingest_cmd.py
@@ -1,0 +1,355 @@
+"""End-to-end tests for the reject-ingest CLI command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from auto_lorebook import entity_yaml, reading_pipeline
+from auto_lorebook.commands import (
+    approve_reading_cmd,
+    generate_reading_cmd,
+    reject_ingest_cmd,
+    review_cmd,
+)
+from auto_lorebook.openrouter import OpenRouterResponse
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_SRT = (
+    "1\n"
+    "00:00:00,000 --> 00:00:30,000\n"
+    "Welcome to the session.\n"
+    "\n"
+    "2\n"
+    "00:00:30,000 --> 00:02:00,000\n"
+    "Today we talk about Aldara.\n"
+    "\n"
+    "3\n"
+    "00:02:00,000 --> 00:05:00,000\n"
+    "King Theron founded Aldara in the Second Age.\n"
+)
+
+
+def _stub_structure_payload() -> str:
+    return json.dumps({
+        "default_speaker": "DM",
+        "segments": [
+            {
+                "id": "seg-001",
+                "start": "0:00:00",
+                "end": "0:02:00",
+                "title": "Intro",
+                "speaker": "DM",
+            },
+            {
+                "id": "seg-002",
+                "start": "0:02:00",
+                "end": "0:05:00",
+                "title": "Founding of Aldara",
+                "speaker": "DM",
+            },
+        ],
+        "uncertainty_flags": [],
+    })
+
+
+def _seg_bullets_payload(segment_id: str) -> str:
+    per_seg = {
+        "seg-001": [{"text": "Intro bullet", "anchor": "0:00:15"}],
+        "seg-002": [{"text": "King Theron founded Aldara", "anchor": "0:02:30"}],
+    }
+    return json.dumps({"bullets": per_seg.get(segment_id, [])})
+
+
+def _stub_plan_payload() -> str:
+    return json.dumps({
+        "entity_resolutions": [
+            {
+                "mention": "Aldara",
+                "mention_locations": ["[0:02:00-0:05:00] founding"],
+                "resolution": "new",
+                "proposed_entity_name": "Aldara",
+                "proposed_category": "locations",
+                "rationale": "Subject of this lore segment.",
+            },
+        ],
+        "new_entities": [{"name": "Aldara", "category": "locations"}],
+        "planned_claims": [
+            {
+                "claim_group_id": "cg-001",
+                "reading_section": "[0:02:00-0:05:00] Founding of Aldara",
+                "reading_bullet_index": 0,
+                "locator": "0:02:30",
+                "locator_hint": "0:02:00-0:02:30",
+                "proposed_speaker": "DM",
+                "proposed_status": "authoritative",
+                "proposed_status_reason": None,
+                "targets": [
+                    {
+                        "entity": "Aldara",
+                        "entity_state": "new",
+                        "proposed_section": "founding",
+                        "proposed_category": "locations",
+                        "rationale": "Founding fact.",
+                    },
+                ],
+            }
+        ],
+        "unresolved": [],
+    })
+
+
+def _stub_extractor_payload() -> str:
+    return json.dumps({
+        "text": "King Theron founded Aldara in the Second Age.",
+        "raw_transcript_span": "King Theron founded Aldara in the Second Age.",
+        "text_corrects_transcript": False,
+        "corrections_applied": [],
+    })
+
+
+def _wire_client(client_mock: MagicMock) -> None:
+    def side_effect(
+        messages: list[dict[str, str]], **_kw: object
+    ) -> OpenRouterResponse:
+        system = next((m for m in messages if m["role"] == "system"), {}).get(
+            "content", ""
+        )
+        user = next((m for m in messages if m["role"] == "user"), {}).get("content", "")
+        if "segmenting" in system:
+            text = _stub_structure_payload()
+        elif "routing claim bullets" in system:
+            text = _stub_plan_payload()
+        elif "locate the verbatim transcript span" in system:
+            text = _stub_extractor_payload()
+        else:
+            for seg_id in ("seg-001", "seg-002"):
+                if seg_id in user:
+                    text = _seg_bullets_payload(seg_id)
+                    break
+            else:
+                text = json.dumps({"bullets": []})
+        return OpenRouterResponse(text=text, model="m", tokens_in=0, tokens_out=0)
+
+    client_mock.complete.side_effect = side_effect
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def ingested_wiki(tmp_wiki: Path, tmp_home: Path) -> Path:  # noqa: ARG001
+    source_id = "yt-abc12345678"
+    src_dir = tmp_wiki / "sources" / source_id
+    src_dir.mkdir(parents=True)
+    (src_dir / "transcript.en.srt").write_text(_SRT, encoding="utf-8")
+    info = {
+        "schema_version": 1,
+        "source_id": source_id,
+        "source_type": "youtube",
+        "source_url": "https://youtube.com/watch?v=abc",
+        "title": "Session 3",
+        "duration_seconds": 300,
+        "caption_type": "manual",
+        "fetched_at": "2026-04-20T14:35:12Z",
+        "session_date": None,
+        "transcript_filename": "transcript.en.srt",
+        "context": {
+            "perspective": None,
+            "source_nature": None,
+            "setting": None,
+            "speakers": [],
+            "notes": None,
+        },
+    }
+    (src_dir / "info.yaml").write_text(
+        yaml.safe_dump(info, sort_keys=False), encoding="utf-8"
+    )
+    return tmp_wiki
+
+
+def _write_user_config(home: Path, wiki: Path) -> None:
+    cfg_path = home / "config.yaml"
+    cfg_path.write_text(
+        f"""schema_version: 1
+wiki_repo_path: {wiki}
+openrouter:
+  api_key_env: FAKE_OR_KEY
+models:
+  primary: anthropic/claude-sonnet-4-5
+""",
+        encoding="utf-8",
+    )
+
+
+def _args(**kwargs: object) -> argparse.Namespace:
+    return argparse.Namespace(**kwargs)
+
+
+SOURCE_ID = "yt-abc12345678"
+
+
+def _approve_one(
+    tmp_home: Path,
+    wiki: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drive the pipeline to a single approved fact under SOURCE_ID."""
+    _write_user_config(tmp_home, wiki)
+    monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+    client = MagicMock()
+    _wire_client(client)
+    with patch("auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client):
+        generate_reading_cmd.run(_args(source_id=SOURCE_ID))
+        approve_reading_cmd.run(_args(source_id=SOURCE_ID))
+        review_cmd.run(_args(source_id=SOURCE_ID, auto_approve=True))
+
+
+class TestRejectIngest:
+    def test_yes_skips_prompt(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _approve_one(tmp_home, ingested_wiki, monkeypatch)
+        aldara_path = ingested_wiki / "locations" / "aldara.yaml"
+        assert aldara_path.exists()
+        rc = reject_ingest_cmd.run(_args(source_id=SOURCE_ID, yes=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Rejected ingest" in out
+        assert not aldara_path.exists()
+
+    def test_tty_guard_refuses_without_yes(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _approve_one(tmp_home, ingested_wiki, monkeypatch)
+        with patch(
+            "auto_lorebook.commands.reject_ingest._is_interactive",
+            return_value=False,
+        ):
+            rc = reject_ingest_cmd.run(_args(source_id=SOURCE_ID, yes=False))
+        assert rc == 1
+        # Entity still in place — guard prevented the destructive op.
+        assert (ingested_wiki / "locations" / "aldara.yaml").exists()
+
+    def test_confirmation_y_runs(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _approve_one(tmp_home, ingested_wiki, monkeypatch)
+        aldara_path = ingested_wiki / "locations" / "aldara.yaml"
+        with (
+            patch(
+                "auto_lorebook.commands.reject_ingest._is_interactive",
+                return_value=True,
+            ),
+            patch("builtins.input", side_effect=["y"]),
+        ):
+            rc = reject_ingest_cmd.run(_args(source_id=SOURCE_ID, yes=False))
+        assert rc == 0
+        assert not aldara_path.exists()
+
+    def test_confirmation_n_keeps_state(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _approve_one(tmp_home, ingested_wiki, monkeypatch)
+        aldara_path = ingested_wiki / "locations" / "aldara.yaml"
+        with (
+            patch(
+                "auto_lorebook.commands.reject_ingest._is_interactive",
+                return_value=True,
+            ),
+            patch("builtins.input", side_effect=[""]),  # blank == no
+        ):
+            rc = reject_ingest_cmd.run(_args(source_id=SOURCE_ID, yes=False))
+        assert rc == 0
+        assert aldara_path.exists()
+        out = capsys.readouterr().out
+        assert "Cancelled" in out
+
+    def test_end_to_end_cleanup(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _approve_one(tmp_home, ingested_wiki, monkeypatch)
+        # Pre-conditions: stub exists, pending plan + (drained) proposals dir
+        aldara_path = ingested_wiki / "locations" / "aldara.yaml"
+        plan_path = reading_pipeline.pending_plan_path(SOURCE_ID)
+        proposals_dir = reading_pipeline.pending_proposals_dir(SOURCE_ID)
+        sources_dir = ingested_wiki / "sources" / SOURCE_ID
+        assert aldara_path.exists()
+        assert plan_path.exists()
+        # proposals dir exists but is empty (auto-approve drained it)
+        assert proposals_dir.is_dir()
+        assert sources_dir.is_dir()
+
+        rc = reject_ingest_cmd.run(_args(source_id=SOURCE_ID, yes=True))
+        assert rc == 0
+        assert not aldara_path.exists()
+        assert not plan_path.exists()
+        assert not proposals_dir.exists()
+        # sources/ untouched
+        assert (sources_dir / "info.yaml").exists()
+        assert (sources_dir / "transcript.en.srt").exists()
+        # reading-stage pending artifacts survive
+        assert reading_pipeline.pending_structure_path(SOURCE_ID).exists()
+
+    def test_nothing_to_reject(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        # No ingest has run; nothing to reject.
+        rc = reject_ingest_cmd.run(_args(source_id="ingest-that-never-was", yes=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Nothing to reject" in out
+
+    def test_proper_entity_yaml_round_trip(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """After yes-rejection, no entity YAMLs survive that referenced this ingest."""
+        _approve_one(tmp_home, ingested_wiki, monkeypatch)
+        rc = reject_ingest_cmd.run(_args(source_id=SOURCE_ID, yes=True))
+        assert rc == 0
+        # Walk every category dir; assert nothing refers to SOURCE_ID
+        for cat in entity_yaml.CATEGORIES:
+            for path in (ingested_wiki / cat).glob("*.yaml"):
+                e = entity_yaml.read(path)
+                assert e.created_by_ingest != SOURCE_ID
+                for f in e.facts:
+                    assert f.get("created_by_ingest") != SOURCE_ID
+                for a in e.aliases:
+                    assert a.added_by_ingest != SOURCE_ID

--- a/tests/test_replan_cmd.py
+++ b/tests/test_replan_cmd.py
@@ -1,0 +1,299 @@
+"""End-to-end tests for the replan CLI command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from auto_lorebook import entity_yaml, reading_pipeline
+from auto_lorebook.commands import (
+    approve_reading_cmd,
+    generate_reading_cmd,
+    replan_cmd,
+    review_cmd,
+)
+from auto_lorebook.openrouter import OpenRouterResponse
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_SRT = (
+    "1\n"
+    "00:00:00,000 --> 00:00:30,000\n"
+    "Welcome to the session.\n"
+    "\n"
+    "2\n"
+    "00:00:30,000 --> 00:02:00,000\n"
+    "Today we talk about Aldara.\n"
+    "\n"
+    "3\n"
+    "00:02:00,000 --> 00:05:00,000\n"
+    "King Theron founded Aldara in the Second Age.\n"
+)
+
+
+def _stub_structure_payload() -> str:
+    return json.dumps({
+        "default_speaker": "DM",
+        "segments": [
+            {
+                "id": "seg-001",
+                "start": "0:00:00",
+                "end": "0:02:00",
+                "title": "Intro",
+                "speaker": "DM",
+            },
+            {
+                "id": "seg-002",
+                "start": "0:02:00",
+                "end": "0:05:00",
+                "title": "Founding of Aldara",
+                "speaker": "DM",
+            },
+        ],
+        "uncertainty_flags": [],
+    })
+
+
+def _seg_bullets_payload(segment_id: str) -> str:
+    per_seg = {
+        "seg-001": [{"text": "Intro bullet", "anchor": "0:00:15"}],
+        "seg-002": [{"text": "King Theron founded Aldara", "anchor": "0:02:30"}],
+    }
+    return json.dumps({"bullets": per_seg.get(segment_id, [])})
+
+
+def _stub_plan_payload() -> str:
+    return json.dumps({
+        "entity_resolutions": [
+            {
+                "mention": "Aldara",
+                "mention_locations": ["[0:02:00-0:05:00] founding"],
+                "resolution": "new",
+                "proposed_entity_name": "Aldara",
+                "proposed_category": "locations",
+                "rationale": "Subject of this lore segment.",
+            },
+        ],
+        "new_entities": [{"name": "Aldara", "category": "locations"}],
+        "planned_claims": [
+            {
+                "claim_group_id": "cg-001",
+                "reading_section": "[0:02:00-0:05:00] Founding of Aldara",
+                "reading_bullet_index": 0,
+                "locator": "0:02:30",
+                "locator_hint": "0:02:00-0:02:30",
+                "proposed_speaker": "DM",
+                "proposed_status": "authoritative",
+                "proposed_status_reason": None,
+                "targets": [
+                    {
+                        "entity": "Aldara",
+                        "entity_state": "new",
+                        "proposed_section": "founding",
+                        "proposed_category": "locations",
+                        "rationale": "Founding fact.",
+                    },
+                ],
+            }
+        ],
+        "unresolved": [],
+    })
+
+
+def _stub_extractor_payload() -> str:
+    return json.dumps({
+        "text": "King Theron founded Aldara in the Second Age.",
+        "raw_transcript_span": "King Theron founded Aldara in the Second Age.",
+        "text_corrects_transcript": False,
+        "corrections_applied": [],
+    })
+
+
+def _wire_client(client_mock: MagicMock) -> None:
+    def side_effect(
+        messages: list[dict[str, str]], **_kw: object
+    ) -> OpenRouterResponse:
+        system = next((m for m in messages if m["role"] == "system"), {}).get(
+            "content", ""
+        )
+        user = next((m for m in messages if m["role"] == "user"), {}).get("content", "")
+        if "segmenting" in system:
+            text = _stub_structure_payload()
+        elif "routing claim bullets" in system:
+            text = _stub_plan_payload()
+        elif "locate the verbatim transcript span" in system:
+            text = _stub_extractor_payload()
+        else:
+            for seg_id in ("seg-001", "seg-002"):
+                if seg_id in user:
+                    text = _seg_bullets_payload(seg_id)
+                    break
+            else:
+                text = json.dumps({"bullets": []})
+        return OpenRouterResponse(text=text, model="m", tokens_in=0, tokens_out=0)
+
+    client_mock.complete.side_effect = side_effect
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def ingested_wiki(tmp_wiki: Path, tmp_home: Path) -> Path:  # noqa: ARG001
+    source_id = "yt-abc12345678"
+    src_dir = tmp_wiki / "sources" / source_id
+    src_dir.mkdir(parents=True)
+    (src_dir / "transcript.en.srt").write_text(_SRT, encoding="utf-8")
+    info = {
+        "schema_version": 1,
+        "source_id": source_id,
+        "source_type": "youtube",
+        "source_url": "https://youtube.com/watch?v=abc",
+        "title": "Session 3",
+        "duration_seconds": 300,
+        "caption_type": "manual",
+        "fetched_at": "2026-04-20T14:35:12Z",
+        "session_date": None,
+        "transcript_filename": "transcript.en.srt",
+        "context": {
+            "perspective": None,
+            "source_nature": None,
+            "setting": None,
+            "speakers": [],
+            "notes": None,
+        },
+    }
+    (src_dir / "info.yaml").write_text(
+        yaml.safe_dump(info, sort_keys=False), encoding="utf-8"
+    )
+    return tmp_wiki
+
+
+def _write_user_config(home: Path, wiki: Path) -> None:
+    cfg_path = home / "config.yaml"
+    cfg_path.write_text(
+        f"""schema_version: 1
+wiki_repo_path: {wiki}
+openrouter:
+  api_key_env: FAKE_OR_KEY
+models:
+  primary: anthropic/claude-sonnet-4-5
+""",
+        encoding="utf-8",
+    )
+
+
+def _args(**kwargs: object) -> argparse.Namespace:
+    return argparse.Namespace(**kwargs)
+
+
+SOURCE_ID = "yt-abc12345678"
+
+
+class TestReplan:
+    def test_preserves_approved_facts(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_client(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id=SOURCE_ID))
+            approve_reading_cmd.run(_args(source_id=SOURCE_ID))
+            review_cmd.run(_args(source_id=SOURCE_ID, auto_approve=True))
+            # Now the entity stub exists and the proposals dir is empty.
+            aldara_path = ingested_wiki / "locations" / "aldara.yaml"
+            facts_before = entity_yaml.read(aldara_path).facts
+            assert len(facts_before) == 1
+            rc = replan_cmd.run(_args(source_id=SOURCE_ID))
+        assert rc == 0
+        # Approved fact survives
+        facts_after = entity_yaml.read(aldara_path).facts
+        assert facts_after == facts_before
+        # Proposals dir repopulated by the new extract — Aldara is now
+        # `existing` to the planner so we won't get a fresh aldara-f001.
+        # This mocked plan still proposes `new` though, so the test just
+        # asserts proposals exist (count depends on prompt response). For
+        # a stricter assertion, mock the planner to skip Aldara.
+        proposals_dir = reading_pipeline.pending_proposals_dir(SOURCE_ID)
+        assert proposals_dir.exists()
+
+    def test_no_stale_proposal_files(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_client(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id=SOURCE_ID))
+            approve_reading_cmd.run(_args(source_id=SOURCE_ID))
+            # Drop a stale file into the proposals dir as if from an earlier
+            # run that we want overwritten.
+            proposals_dir = reading_pipeline.pending_proposals_dir(SOURCE_ID)
+            (proposals_dir / "stale-f999.yaml").write_text(
+                "schema_version: 1\nproposal_type: new_fact\n",
+                encoding="utf-8",
+            )
+            assert (proposals_dir / "stale-f999.yaml").exists()
+            replan_cmd.run(_args(source_id=SOURCE_ID))
+        # After replan the stale file is gone (extract rmtrees the dir).
+        assert not (proposals_dir / "stale-f999.yaml").exists()
+
+    def test_errors_when_reading_not_approved(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+        # No generate-reading / approve-reading run.
+        rc = replan_cmd.run(_args(source_id=SOURCE_ID))
+        assert rc == 1
+
+    def test_errors_when_structure_missing(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_client(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id=SOURCE_ID))
+            approve_reading_cmd.run(_args(source_id=SOURCE_ID))
+            # Remove structure.yaml to break the prerequisite.
+            reading_pipeline.pending_structure_path(SOURCE_ID).unlink()
+            rc = replan_cmd.run(_args(source_id=SOURCE_ID))
+        assert rc == 1

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,996 @@
+"""Tests for review.py — Stage 4 (review) engine."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import (
+    entity_yaml,
+    plan_yaml,
+    proposal_yaml,
+    reading_pipeline,
+    review,
+)
+from auto_lorebook.review import (
+    ApproveDecision,
+    Decision,
+    EditDecision,
+    ProposalView,
+    RejectDecision,
+    ReviewResult,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cfg(
+    tmp_path: Path, tmp_wiki: Path, monkeypatch: pytest.MonkeyPatch
+) -> cfg_mod.Config:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    return cfg_mod.Config(wiki_repo_path=tmp_wiki)
+
+
+def _write_info(wiki: Path, source_id: str = "yt-x") -> None:
+    src = wiki / "sources" / source_id
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "info.yaml").write_text(
+        yaml.safe_dump({
+            "schema_version": 1,
+            "source_id": source_id,
+            "source_type": "youtube",
+            "source_url": "https://example.com/v?x=1",
+            "title": "Test source",
+            "duration_seconds": 600,
+            "fetched_at": "2026-04-20T00:00:00Z",
+            "session_date": "2026-04-15",
+            "transcript_filename": "transcript.en.srt",
+            "context": {},
+        }),
+        encoding="utf-8",
+    )
+
+
+def _write_plan(
+    wiki: Path,  # noqa: ARG001
+    source_id: str,
+    *,
+    new_entities: list[plan_yaml.NewEntityProposal] | None = None,
+    entity_resolutions: list[plan_yaml.EntityResolution] | None = None,
+    planned_claims: list[plan_yaml.PlannedClaim] | None = None,
+) -> None:
+    plan = plan_yaml.Plan(
+        source_id=source_id,
+        planned_at="2026-04-20T00:00:00Z",
+        new_entities=new_entities or [],
+        entity_resolutions=entity_resolutions or [],
+        planned_claims=planned_claims or [],
+    )
+    plan_yaml.write(plan, reading_pipeline.pending_plan_path(source_id))
+
+
+def _write_proposal(source_id: str, p: proposal_yaml.Proposal) -> None:
+    path = reading_pipeline.pending_proposal_path(source_id, p.proposed_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    proposal_yaml.write(p, path)
+
+
+def _make_proposal(
+    *,
+    target: str,
+    proposed_id: str,
+    cg: str = "cg-001",
+    proposal_type: str = "new_entity_with_facts",
+    siblings: list[proposal_yaml.Sibling] | None = None,
+    text: str = "Aldara was founded in the Second Age.",
+    locator: str = "0:00:08-0:00:18",
+    section: str = "founding",
+) -> proposal_yaml.Proposal:
+    return proposal_yaml.Proposal(
+        proposal_type=proposal_type,
+        target_entity=target,
+        proposed_id=proposed_id,
+        claim_group_id=cg,
+        claim_group_siblings=siblings or [],
+        text=text,
+        raw_transcript_span=text,
+        text_corrects_transcript=False,
+        corrections_applied=[],
+        source_id="yt-x",
+        locator=locator,
+        speaker="DM",
+        reading_section="[0:00:00-0:00:30] Founding",
+        reading_bullet_index=0,
+        status="authoritative",
+        status_reason=None,
+        session_date="2026-04-15",
+        section=section,
+        context_before="",
+        context_after="",
+    )
+
+
+def _make_claim(
+    *,
+    cg: str = "cg-001",
+    targets: list[plan_yaml.ClaimTarget],
+) -> plan_yaml.PlannedClaim:
+    return plan_yaml.PlannedClaim(
+        claim_group_id=cg,
+        reading_section="[0:00:00-0:00:30] Founding",
+        reading_bullet_index=0,
+        locator="0:00:08",
+        locator_hint="0:00:00-0:00:30",
+        proposed_speaker="DM",
+        proposed_status="authoritative",
+        proposed_status_reason=None,
+        targets=targets,
+    )
+
+
+class ScriptedReviewer:
+    """Reviewer that yields scripted decisions and alias confirmations."""
+
+    by_label = "human-review"
+
+    def __init__(
+        self,
+        decisions: list[Decision],
+        alias_responses: list[bool] | None = None,
+    ) -> None:
+        self._decisions = list(decisions)
+        self._alias_responses = list(alias_responses or [])
+        self.decided: list[ProposalView] = []
+        self.alias_calls: list[tuple[str, str]] = []
+
+    def decide(self, view: ProposalView) -> Decision:
+        self.decided.append(view)
+        if not self._decisions:
+            msg = "ScriptedReviewer ran out of decisions"
+            raise AssertionError(msg)
+        return self._decisions.pop(0)
+
+    def confirm_alias(self, entity: str, mention: str) -> bool:
+        self.alias_calls.append((entity, mention))
+        if not self._alias_responses:
+            return False
+        return self._alias_responses.pop(0)
+
+
+def _seed_existing_entity(
+    wiki: Path,
+    *,
+    name: str = "Aldara",
+    category: str = "locations",
+    slug: str = "aldara",
+    facts: list[dict] | None = None,
+) -> None:
+    e = entity_yaml.Entity(
+        entity=name,
+        category=category,
+        slug=slug,
+        created_at="2026-01-01T00:00:00Z",
+        created_by_ingest="prior-ingest",
+        updated_at="2026-01-01T00:00:00Z",
+        facts=facts or [],
+    )
+    entity_yaml.write(e, wiki / category / f"{slug}.yaml")
+
+
+# ---------------------------------------------------------------------------
+# Walk order
+# ---------------------------------------------------------------------------
+
+
+class TestSortedProposals:
+    def test_groups_siblings_in_target_order(self, cfg: cfg_mod.Config) -> None:
+        """Plan order beats lex sort: targets ordered as in claim.targets."""
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        # cg-001: War of the Dusk first, then Aldara — slug-sort would invert.
+        claim1 = _make_claim(
+            cg="cg-001",
+            targets=[
+                plan_yaml.ClaimTarget(
+                    entity="War of the Dusk",
+                    entity_state="new",
+                    proposed_section="overview",
+                    proposed_category="events",
+                ),
+                plan_yaml.ClaimTarget(
+                    entity="Aldara",
+                    entity_state="new",
+                    proposed_section="founding",
+                    proposed_category="locations",
+                ),
+            ],
+        )
+        claim2 = _make_claim(
+            cg="cg-002",
+            targets=[
+                plan_yaml.ClaimTarget(
+                    entity="Theron",
+                    entity_state="new",
+                    proposed_section="lineage",
+                    proposed_category="characters",
+                ),
+            ],
+        )
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(name="War of the Dusk", category="events"),
+                plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
+                plan_yaml.NewEntityProposal(name="Theron", category="characters"),
+            ],
+            planned_claims=[claim1, claim2],
+        )
+        for p in [
+            _make_proposal(
+                target="War of the Dusk", proposed_id="war-of-the-dusk-f001"
+            ),
+            _make_proposal(target="Aldara", proposed_id="aldara-f001"),
+            _make_proposal(target="Theron", proposed_id="theron-f001", cg="cg-002"),
+        ]:
+            _write_proposal(source_id, p)
+
+        plan = plan_yaml.read(reading_pipeline.pending_plan_path(source_id))
+        ordered = review.sorted_proposals(plan, source_id)
+        assert [p.target_entity for p in ordered] == [
+            "War of the Dusk",
+            "Aldara",
+            "Theron",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Fact dict shape
+# ---------------------------------------------------------------------------
+
+
+class TestFactDict:
+    def test_plain_approve(self) -> None:
+        p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
+        fact = review.proposal_to_fact_dict(
+            p, edited_text=None, ingest_id="yt-x", by_label="human-review"
+        )
+        assert fact["id"] == "aldara-f001"
+        assert fact["text"] == p.text
+        assert fact["edited_by_human"] is False
+        assert fact["edited_at"] is None
+        assert fact["text_source"] is None
+        assert fact["created_by_ingest"] == "yt-x"
+        assert fact["section"] == "founding"
+        assert fact["claim_group_id"] == "cg-001"
+        assert fact["status_history"][0]["by"] == "human-review"
+        assert fact["status_history"][0]["status"] == "authoritative"
+
+    def test_edit_path_preserves_original_in_text_source(self) -> None:
+        p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
+        fact = review.proposal_to_fact_dict(
+            p,
+            edited_text="Aldara was founded earlier than that.",
+            ingest_id="yt-x",
+            by_label="human-review",
+        )
+        assert fact["text"] == "Aldara was founded earlier than that."
+        assert fact["text_source"] == p.text
+        assert fact["edited_by_human"] is True
+        assert fact["edited_at"] is not None
+        # human edit forces text_corrects_transcript even if original was False
+        assert fact["text_corrects_transcript"] is True
+
+    def test_by_label_passed_through(self) -> None:
+        p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
+        fact = review.proposal_to_fact_dict(
+            p, edited_text=None, ingest_id="yt-x", by_label="auto-approve"
+        )
+        assert fact["status_history"][0]["by"] == "auto-approve"
+
+
+# ---------------------------------------------------------------------------
+# Existing-entity approve
+# ---------------------------------------------------------------------------
+
+
+class TestExistingEntityApprove:
+    def test_appends_fact_and_deletes_proposal(self, cfg: cfg_mod.Config) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        _seed_existing_entity(cfg.wiki_repo_path, name="Aldara", slug="aldara")
+
+        proposal = _make_proposal(
+            target="Aldara", proposed_id="aldara-f001", proposal_type="new_fact"
+        )
+        _write_proposal(source_id, proposal)
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            entity_resolutions=[
+                plan_yaml.EntityResolution(
+                    mention="Aldara",
+                    resolution="existing",
+                    matched_entity="Aldara",
+                ),
+            ],
+            planned_claims=[
+                _make_claim(
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="existing",
+                            proposed_section="founding",
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        result = review.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=ScriptedReviewer([ApproveDecision()]),
+        )
+        assert result.approved == 1
+        assert result.rejected == 0
+        # proposal file gone
+        assert not reading_pipeline.pending_proposal_path(
+            source_id, "aldara-f001"
+        ).exists()
+        # entity grew by one fact
+        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        assert len(e.facts) == 1
+        assert e.facts[0]["id"] == "aldara-f001"
+
+
+# ---------------------------------------------------------------------------
+# Idempotent re-approval guard
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotentGuard:
+    def test_does_not_double_append(self, cfg: cfg_mod.Config) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        _seed_existing_entity(
+            cfg.wiki_repo_path,
+            name="Aldara",
+            slug="aldara",
+            facts=[{"id": "aldara-f001", "text": "previously approved."}],
+        )
+
+        proposal = _make_proposal(
+            target="Aldara", proposed_id="aldara-f001", proposal_type="new_fact"
+        )
+        _write_proposal(source_id, proposal)
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            planned_claims=[
+                _make_claim(
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="existing",
+                            proposed_section="founding",
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        result = review.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=ScriptedReviewer([ApproveDecision()]),
+        )
+        # neither approved nor rejected counter increments — idempotent skip
+        assert result.approved == 0
+        # proposal file still cleaned up
+        assert not reading_pipeline.pending_proposal_path(
+            source_id, "aldara-f001"
+        ).exists()
+        # only the original fact remains
+        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        assert len(e.facts) == 1
+
+
+# ---------------------------------------------------------------------------
+# New-entity stub creation + alias confirmation
+# ---------------------------------------------------------------------------
+
+
+class TestNewEntityStub:
+    def test_creates_stub_with_timestamps(self, cfg: cfg_mod.Config) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        proposal = _make_proposal(target="Aldara", proposed_id="aldara-f001")
+        _write_proposal(source_id, proposal)
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
+            ],
+            planned_claims=[
+                _make_claim(
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        result = review.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=ScriptedReviewer([ApproveDecision()]),
+        )
+        assert result.approved == 1
+        path = cfg.wiki_repo_path / "locations" / "aldara.yaml"
+        assert path.exists()
+        e = entity_yaml.read(path)
+        assert e.entity == "Aldara"
+        assert e.created_at is not None
+        assert e.created_by_ingest == "yt-x"
+        assert e.updated_at == e.created_at  # same timestamp on creation
+        assert e.aliases == []
+        assert len(e.facts) == 1
+
+    def test_first_approval_alias_source_is_stub_creation(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        proposal = _make_proposal(target="Aldara", proposed_id="aldara-f001")
+        _write_proposal(source_id, proposal)
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(
+                    name="Aldara",
+                    category="locations",
+                    aliases_suggested=["the Realm"],
+                ),
+            ],
+            planned_claims=[
+                _make_claim(
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        result = review.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=ScriptedReviewer([ApproveDecision()], alias_responses=[True]),
+        )
+        assert result.approved == 1
+        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        assert len(e.aliases) == 1
+        assert e.aliases[0].name == "the Realm"
+        assert e.aliases[0].source == "stub-creation"
+        assert e.aliases[0].added_by_ingest == "yt-x"
+
+    def test_existing_entity_alias_source_is_alias_confirmation(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        _seed_existing_entity(cfg.wiki_repo_path, name="Aldara", slug="aldara")
+        proposal = _make_proposal(
+            target="Aldara", proposed_id="aldara-f001", proposal_type="new_fact"
+        )
+        _write_proposal(source_id, proposal)
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            entity_resolutions=[
+                plan_yaml.EntityResolution(
+                    mention="the Aldaran Realm",
+                    resolution="existing",
+                    matched_entity="Aldara",
+                    suggested_aliases_to_add=["the Aldaran Realm"],
+                ),
+            ],
+            planned_claims=[
+                _make_claim(
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="existing",
+                            proposed_section="founding",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        review.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=ScriptedReviewer([ApproveDecision()], alias_responses=[True]),
+        )
+        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        assert len(e.aliases) == 1
+        assert e.aliases[0].source == "alias-confirmation"
+
+
+# ---------------------------------------------------------------------------
+# Reject
+# ---------------------------------------------------------------------------
+
+
+class TestReject:
+    def test_deletes_proposal_without_touching_entity(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        _seed_existing_entity(cfg.wiki_repo_path, name="Aldara", slug="aldara")
+        proposal = _make_proposal(
+            target="Aldara", proposed_id="aldara-f001", proposal_type="new_fact"
+        )
+        _write_proposal(source_id, proposal)
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            planned_claims=[
+                _make_claim(
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="existing",
+                            proposed_section="founding",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        result = review.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=ScriptedReviewer([RejectDecision()]),
+        )
+        assert result.rejected == 1
+        assert result.approved == 0
+        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        assert e.facts == []
+        assert not reading_pipeline.pending_proposal_path(
+            source_id, "aldara-f001"
+        ).exists()
+
+
+# ---------------------------------------------------------------------------
+# Multi-target dedup at review time
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTargetDedup:
+    def test_two_proposals_share_one_stub(self, cfg: cfg_mod.Config) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        # Two new-entity proposals in the same claim group both targeting Aldara.
+        # (Multi-target onto a brand-new entity is rare but legal.)
+        # In practice they'd be different entities; we contrive same-target to
+        # exercise the dedup path.
+        siblings = [
+            proposal_yaml.Sibling(entity="Aldara", proposed_id="aldara-f002"),
+        ]
+        siblings_back = [
+            proposal_yaml.Sibling(entity="Aldara", proposed_id="aldara-f001"),
+        ]
+        _write_proposal(
+            source_id,
+            _make_proposal(
+                target="Aldara",
+                proposed_id="aldara-f001",
+                cg="cg-001",
+                siblings=siblings,
+            ),
+        )
+        _write_proposal(
+            source_id,
+            _make_proposal(
+                target="Aldara",
+                proposed_id="aldara-f002",
+                cg="cg-002",
+                siblings=siblings_back,
+            ),
+        )
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg="cg-001",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+                _make_claim(
+                    cg="cg-002",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="lore",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        review.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=ScriptedReviewer([ApproveDecision(), ApproveDecision()]),
+        )
+        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        assert len(e.facts) == 2
+        assert {f["id"] for f in e.facts} == {"aldara-f001", "aldara-f002"}
+        # created_by_ingest stays as the first-approval ingest
+        assert e.created_by_ingest == "yt-x"
+        # updated_at advanced past created_at after the second append
+        assert e.updated_at is not None
+
+
+# ---------------------------------------------------------------------------
+# `created_earlier_in_session` annotation
+# ---------------------------------------------------------------------------
+
+
+class TestCreatedEarlierInSession:
+    def test_second_proposal_view_marks_session_creation(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        _write_proposal(
+            source_id,
+            _make_proposal(target="Aldara", proposed_id="aldara-f001", cg="cg-001"),
+        )
+        _write_proposal(
+            source_id,
+            _make_proposal(target="Aldara", proposed_id="aldara-f002", cg="cg-002"),
+        )
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg="cg-001",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+                _make_claim(
+                    cg="cg-002",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="lore",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        scripted = ScriptedReviewer([ApproveDecision(), ApproveDecision()])
+        review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        # First view: no on-disk entity yet
+        assert scripted.decided[0].created_earlier_in_session is False
+        # Second view: stub was created in this same run
+        assert scripted.decided[1].created_earlier_in_session is True
+
+
+# ---------------------------------------------------------------------------
+# Sibling alias dedup
+# ---------------------------------------------------------------------------
+
+
+class TestSiblingAliasDedup:
+    def test_second_sibling_skips_already_merged_alias(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        _write_proposal(
+            source_id,
+            _make_proposal(target="Aldara", proposed_id="aldara-f001", cg="cg-001"),
+        )
+        _write_proposal(
+            source_id,
+            _make_proposal(target="Aldara", proposed_id="aldara-f002", cg="cg-002"),
+        )
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(
+                    name="Aldara",
+                    category="locations",
+                    aliases_suggested=["the Realm"],
+                ),
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg="cg-001",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+                _make_claim(
+                    cg="cg-002",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="lore",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        scripted = ScriptedReviewer(
+            [ApproveDecision(), ApproveDecision()], alias_responses=[True]
+        )
+        review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        # Only one alias prompt fired — the second sibling saw the alias as
+        # already merged.
+        assert len(scripted.alias_calls) == 1
+        # And only one alias landed.
+        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        assert len(e.aliases) == 1
+
+
+# ---------------------------------------------------------------------------
+# In-memory index refresh (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+class TestIndexRefresh:
+    def test_sibling_b_resolves_via_index_after_a_creates_stub(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        # A targets new entity Aldara; B is a `new_fact` proposal claiming
+        # Aldara as existing. B can only succeed if the index refresh after A's
+        # approval surfaces Aldara as existing.
+        _write_proposal(
+            source_id,
+            _make_proposal(
+                target="Aldara",
+                proposed_id="aldara-f001",
+                cg="cg-001",
+                proposal_type="new_entity_with_facts",
+            ),
+        )
+        _write_proposal(
+            source_id,
+            _make_proposal(
+                target="Aldara",
+                proposed_id="aldara-f002",
+                cg="cg-002",
+                proposal_type="new_fact",
+            ),
+        )
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg="cg-001",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+                _make_claim(
+                    cg="cg-002",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="existing",
+                            proposed_section="lore",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        result = review.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=ScriptedReviewer([ApproveDecision(), ApproveDecision()]),
+        )
+        assert result.approved == 2
+        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        assert len(e.facts) == 2
+
+
+# ---------------------------------------------------------------------------
+# KeyboardInterrupt resume + empty dir
+# ---------------------------------------------------------------------------
+
+
+class _RaisingReviewer:
+    by_label = "human-review"
+
+    def __init__(self, raise_on: int) -> None:
+        self.raise_on = raise_on
+        self.calls = 0
+
+    def decide(self, view: ProposalView) -> Decision:  # noqa: ARG002
+        self.calls += 1
+        if self.calls == self.raise_on:
+            raise KeyboardInterrupt
+        return ApproveDecision()
+
+    def confirm_alias(self, entity: str, mention: str) -> bool:  # noqa: ARG002
+        return False
+
+
+class TestResumeAndEmpty:
+    def test_keyboard_interrupt_leaves_remaining_files(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        for i in range(1, 4):
+            _write_proposal(
+                source_id,
+                _make_proposal(
+                    target=f"E{i}",
+                    proposed_id=f"e{i}-f001",
+                    cg=f"cg-{i:03d}",
+                ),
+            )
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(name=f"E{i}", category="concepts")
+                for i in range(1, 4)
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg=f"cg-{i:03d}",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity=f"E{i}",
+                            entity_state="new",
+                            proposed_section="overview",
+                            proposed_category="concepts",
+                        ),
+                    ],
+                )
+                for i in range(1, 4)
+            ],
+        )
+        with pytest.raises(KeyboardInterrupt):
+            review.run(
+                cfg=cfg,
+                source_id=source_id,
+                reviewer=_RaisingReviewer(raise_on=2),
+            )
+        # First proposal approved → file gone
+        assert not reading_pipeline.pending_proposal_path(source_id, "e1-f001").exists()
+        # Second + third still pending
+        assert reading_pipeline.pending_proposal_path(source_id, "e2-f001").exists()
+        assert reading_pipeline.pending_proposal_path(source_id, "e3-f001").exists()
+
+    def test_empty_proposals_dir_returns_zeroed_result(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        _write_plan(cfg.wiki_repo_path, source_id)
+        result = review.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=ScriptedReviewer([]),
+        )
+        assert result == ReviewResult()
+
+
+# ---------------------------------------------------------------------------
+# Edit path end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestEditPath:
+    def test_edit_writes_text_source_and_increments_edited_counter(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        _seed_existing_entity(cfg.wiki_repo_path, name="Aldara", slug="aldara")
+        proposal = _make_proposal(
+            target="Aldara",
+            proposed_id="aldara-f001",
+            proposal_type="new_fact",
+            text="Original LLM text.",
+        )
+        _write_proposal(source_id, proposal)
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            planned_claims=[
+                _make_claim(
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="existing",
+                            proposed_section="founding",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        result = review.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=ScriptedReviewer([EditDecision(new_text="Edited by hand.")]),
+        )
+        assert result.edited == 1
+        assert result.approved == 0
+        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        assert e.facts[0]["text"] == "Edited by hand."
+        assert e.facts[0]["text_source"] == "Original LLM text."
+        assert e.facts[0]["edited_by_human"] is True

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -265,7 +265,7 @@ class TestFactDict:
     def test_plain_approve(self) -> None:
         p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
         fact = review.proposal_to_fact_dict(
-            p, edited_text=None, ingest_id="yt-x", by_label="human-review"
+            p, edits=None, ingest_id="yt-x", by_label="human-review"
         )
         assert fact["id"] == "aldara-f001"
         assert fact["text"] == p.text
@@ -282,7 +282,7 @@ class TestFactDict:
         p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
         fact = review.proposal_to_fact_dict(
             p,
-            edited_text="Aldara was founded earlier than that.",
+            edits=EditDecision(new_text="Aldara was founded earlier than that."),
             ingest_id="yt-x",
             by_label="human-review",
         )
@@ -296,9 +296,62 @@ class TestFactDict:
     def test_by_label_passed_through(self) -> None:
         p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
         fact = review.proposal_to_fact_dict(
-            p, edited_text=None, ingest_id="yt-x", by_label="auto-approve"
+            p, edits=None, ingest_id="yt-x", by_label="auto-approve"
         )
         assert fact["status_history"][0]["by"] == "auto-approve"
+
+    def test_speaker_status_section_overrides(self) -> None:
+        p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
+        fact = review.proposal_to_fact_dict(
+            p,
+            edits=EditDecision(
+                new_speaker="Player-Thorin",
+                new_status="hearsay",
+                new_status_reason="Speaker is a tavern rumor source.",
+                new_section="legends",
+            ),
+            ingest_id="yt-x",
+            by_label="human-review",
+        )
+        assert fact["speaker"] == "Player-Thorin"
+        assert fact["status"] == "hearsay"
+        assert fact["status_reason"] == "Speaker is a tavern rumor source."
+        assert fact["section"] == "legends"
+        # status_history reflects the *edited* status, not the proposal's.
+        assert fact["status_history"][0]["status"] == "hearsay"
+        assert (
+            fact["status_history"][0]["reason"] == "Speaker is a tavern rumor source."
+        )
+        # Text untouched, so edited_by_human stays false.
+        assert fact["edited_by_human"] is False
+        assert fact["text_source"] is None
+
+    def test_partial_edit_only_changes_specified_fields(self) -> None:
+        p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
+        fact = review.proposal_to_fact_dict(
+            p,
+            edits=EditDecision(new_status="trustworthy"),
+            ingest_id="yt-x",
+            by_label="human-review",
+        )
+        assert fact["status"] == "trustworthy"
+        assert fact["speaker"] == p.speaker  # untouched
+        assert fact["section"] == p.section  # untouched
+        assert fact["text"] == p.text  # untouched
+
+    def test_noop_edit_keeps_proposal_values(self) -> None:
+        p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
+        fact = review.proposal_to_fact_dict(
+            p,
+            edits=EditDecision(),  # no overrides
+            ingest_id="yt-x",
+            by_label="human-review",
+        )
+        assert fact["text"] == p.text
+        assert fact["speaker"] == p.speaker
+        assert fact["status"] == p.status
+        assert fact["section"] == p.section
+        assert fact["edited_by_human"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_review_cmd.py
+++ b/tests/test_review_cmd.py
@@ -1,0 +1,286 @@
+"""End-to-end tests for the review CLI command.
+
+Drives the full pipeline (generate-reading → approve-reading → review)
+with a mocked OpenRouter client so the proposals exist on disk before
+review runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from auto_lorebook import entity_yaml
+from auto_lorebook.commands import (
+    approve_reading_cmd,
+    generate_reading_cmd,
+    review_cmd,
+)
+from auto_lorebook.openrouter import OpenRouterResponse
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_SRT = (
+    "1\n"
+    "00:00:00,000 --> 00:00:30,000\n"
+    "Welcome to the session.\n"
+    "\n"
+    "2\n"
+    "00:00:30,000 --> 00:02:00,000\n"
+    "Today we talk about Aldara.\n"
+    "\n"
+    "3\n"
+    "00:02:00,000 --> 00:05:00,000\n"
+    "King Theron founded Aldara in the Second Age.\n"
+    "\n"
+    "4\n"
+    "00:05:00,000 --> 00:10:00,000\n"
+    "The war followed. Many died.\n"
+)
+
+
+def _stub_structure_payload() -> str:
+    return json.dumps({
+        "default_speaker": "DM",
+        "segments": [
+            {
+                "id": "seg-001",
+                "start": "0:00:00",
+                "end": "0:02:00",
+                "title": "Intro",
+                "speaker": "DM",
+            },
+            {
+                "id": "seg-002",
+                "start": "0:02:00",
+                "end": "0:10:00",
+                "title": "Founding of Aldara",
+                "speaker": "DM",
+            },
+        ],
+        "uncertainty_flags": [],
+    })
+
+
+def _seg_bullets_payload(segment_id: str) -> str:
+    per_seg = {
+        "seg-001": [{"text": "Intro bullet", "anchor": "0:00:15"}],
+        "seg-002": [
+            {"text": "King Theron founded Aldara", "anchor": "0:02:30"},
+        ],
+    }
+    return json.dumps({"bullets": per_seg.get(segment_id, [])})
+
+
+def _stub_plan_payload() -> str:
+    return json.dumps({
+        "entity_resolutions": [
+            {
+                "mention": "Aldara",
+                "mention_locations": ["[0:02:00-0:10:00] founding"],
+                "resolution": "new",
+                "proposed_entity_name": "Aldara",
+                "proposed_category": "locations",
+                "rationale": "Subject of this lore segment.",
+            },
+        ],
+        "new_entities": [
+            {"name": "Aldara", "category": "locations"},
+        ],
+        "planned_claims": [
+            {
+                "claim_group_id": "cg-001",
+                "reading_section": "[0:02:00-0:10:00] Founding of Aldara",
+                "reading_bullet_index": 0,
+                "locator": "0:02:30",
+                "locator_hint": "0:02:00-0:02:30",
+                "proposed_speaker": "DM",
+                "proposed_status": "authoritative",
+                "proposed_status_reason": None,
+                "targets": [
+                    {
+                        "entity": "Aldara",
+                        "entity_state": "new",
+                        "proposed_section": "founding",
+                        "proposed_category": "locations",
+                        "rationale": "Founding fact.",
+                    },
+                ],
+            }
+        ],
+        "unresolved": [],
+    })
+
+
+def _stub_extractor_payload() -> str:
+    return json.dumps({
+        "text": "King Theron founded Aldara in the Second Age.",
+        "raw_transcript_span": "King Theron founded Aldara in the Second Age.",
+        "text_corrects_transcript": False,
+        "corrections_applied": [],
+    })
+
+
+def _wire_client_responses(client_mock: MagicMock) -> None:
+    def side_effect(
+        messages: list[dict[str, str]], **_kwargs: object
+    ) -> OpenRouterResponse:
+        system = next((m for m in messages if m["role"] == "system"), {})
+        user = next((m for m in messages if m["role"] == "user"), {})
+        system_text = system.get("content", "")
+        user_text = user.get("content", "")
+
+        if "segmenting" in system_text:
+            text = _stub_structure_payload()
+        elif "routing claim bullets" in system_text:
+            text = _stub_plan_payload()
+        elif "locate the verbatim transcript span" in system_text:
+            text = _stub_extractor_payload()
+        else:
+            for seg_id in ("seg-001", "seg-002"):
+                if seg_id in user_text:
+                    text = _seg_bullets_payload(seg_id)
+                    break
+            else:
+                text = json.dumps({"bullets": []})
+        return OpenRouterResponse(text=text, model="m", tokens_in=0, tokens_out=0)
+
+    client_mock.complete.side_effect = side_effect
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def ingested_wiki(tmp_wiki: Path, tmp_home: Path) -> Path:  # noqa: ARG001
+    source_id = "yt-abc12345678"
+    src_dir = tmp_wiki / "sources" / source_id
+    src_dir.mkdir(parents=True)
+    (src_dir / "transcript.en.srt").write_text(_SRT, encoding="utf-8")
+    info = {
+        "schema_version": 1,
+        "source_id": source_id,
+        "source_type": "youtube",
+        "source_url": "https://youtube.com/watch?v=abc12345678",
+        "title": "Session 3",
+        "duration_seconds": 600,
+        "caption_type": "manual",
+        "fetched_at": "2026-04-20T14:35:12Z",
+        "session_date": None,
+        "transcript_filename": "transcript.en.srt",
+        "context": {
+            "perspective": None,
+            "source_nature": None,
+            "setting": None,
+            "speakers": [],
+            "notes": None,
+        },
+    }
+    (src_dir / "info.yaml").write_text(
+        yaml.safe_dump(info, sort_keys=False), encoding="utf-8"
+    )
+    return tmp_wiki
+
+
+def _write_user_config(home: Path, wiki: Path) -> None:
+    cfg_path = home / "config.yaml"
+    cfg_path.write_text(
+        f"""schema_version: 1
+wiki_repo_path: {wiki}
+openrouter:
+  api_key_env: FAKE_OR_KEY
+models:
+  primary: anthropic/claude-sonnet-4-5
+""",
+        encoding="utf-8",
+    )
+
+
+def _args(**kwargs: object) -> argparse.Namespace:
+    return argparse.Namespace(**kwargs)
+
+
+class TestAutoApprove:
+    def test_full_pipeline_lands_a_fact_in_entity_yaml(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            assert approve_reading_cmd.run(_args(source_id="yt-abc12345678")) == 0
+            rc = review_cmd.run(_args(source_id="yt-abc12345678", auto_approve=True))
+        assert rc == 0
+        # Stub created
+        aldara_path = ingested_wiki / "locations" / "aldara.yaml"
+        assert aldara_path.exists()
+        e = entity_yaml.read(aldara_path)
+        assert e.entity == "Aldara"
+        assert e.created_by_ingest == "yt-abc12345678"
+        assert len(e.facts) == 1
+        assert e.facts[0]["id"] == "aldara-f001"
+        # Proposals dir is empty
+        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        assert list(proposals_dir.glob("*.yaml")) == []
+        out = capsys.readouterr().out
+        assert "approved=1" in out
+
+
+class TestTTYGuard:
+    def test_refuses_non_interactive_without_auto_approve(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        with patch("auto_lorebook.commands.review._is_interactive", return_value=False):
+            rc = review_cmd.run(_args(source_id="yt-abc12345678", auto_approve=False))
+        assert rc == 1
+
+
+class TestEmptyDir:
+    def test_says_nothing_to_review(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            approve_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            # Drain via auto-approve, then run again — should be empty.
+            review_cmd.run(_args(source_id="yt-abc12345678", auto_approve=True))
+            capsys.readouterr()
+            rc = review_cmd.run(_args(source_id="yt-abc12345678", auto_approve=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Nothing to review" in out

--- a/tests/test_stage1a.py
+++ b/tests/test_stage1a.py
@@ -159,3 +159,89 @@ class TestRun:
                 client=client,
                 model="m/one",
             )
+
+
+def _payload_with_last_end(end: str) -> str:
+    """Two segments; last one ends at the given timestamp."""
+    return json.dumps({
+        "default_speaker": "DM",
+        "segments": [
+            {
+                "id": "seg-001",
+                "start": "0:00:00",
+                "end": "0:01:00",
+                "title": "Intro",
+                "speaker": "DM",
+            },
+            {
+                "id": "seg-002",
+                "start": "0:01:00",
+                "end": end,
+                "title": "Body",
+                "speaker": "DM",
+            },
+        ],
+        "uncertainty_flags": [],
+    })
+
+
+class TestTailClamp:
+    def test_small_tail_gap_is_clamped(self) -> None:
+        # Last segment ends at 116s; transcript is 120s. Gap = 4s, clamp.
+        client = _mock_client(_payload_with_last_end("0:01:56"))
+        transcript = LoadedTranscript(
+            text_for_llm="[0:00:01] hi\n", total_duration=120.0
+        )
+        result = run(
+            transcript=transcript,
+            preamble_text="",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+        )
+        assert result.segments[-1].end == pytest.approx(120.0)
+
+    def test_gap_at_threshold_boundary_is_clamped(self) -> None:
+        # Gap exactly == threshold (30s): clamp.
+        client = _mock_client(_payload_with_last_end("0:01:30"))
+        transcript = LoadedTranscript(
+            text_for_llm="[0:00:01] hi\n", total_duration=120.0
+        )
+        result = run(
+            transcript=transcript,
+            preamble_text="",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+        )
+        assert result.segments[-1].end == pytest.approx(120.0)
+
+    def test_gap_beyond_threshold_still_raises(self) -> None:
+        # Gap = 60s > 30s threshold: real coverage drop, raise as before.
+        client = _mock_client(_payload_with_last_end("0:01:00"))
+        transcript = LoadedTranscript(
+            text_for_llm="[0:00:01] hi\n", total_duration=120.0
+        )
+        with pytest.raises(Stage1aError, match="last segment ends"):
+            run(
+                transcript=transcript,
+                preamble_text="",
+                source_id="yt-x",
+                client=client,
+                model="m/one",
+            )
+
+    def test_no_tail_gap_unchanged(self) -> None:
+        # Last segment already ends at total_duration: no clamp needed.
+        client = _mock_client(_payload_with_last_end("0:02:00"))
+        transcript = LoadedTranscript(
+            text_for_llm="[0:00:01] hi\n", total_duration=120.0
+        )
+        result = run(
+            transcript=transcript,
+            preamble_text="",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+        )
+        assert result.segments[-1].end == pytest.approx(120.0)

--- a/tests/test_stage3.py
+++ b/tests/test_stage3.py
@@ -581,26 +581,135 @@ class TestParallel:
 
 
 class TestErrors:
-    def test_malformed_json_raises_stage3error(self) -> None:
+    def test_malformed_json_emits_flagged_proposal(self) -> None:
+        """Unparseable JSON for one claim group does not kill the run."""
         transcript, structure = _default_setup()
         plan = Plan(
             source_id="yt-x",
             planned_at="2026-04-20T00:00:00Z",
             planned_claims=[_claim()],
         )
-        with pytest.raises(Stage3Error):
-            stage3.run(
-                plan=plan,
-                transcript=transcript,
-                structure=structure,
-                info=_info(),
-                preamble_text="",
-                source_id="yt-x",
-                client=_mock_client("not-json"),
-                model="m/one",
-                existing_fact_counts={"Aldara": 0},
-                existing_slugs={"Aldara": "aldara"},
-            )
+        proposals = stage3.run(
+            plan=plan,
+            transcript=transcript,
+            structure=structure,
+            info=_info(),
+            preamble_text="",
+            source_id="yt-x",
+            client=_mock_client("not-json"),
+            model="m/one",
+            existing_fact_counts={"Aldara": 0},
+            existing_slugs={"Aldara": "aldara"},
+        )
+        assert len(proposals) == 1
+        assert proposals[0].extractor_flagged is True
+        assert "unparseable JSON" in (proposals[0].flag_reason or "")
+        assert proposals[0].locator == _claim().locator_hint
+
+    def test_missing_raw_span_emits_flagged_proposal(self) -> None:
+        """LLM JSON missing raw_transcript_span flags the claim, doesn't raise."""
+        transcript, structure = _default_setup()
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[_claim()],
+        )
+        payload = json.dumps({
+            "text": "King Theron rules Aldara.",
+            # raw_transcript_span deliberately absent
+            "text_corrects_transcript": False,
+            "corrections_applied": [],
+        })
+        proposals = stage3.run(
+            plan=plan,
+            transcript=transcript,
+            structure=structure,
+            info=_info(),
+            preamble_text="",
+            source_id="yt-x",
+            client=_mock_client(payload),
+            model="m/one",
+            existing_fact_counts={"Aldara": 0},
+            existing_slugs={"Aldara": "aldara"},
+        )
+        assert len(proposals) == 1
+        assert proposals[0].extractor_flagged is True
+        assert "missing required fields" in (proposals[0].flag_reason or "")
+
+    def test_one_bad_claim_does_not_kill_others(self) -> None:
+        """Mix of good + malformed claim groups: good ones land, bad ones flag."""
+        transcript, structure = _default_setup()
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[
+                _claim(cg_id="cg-001"),
+                _claim(cg_id="cg-002"),
+            ],
+        )
+        client = _client_seq([_aldara_payload(), "not-json"])
+        proposals = stage3.run(
+            plan=plan,
+            transcript=transcript,
+            structure=structure,
+            info=_info(),
+            preamble_text="",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+            existing_fact_counts={"Aldara": 0},
+            existing_slugs={"Aldara": "aldara"},
+        )
+        assert len(proposals) == 2
+        flagged = [p for p in proposals if p.extractor_flagged]
+        clean = [p for p in proposals if not p.extractor_flagged]
+        assert len(flagged) == 1
+        assert len(clean) == 1
+        assert flagged[0].claim_group_id == "cg-002"
+        assert clean[0].claim_group_id == "cg-001"
+
+    def test_malformed_correction_dropped_silently(self) -> None:
+        """One bad correction in `corrections_applied` shouldn't fail the proposal."""
+        transcript, structure = _default_setup()
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[_claim()],
+        )
+        payload = json.dumps({
+            "text": "King Theron rules Aldara.",
+            "raw_transcript_span": "King Theron rules Aldara.",
+            "text_corrects_transcript": True,
+            "corrections_applied": [
+                {
+                    "from": "Fair-on",
+                    "to": "Theron",
+                    "source": "global-transcription-correction",
+                },
+                # Malformed: missing `to`
+                {"from": "x", "source": "reading-name-correction"},
+                # Malformed: empty `to`
+                {"from": "y", "to": "", "source": "reading-name-correction"},
+            ],
+        })
+        proposals = stage3.run(
+            plan=plan,
+            transcript=transcript,
+            structure=structure,
+            info=_info(),
+            preamble_text="",
+            source_id="yt-x",
+            client=_mock_client(payload),
+            model="m/one",
+            existing_fact_counts={"Aldara": 0},
+            existing_slugs={"Aldara": "aldara"},
+        )
+        assert len(proposals) == 1
+        p = proposals[0]
+        assert p.extractor_flagged is False
+        # Only the valid correction survives.
+        assert len(p.corrections_applied) == 1
+        assert p.corrections_applied[0].from_ == "Fair-on"
 
     def test_plain_text_transcript_raises(self) -> None:
         transcript = LoadedTranscript(

--- a/tests/test_stage3.py
+++ b/tests/test_stage3.py
@@ -1,0 +1,652 @@
+"""Tests for stage3.py — Stage 3 extractor."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from auto_lorebook import stage3
+from auto_lorebook.info_yaml import Info, SourceContext
+from auto_lorebook.openrouter import OpenRouterResponse
+from auto_lorebook.plan_yaml import (
+    ClaimTarget,
+    Plan,
+    PlannedClaim,
+)
+from auto_lorebook.srt import Cue
+from auto_lorebook.stage3 import Stage3Error
+from auto_lorebook.structure import Segment, Structure
+from auto_lorebook.transcript import LoadedTranscript
+
+
+def _info(session_date: str = "2026-01-15") -> Info:
+    return Info(
+        source_id="yt-x",
+        source_type="youtube",
+        fetched_at="2026-04-20T00:00:00Z",
+        title="t",
+        duration_seconds=120,
+        session_date=session_date,
+        context=SourceContext(),
+    )
+
+
+def _structure(*, segments: list[Segment]) -> Structure:
+    return Structure(
+        source_id="yt-x",
+        generated_at="2026-04-20T00:00:00Z",
+        default_speaker="DM",
+        segments=segments,
+    )
+
+
+def _transcript(cues: list[Cue], duration: float = 120.0) -> LoadedTranscript:
+    return LoadedTranscript(
+        text_for_llm="\n".join(f"[{c.start:.0f}] {c.text}" for c in cues) + "\n",
+        total_duration=duration,
+        cues=tuple(cues),
+    )
+
+
+def _mock_client(text: str) -> MagicMock:
+    client = MagicMock()
+    client.complete.return_value = OpenRouterResponse(
+        text=text, model="m/one", tokens_in=10, tokens_out=20
+    )
+    return client
+
+
+def _client_seq(payloads: list[str]) -> MagicMock:
+    client = MagicMock()
+    client.complete.side_effect = [
+        OpenRouterResponse(text=t, model="m/one", tokens_in=10, tokens_out=20)
+        for t in payloads
+    ]
+    return client
+
+
+def _claim(
+    *,
+    cg_id: str = "cg-001",
+    targets: list[ClaimTarget] | None = None,
+    locator_hint: str = "0:00:01-0:00:09",
+    reading_section: str = "[0:00:00-0:00:30] Founding of Aldara",
+    bullet_idx: int = 0,
+) -> PlannedClaim:
+    return PlannedClaim(
+        claim_group_id=cg_id,
+        reading_section=reading_section,
+        reading_bullet_index=bullet_idx,
+        locator="0:00:05",
+        locator_hint=locator_hint,
+        proposed_speaker="DM",
+        proposed_status="authoritative",
+        proposed_status_reason=None,
+        targets=targets
+        or [
+            ClaimTarget(
+                entity="Aldara",
+                entity_state="existing",
+                proposed_section="founding",
+                rationale="r",
+            ),
+        ],
+    )
+
+
+def _aldara_payload() -> str:
+    return json.dumps({
+        "text": "King Theron rules Aldara.",
+        "raw_transcript_span": "King Theron rules Aldara.",
+        "text_corrects_transcript": False,
+        "corrections_applied": [],
+    })
+
+
+def _default_setup() -> tuple[LoadedTranscript, Structure]:
+    cues = [
+        Cue(index=1, start=0.0, end=2.0, text="Long ago."),
+        Cue(index=2, start=2.0, end=4.0, text="King Theron rules Aldara."),
+        Cue(index=3, start=4.0, end=6.0, text="His son is heir."),
+        Cue(index=4, start=6.0, end=8.0, text="The realm prospers."),
+        Cue(index=5, start=30.0, end=32.0, text="Different topic."),
+    ]
+    structure = _structure(
+        segments=[
+            Segment(
+                id="seg1",
+                start=0.0,
+                end=30.0,
+                title="Founding of Aldara",
+                speaker="DM",
+            ),
+            Segment(id="seg2", start=30.0, end=120.0, title="Other", speaker="DM"),
+        ]
+    )
+    return _transcript(cues), structure
+
+
+# ---------------------------------------------------------------------------
+# Pre-allocation
+# ---------------------------------------------------------------------------
+
+
+class TestAllocateProposedIds:
+    def test_distinct_sequential_ids_for_same_existing_target(self) -> None:
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[
+                _claim(cg_id="cg-001"),
+                _claim(cg_id="cg-002"),
+            ],
+        )
+        allocations = stage3.allocate_proposed_ids(
+            plan,
+            existing_fact_counts={"Aldara": 4},
+            existing_slugs={"Aldara": "aldara"},
+        )
+        assert allocations["cg-001"][0].proposed_id == "aldara-f005"
+        assert allocations["cg-002"][0].proposed_id == "aldara-f006"
+
+    def test_new_entity_starts_at_f001_and_uses_slugify(self) -> None:
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[
+                _claim(
+                    cg_id="cg-001",
+                    targets=[
+                        ClaimTarget(
+                            entity="War of the Dusk",
+                            entity_state="new",
+                            proposed_category="events",
+                            proposed_section="overview",
+                            rationale="r",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        allocations = stage3.allocate_proposed_ids(
+            plan, existing_fact_counts={}, existing_slugs={}
+        )
+        assert allocations["cg-001"][0].proposed_id == "war-of-the-dusk-f001"
+
+    def test_siblings_exclude_self(self) -> None:
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[
+                _claim(
+                    cg_id="cg-001",
+                    targets=[
+                        ClaimTarget(
+                            entity="Aldara",
+                            entity_state="existing",
+                            proposed_section="founding",
+                            rationale="r",
+                        ),
+                        ClaimTarget(
+                            entity="Theron",
+                            entity_state="existing",
+                            proposed_section="lineage",
+                            rationale="r",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        allocations = stage3.allocate_proposed_ids(
+            plan,
+            existing_fact_counts={"Aldara": 0, "Theron": 0},
+            existing_slugs={"Aldara": "aldara", "Theron": "theron"},
+        )
+        a = allocations["cg-001"][0]
+        b = allocations["cg-001"][1]
+        assert a.proposed_id == "aldara-f001"
+        assert b.proposed_id == "theron-f001"
+        assert [s.entity for s in a.siblings] == ["Theron"]
+        assert [s.entity for s in b.siblings] == ["Aldara"]
+        assert a.siblings[0].proposed_id == "theron-f001"
+
+
+# ---------------------------------------------------------------------------
+# Segment lookup
+# ---------------------------------------------------------------------------
+
+
+class TestSegmentLookup:
+    def test_matches_segment_by_start_prefix(self) -> None:
+        structure = _structure(
+            segments=[
+                Segment(
+                    id="seg1", start=270.0, end=480.0, title="Founding", speaker="DM"
+                ),
+                Segment(id="seg2", start=480.0, end=720.0, title="War", speaker="DM"),
+            ]
+        )
+        seg = stage3.find_segment_for_reading_section(
+            structure, "[4:30-8:00] Founding of Aldara"
+        )
+        assert seg is not None
+        assert seg.id == "seg1"
+
+    def test_returns_none_when_no_prefix(self) -> None:
+        structure = _structure(
+            segments=[
+                Segment(id="seg1", start=0.0, end=10.0, title="x", speaker="DM"),
+            ]
+        )
+        assert (
+            stage3.find_segment_for_reading_section(structure, "no prefix here") is None
+        )
+
+    def test_returns_none_when_no_match(self) -> None:
+        structure = _structure(
+            segments=[
+                Segment(id="seg1", start=0.0, end=10.0, title="x", speaker="DM"),
+            ]
+        )
+        assert (
+            stage3.find_segment_for_reading_section(
+                structure, "[1:00:00-1:01:00] Way later"
+            )
+            is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Run / happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_single_target_emits_one_proposal(self) -> None:
+        transcript, structure = _default_setup()
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[_claim()],
+        )
+        proposals = stage3.run(
+            plan=plan,
+            transcript=transcript,
+            structure=structure,
+            info=_info(),
+            preamble_text="(preamble)",
+            source_id="yt-x",
+            client=_mock_client(_aldara_payload()),
+            model="m/one",
+            existing_fact_counts={"Aldara": 0},
+            existing_slugs={"Aldara": "aldara"},
+        )
+        assert len(proposals) == 1
+        p = proposals[0]
+        assert p.target_entity == "Aldara"
+        assert p.proposed_id == "aldara-f001"
+        assert p.proposal_type == "new_fact"
+        assert p.text == "King Theron rules Aldara."
+        assert p.raw_transcript_span == "King Theron rules Aldara."
+        assert p.locator == "0:00:02-0:00:04"
+        assert p.context_before == "Long ago."
+        assert p.context_after == "His son is heir."
+        assert p.session_date == "2026-01-15"
+        assert p.speaker == "DM"
+        assert p.section == "founding"
+        assert p.reading_section == "[0:00:00-0:00:30] Founding of Aldara"
+        assert p.hint_widened is False
+        assert p.extractor_flagged is False
+
+    def test_corrections_passed_through(self) -> None:
+        transcript, structure = _default_setup()
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[_claim()],
+        )
+        payload = json.dumps({
+            "text": "King Theron rules Aldara.",
+            "raw_transcript_span": "King Theron rules Aldara.",
+            "text_corrects_transcript": True,
+            "corrections_applied": [
+                {
+                    "from": "Fair-on",
+                    "to": "Theron",
+                    "source": "global-transcription-correction",
+                },
+            ],
+        })
+        proposals = stage3.run(
+            plan=plan,
+            transcript=transcript,
+            structure=structure,
+            info=_info(),
+            preamble_text="",
+            source_id="yt-x",
+            client=_mock_client(payload),
+            model="m/one",
+            existing_fact_counts={"Aldara": 0},
+            existing_slugs={"Aldara": "aldara"},
+        )
+        assert proposals[0].text_corrects_transcript is True
+        assert len(proposals[0].corrections_applied) == 1
+        assert proposals[0].corrections_applied[0].from_ == "Fair-on"
+
+
+# ---------------------------------------------------------------------------
+# Multi-target dedup
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTargetDedup:
+    def test_one_call_n_proposals(self) -> None:
+        transcript, structure = _default_setup()
+        claim = _claim(
+            targets=[
+                ClaimTarget(
+                    entity="Aldara",
+                    entity_state="existing",
+                    proposed_section="founding",
+                    rationale="r",
+                ),
+                ClaimTarget(
+                    entity="Theron",
+                    entity_state="existing",
+                    proposed_section="lineage",
+                    rationale="r",
+                ),
+                ClaimTarget(
+                    entity="Second Age",
+                    entity_state="new",
+                    proposed_category="events",
+                    proposed_section="events-in-era",
+                    rationale="r",
+                ),
+            ],
+        )
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[claim],
+        )
+        client = _mock_client(_aldara_payload())
+        proposals = stage3.run(
+            plan=plan,
+            transcript=transcript,
+            structure=structure,
+            info=_info(),
+            preamble_text="",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+            existing_fact_counts={"Aldara": 0, "Theron": 10},
+            existing_slugs={"Aldara": "aldara", "Theron": "theron"},
+        )
+        # one LLM call, three proposals
+        assert client.complete.call_count == 1
+        assert len(proposals) == 3
+        # span/locator/text shared
+        spans = {p.raw_transcript_span for p in proposals}
+        assert spans == {"King Theron rules Aldara."}
+        assert {p.locator for p in proposals} == {"0:00:02-0:00:04"}
+        # ids distinct
+        assert {p.proposed_id for p in proposals} == {
+            "aldara-f001",
+            "theron-f011",
+            "second-age-f001",
+        }
+        # proposal_type per target
+        by_entity = {p.target_entity: p for p in proposals}
+        assert by_entity["Second Age"].proposal_type == "new_entity_with_facts"
+        assert by_entity["Aldara"].proposal_type == "new_fact"
+        # siblings exclude self
+        assert {s.entity for s in by_entity["Aldara"].claim_group_siblings} == {
+            "Theron",
+            "Second Age",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Widening + flagging
+# ---------------------------------------------------------------------------
+
+
+class TestSubstringFallback:
+    def test_widens_to_segment_no_second_llm_call(self) -> None:
+        # Hint window covers cues [1..3] (start in [1, 5)); span is in cue at t=4
+        cues = [
+            Cue(index=1, start=1.0, end=2.0, text="alpha alpha"),
+            Cue(index=2, start=4.0, end=5.0, text="THE-MISSING-SPAN beta"),
+            Cue(index=3, start=10.0, end=11.0, text="gamma gamma"),
+        ]
+        transcript = _transcript(cues, duration=30.0)
+        structure = _structure(
+            segments=[
+                Segment(id="seg1", start=0.0, end=20.0, title="Whole", speaker="DM"),
+            ]
+        )
+        # Hint window 1.0-3.0 (only cue 1; span lives outside it)
+        claim = _claim(
+            locator_hint="0:00:01-0:00:03",
+            reading_section="[0:00:00-0:00:20] Whole",
+        )
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[claim],
+        )
+        payload = json.dumps({
+            "text": "THE-MISSING-SPAN beta",
+            "raw_transcript_span": "THE-MISSING-SPAN beta",
+            "text_corrects_transcript": False,
+            "corrections_applied": [],
+        })
+        client = _mock_client(payload)
+        proposals = stage3.run(
+            plan=plan,
+            transcript=transcript,
+            structure=structure,
+            info=_info(),
+            preamble_text="",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+            existing_fact_counts={"Aldara": 0},
+            existing_slugs={"Aldara": "aldara"},
+        )
+        # Only one LLM call, even though we widened mechanically.
+        assert client.complete.call_count == 1
+        assert len(proposals) == 1
+        assert proposals[0].hint_widened is True
+        assert proposals[0].extractor_flagged is False
+        assert proposals[0].locator == "0:00:04-0:00:10"
+
+    def test_flags_when_span_missing_everywhere(self) -> None:
+        transcript, structure = _default_setup()
+        claim = _claim()
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[claim],
+        )
+        payload = json.dumps({
+            "text": "Made up text not in transcript.",
+            "raw_transcript_span": "Made up text not in transcript.",
+            "text_corrects_transcript": False,
+            "corrections_applied": [],
+        })
+        proposals = stage3.run(
+            plan=plan,
+            transcript=transcript,
+            structure=structure,
+            info=_info(),
+            preamble_text="",
+            source_id="yt-x",
+            client=_mock_client(payload),
+            model="m/one",
+            existing_fact_counts={"Aldara": 0},
+            existing_slugs={"Aldara": "aldara"},
+        )
+        assert len(proposals) == 1
+        p = proposals[0]
+        assert p.extractor_flagged is True
+        assert p.flag_reason
+        assert p.locator == claim.locator_hint
+        assert not p.context_before
+        assert not p.context_after
+        # text + raw retained as model's last attempt
+        assert p.raw_transcript_span == "Made up text not in transcript."
+
+    def test_flagged_proposals_emitted_per_target(self) -> None:
+        transcript, structure = _default_setup()
+        claim = _claim(
+            targets=[
+                ClaimTarget(
+                    entity="Aldara",
+                    entity_state="existing",
+                    proposed_section="founding",
+                    rationale="r",
+                ),
+                ClaimTarget(
+                    entity="Theron",
+                    entity_state="existing",
+                    proposed_section="lineage",
+                    rationale="r",
+                ),
+            ],
+        )
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[claim],
+        )
+        payload = json.dumps({
+            "text": "missing",
+            "raw_transcript_span": "missing",
+            "text_corrects_transcript": False,
+            "corrections_applied": [],
+        })
+        proposals = stage3.run(
+            plan=plan,
+            transcript=transcript,
+            structure=structure,
+            info=_info(),
+            preamble_text="",
+            source_id="yt-x",
+            client=_mock_client(payload),
+            model="m/one",
+            existing_fact_counts={"Aldara": 0, "Theron": 0},
+            existing_slugs={"Aldara": "aldara", "Theron": "theron"},
+        )
+        assert len(proposals) == 2
+        assert all(p.extractor_flagged for p in proposals)
+
+
+# ---------------------------------------------------------------------------
+# Parallelism + errors
+# ---------------------------------------------------------------------------
+
+
+class TestParallel:
+    def test_one_llm_call_per_claim(self) -> None:
+        transcript, structure = _default_setup()
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[
+                _claim(cg_id="cg-001"),
+                _claim(cg_id="cg-002"),
+                _claim(cg_id="cg-003"),
+            ],
+        )
+        client = _mock_client(_aldara_payload())
+        proposals = stage3.run(
+            plan=plan,
+            transcript=transcript,
+            structure=structure,
+            info=_info(),
+            preamble_text="",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+            existing_fact_counts={"Aldara": 0},
+            existing_slugs={"Aldara": "aldara"},
+        )
+        # 3 claims with 1 target each = 3 proposals; 3 LLM calls (one per claim).
+        assert client.complete.call_count == 3
+        assert len(proposals) == 3
+
+
+class TestErrors:
+    def test_malformed_json_raises_stage3error(self) -> None:
+        transcript, structure = _default_setup()
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[_claim()],
+        )
+        with pytest.raises(Stage3Error):
+            stage3.run(
+                plan=plan,
+                transcript=transcript,
+                structure=structure,
+                info=_info(),
+                preamble_text="",
+                source_id="yt-x",
+                client=_mock_client("not-json"),
+                model="m/one",
+                existing_fact_counts={"Aldara": 0},
+                existing_slugs={"Aldara": "aldara"},
+            )
+
+    def test_plain_text_transcript_raises(self) -> None:
+        transcript = LoadedTranscript(
+            text_for_llm="plain", total_duration=10.0, cues=None
+        )
+        structure = _structure(
+            segments=[
+                Segment(id="seg1", start=0.0, end=10.0, title="x", speaker="DM"),
+            ]
+        )
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[_claim()],
+        )
+        with pytest.raises(Stage3Error, match="SRT"):
+            stage3.run(
+                plan=plan,
+                transcript=transcript,
+                structure=structure,
+                info=_info(),
+                preamble_text="",
+                source_id="yt-x",
+                client=_mock_client(_aldara_payload()),
+                model="m/one",
+                existing_fact_counts={"Aldara": 0},
+                existing_slugs={"Aldara": "aldara"},
+            )
+
+    def test_empty_plan_returns_empty_list(self) -> None:
+        transcript, structure = _default_setup()
+        plan = Plan(
+            source_id="yt-x",
+            planned_at="2026-04-20T00:00:00Z",
+            planned_claims=[],
+        )
+        out = stage3.run(
+            plan=plan,
+            transcript=transcript,
+            structure=structure,
+            info=_info(),
+            preamble_text="",
+            source_id="yt-x",
+            client=_mock_client(_aldara_payload()),
+            model="m/one",
+            existing_fact_counts={},
+            existing_slugs={},
+        )
+        assert out == []

--- a/tests/test_timestamps.py
+++ b/tests/test_timestamps.py
@@ -7,6 +7,7 @@ import pytest
 from auto_lorebook.timestamps import (
     TimestampError,
     format_timestamp,
+    parse_locator_hint,
     parse_timestamp,
 )
 
@@ -80,3 +81,32 @@ class TestRoundTrip:
     def test_canonical_round_trip(self) -> None:
         for s in (0, 7, 65, 3_661, 36_000):
             assert parse_timestamp(format_timestamp(s)) == pytest.approx(float(s))
+
+
+class TestParseLocatorHint:
+    def test_canonical_range(self) -> None:
+        start, end = parse_locator_hint("0:04:25-0:04:50")
+        assert start == pytest.approx(265.0)
+        assert end == pytest.approx(290.0)
+
+    def test_lenient_components(self) -> None:
+        start, end = parse_locator_hint("4:25-4:50")
+        assert start == pytest.approx(265.0)
+        assert end == pytest.approx(290.0)
+
+    def test_whitespace_around_range(self) -> None:
+        start, end = parse_locator_hint("  0:00:01 - 0:00:02  ")
+        assert start == pytest.approx(1.0)
+        assert end == pytest.approx(2.0)
+
+    def test_missing_dash_raises(self) -> None:
+        with pytest.raises(TimestampError):
+            parse_locator_hint("0:04:25")
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(TimestampError):
+            parse_locator_hint("")
+
+    def test_end_before_start_raises(self) -> None:
+        with pytest.raises(TimestampError):
+            parse_locator_hint("0:00:10-0:00:05")

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -8,10 +8,13 @@ import pytest
 
 from auto_lorebook.corrections import Correction, Corrections
 from auto_lorebook.info_yaml import Info, SourceContext
+from auto_lorebook.srt import Cue
 from auto_lorebook.transcript import (
+    LoadedTranscript,
     TranscriptError,
     apply_corrections,
     load,
+    transcript_window,
 )
 
 if TYPE_CHECKING:
@@ -116,3 +119,84 @@ class TestLoad:
         info = _info("youtube", duration=120, source_id="yt-missing")
         with pytest.raises(TranscriptError):
             load(tmp_wiki, info, Corrections())
+
+
+class TestCuesField:
+    def test_srt_populates_cues(self, tmp_wiki: Path) -> None:
+        src_dir = tmp_wiki / "sources" / "yt-x"
+        src_dir.mkdir(parents=True)
+        (src_dir / "transcript.en.srt").write_text(_SRT, encoding="utf-8")
+        loaded = load(tmp_wiki, _info("youtube", duration=120), Corrections())
+        assert loaded.cues is not None
+        assert len(loaded.cues) == 2
+        assert loaded.cues[0].start == pytest.approx(1.0)
+        assert loaded.cues[0].text == "King Fair-on rules Aldara."
+
+    def test_plain_text_cues_is_none(self, tmp_wiki: Path) -> None:
+        src_dir = tmp_wiki / "sources" / "txt-x"
+        src_dir.mkdir(parents=True)
+        (src_dir / "transcript.txt").write_text("Hello.\n", encoding="utf-8")
+        info = _info("text", duration=10, source_id="txt-x")
+        loaded = load(tmp_wiki, info, Corrections())
+        assert loaded.cues is None
+
+    def test_corrections_apply_per_cue(self, tmp_wiki: Path) -> None:
+        """Corrections apply per-cue so cue.text agrees with text_for_llm.
+
+        If corrections desync the two views, substring lookup breaks.
+        """
+        src_dir = tmp_wiki / "sources" / "yt-x"
+        src_dir.mkdir(parents=True)
+        (src_dir / "transcript.en.srt").write_text(_SRT, encoding="utf-8")
+        cors = Corrections(corrections=[Correction(wrong="Fair-on", right="Theron")])
+        loaded = load(tmp_wiki, _info("youtube", duration=120), cors)
+        assert loaded.cues is not None
+        assert "Theron" in loaded.cues[0].text
+        assert "Fair-on" not in loaded.cues[0].text
+
+    def test_text_for_llm_matches_corrected_cue_text(self, tmp_wiki: Path) -> None:
+        """text_for_llm and cues[*].text agree after corrections."""
+        src_dir = tmp_wiki / "sources" / "yt-x"
+        src_dir.mkdir(parents=True)
+        (src_dir / "transcript.en.srt").write_text(_SRT, encoding="utf-8")
+        cors = Corrections(corrections=[Correction(wrong="Fair-on", right="Theron")])
+        loaded = load(tmp_wiki, _info("youtube", duration=120), cors)
+        assert loaded.cues is not None
+        for cue in loaded.cues:
+            assert cue.text in loaded.text_for_llm
+
+
+class TestTranscriptWindow:
+    def _loaded(self, cues: list[Cue]) -> LoadedTranscript:
+        rendered = "\n".join(f"[{c.start:.0f}] {c.text}" for c in cues)
+        return LoadedTranscript(
+            text_for_llm=rendered,
+            total_duration=cues[-1].end if cues else 0.0,
+            cues=tuple(cues),
+        )
+
+    def test_returns_window_and_cues(self) -> None:
+        loaded = self._loaded([
+            Cue(index=1, start=1.0, end=3.0, text="alpha"),
+            Cue(index=2, start=10.0, end=14.0, text="beta"),
+            Cue(index=3, start=20.0, end=22.0, text="gamma"),
+        ])
+        rendered, cues = transcript_window(loaded, 5.0, 15.0)
+        assert "beta" in rendered
+        assert "alpha" not in rendered
+        assert "gamma" not in rendered
+        assert [c.text for c in cues] == ["beta"]
+
+    def test_window_is_half_open(self) -> None:
+        """Cue starting exactly at `end` is excluded."""
+        loaded = self._loaded([
+            Cue(index=1, start=0.0, end=2.0, text="a"),
+            Cue(index=2, start=5.0, end=7.0, text="b"),
+        ])
+        _, cues = transcript_window(loaded, 0.0, 5.0)
+        assert [c.text for c in cues] == ["a"]
+
+    def test_raises_on_plain_text(self) -> None:
+        loaded = LoadedTranscript(text_for_llm="hello", total_duration=0.0, cues=None)
+        with pytest.raises(TranscriptError):
+            transcript_window(loaded, 0.0, 1.0)


### PR DESCRIPTION
## Summary

This PR implements the Stage 3 (extractor) and Stage 4 (review) phases of the auto-lorebook pipeline, along with supporting infrastructure for proposal management, ingest cleanup, and replanning.

## Key Changes

### Core Engines
- **Stage 3 Extractor** (`stage3.py`): Locates verbatim transcript spans for planned claims via LLM, generates proposals with corrections tracking, and pre-allocates fact IDs based on existing entity state
- **Stage 4 Review Engine** (`review.py`): Walks proposals in plan-authoritative order, applies human decisions (approve/edit/reject), and atomically updates entity YAMLs with approved facts
- **Proposal Schema** (`proposal_yaml.py`): New YAML format for Stage 3 output, representing individual facts awaiting review with transcript spans, corrections, and sibling grouping

### CLI Commands
- **`review`** (`commands/review.py`): Interactive proposal review with approve/edit/reject/play options, alias confirmation, and resumable processing on Ctrl-C
- **`reject-ingest`** (`commands/reject_ingest_cmd.py`): Removes all facts/aliases from a source, deletes empty entity stubs, and clears pending artifacts
- **`replan`** (`commands/replan_cmd.py`): Discards unreviewed proposals and re-runs planning/extraction against current wiki state

### Supporting Infrastructure
- **Ingest Cleanup** (`ingest_cleanup.py`): Engine for removing ingest contributions while preserving hand-edited content and cross-ingest references
- **Pipeline Integration** (`reading_pipeline.py`): Added `extract()` orchestration function that calls Stage 3 with concurrency control
- **Entity Index Lookup** (`entity_index.py`): New `lookup()` method for canonical name resolution
- **Timestamp Utilities** (`timestamps.py`): Added `parse_locator_hint()` for span parsing
- **Entity Utilities** (`entity_yaml.py`): Added `slugify()` function for consistent ID generation

### Testing
- Comprehensive test suites for Stage 3 (`test_stage3.py`), Stage 4 (`test_review.py`), ingest cleanup (`test_ingest_cleanup.py`), and all three new CLI commands
- End-to-end integration tests verifying full pipeline flows with mocked LLM clients
- Scripted reviewer implementation for deterministic test execution

## Notable Implementation Details

- **Walk Order**: Review walks proposals in plan-authoritative order (by `planned_claims` then `targets`), preserving siblings contiguity and transcript order regardless of slug lexicographic sorting
- **Atomic Entity Updates**: New entity stubs are created atomically on first fact approval; subsequent approvals append to existing YAMLs
- **Correction Tracking**: Stage 3 distinguishes between global transcription corrections and reading-specific name corrections, with full audit trail in fact metadata
- **Resumable Review**: Proposal files remain on disk until approved/rejected, enabling safe Ctrl-C interruption and resume
- **Ingest Isolation**: Cleanup preserves hand-edited facts/aliases and cross-ingest references; only removes contributions tagged with the target ingest ID
- **Concurrency**: Stage 3 uses ThreadPoolExecutor for parallel LLM calls with configurable max concurrency (default 4)

## Documentation Updates

Updated architecture docs to reflect new `text_source` field in fact schema (stores original LLM text when edited by human) and roadmap to mark Stages 3–4 as complete.

https://claude.ai/code/session_019hXuNtYjLkBexNqz3qn9hj