### PR TITLE
Add Stage 2 planner with entity routing and plan.yaml schema

### DIFF
--- a/docs/architecture/entity-model.md
+++ b/docs/architecture/entity-model.md
@@ -168,6 +168,10 @@ tool may cache the index at `.cache/entity-index.json`. The cache is
 never authoritative — it is rebuilt from YAMLs whenever any entity
 YAML changes.
 
+`auto-lorebook entities rebuild-index` is reserved for that future
+cache. Until a cache exists, it is a no-op that prints a status line —
+the in-memory index is rebuilt on every command run regardless.
+
 ## Global transcription corrections
 
 `.transcription-corrections.yaml` at the wiki root:

--- a/docs/getting-started/entities.md
+++ b/docs/getting-started/entities.md
@@ -1,0 +1,68 @@
+# Hand-creating entities
+
+Entity files normally appear automatically: when you approve a fact in
+the review loop (Phase 4), the tool creates the entity stub atomically
+on first approval. Hand-creation is a bootstrapping aid for seeding a
+fresh wiki with characters, locations, or other entities you already
+know about.
+
+The full schema is documented in
+[entity model](../architecture/entity-model.md). For bootstrapping you
+only need the four required keys.
+
+## Minimum viable stub
+
+Save as `<wiki>/<category>/<slug>.yaml`. Categories are the six
+directories under your wiki repo: `characters`, `locations`,
+`factions`, `events`, `items`, `concepts`.
+
+```yaml
+schema_version: 1
+entity: Aldara
+category: locations
+slug: aldara
+```
+
+Optional fields the tool will read if present:
+
+- `aliases` — list of `{name, added_by_ingest, added_at, source}` records.
+- `superseded_by` — `"<category>/<slug>"` if this entity was merged into
+  another. Hides it from the entity index.
+- `created_at`, `created_by_ingest`, `updated_at` — provenance fields
+  (left blank for hand-created entries).
+
+## Scaffolding command
+
+`entities new` writes a minimum stub for you. The slug is derived from
+the name (lowercase, spaces to hyphens, non-alphanumeric stripped) but
+can be overridden.
+
+```bash
+auto-lorebook entities new --category characters --name "King Theron"
+# created /path/to/wiki/characters/king-theron.yaml
+
+auto-lorebook entities new --category locations --name "Aldara" --slug aldara
+```
+
+The command refuses if the target file already exists; use
+`entities show` to inspect the existing file.
+
+## Verifying recognition
+
+The entity index is rebuilt from the filesystem on every command run.
+After hand-editing or scaffolding a stub, list it:
+
+```bash
+auto-lorebook entities list
+auto-lorebook entities list --category characters
+```
+
+Inspect a single entity by slug, canonical name, or alias:
+
+```bash
+auto-lorebook entities show theron
+auto-lorebook entities show "King Theron"
+```
+
+When you next run `ingest` or `configure-context`, the preamble shows
+the entity index and your hand-created stubs appear in it.

--- a/docs/pipeline/planner.md
+++ b/docs/pipeline/planner.md
@@ -89,9 +89,12 @@ unresolved:
 A single claim can route to multiple entities when it carries
 information about more than one. The example above routes one claim to
 Aldara (founding), Theron (lineage), and the Second Age
-(events-in-era). Each target gets its own proposal; approvals are
-per-target, so the human can accept the claim onto Aldara and Theron
-but reject it from the Second Age page without affecting the others.
+(events-in-era). Each target gets its own proposal file on disk, but
+[review](review.md) bundles siblings into a single decision: the
+claim is shown once with all destinations as a checklist, and approve
+writes to every checked target. The `[t]argets` action lets the human
+uncheck individual destinations — e.g. accept onto Aldara and Theron
+but drop the Second Age page — before approving the bundle.
 
 Targets sharing a `claim_group_id` share the same
 `raw_transcript_span`, `locator`, and extracted `text` — the

--- a/docs/pipeline/review.md
+++ b/docs/pipeline/review.md
@@ -32,25 +32,24 @@ cleanup logic.
 auto-lorebook review <ingest_id>
 ```
 
-Walks through proposals one at a time. Each proposal must be approved,
-edited, or rejected before the next is shown — there is no skip or
-defer. If the user exits (Ctrl-C or closes the terminal), untouched
-proposal files remain in `pending/<ingest_id>/proposals/`, and the
-next invocation of `review` resumes with the first remaining file.
+Walks through claim bundles one at a time. Each bundle must be
+approved, edited, or rejected before the next is shown — there is no
+skip or defer. If the user exits (Ctrl-C or closes the terminal),
+untouched proposal files remain in `pending/<ingest_id>/proposals/`,
+and the next invocation of `review` resumes with the first remaining
+bundle.
 
-### Claim-group ordering
+### Claim-group bundling
 
-Proposals sharing a `claim_group_id` are shown in a contiguous block,
-so the human reads the claim once and then decides per-target. The
-header names the group's position and size. Review order within a
-group is arbitrary; across groups, order follows transcript position.
+Proposals sharing a `claim_group_id` are bundled into a single review
+screen with a single decision. The human reads the claim once and
+approves, edits, or rejects the whole bundle at once; all targets ride
+on that decision. The header names the bundle's position and the
+number of targets it covers. Review order across bundles follows
+transcript position.
 
 ```
-─── Proposal 1 of 12  ·  Claim group cg-001 (1 of 3 targets) ────────
-
-Target entity: Aldara (existing)
-  Matched via: alias "the Aldaran Realm"
-Section: founding
+─── Bundle 1 of 6  ·  Claim group cg-001 (3 targets) ────────────────
 
 Proposed text:
   "Theron's grandfather founded Aldara in the Second Age."
@@ -72,94 +71,97 @@ Context:
   Before: "So let's talk about the founding of Aldara."
   After:  "And that's why the Theron name matters so much now."
 
-Also routes to:
-  → Theron (lineage)              — next
-  → Second Age (events-in-era)    — then
+Routes to:
+  [x] Aldara (existing) — founding
+        Matched via: alias "the Aldaran Realm"
+  [x] Theron (existing) — lineage
+  [x] Second Age (existing) — events-in-era
 
-[a]pprove  [e]dit  [r]eject  [p]lay (open URL)
+[a]pprove  [e]dit  [t]argets  [r]eject  [p]lay (open URL)
 >
 ```
 
-After approval or rejection, the next claim-group sibling shows with
-an abbreviated header — the claim text and locator are unchanged; only
-the target and section differ:
+`[a]pprove` writes the claim to every checked target. `[r]eject` drops
+the whole bundle. `[t]argets` opens an inline checklist where the user
+can uncheck individual destinations before approving — the unchecked
+targets are dropped on approval, the same as if they had been rejected
+individually. A bundle with zero remaining targets cannot be approved;
+it must be rejected.
+
+An edit to `text` propagates across all targets in the bundle by
+default, since one approval covers the whole group. If the user wants
+the claim phrased differently per target, they reject the bundle and
+re-enter the targets as separate facts during a follow-up pass.
+
+### New-entity rows
+
+A target row in the checklist that points at a proposed new entity not
+yet on disk renders as:
 
 ```
-─── Proposal 2 of 12  ·  Claim group cg-001 (2 of 3 targets) ────────
-
-Target entity: Theron (existing)
-Section: lineage
-
-(Same claim text, locator, and context as previous proposal.)
-
-[a]pprove  [e]dit  [r]eject  [p]lay (open URL)
->
+  [x] War of the Dusk (NEW — events, will be created on approval)
+        Proposed aliases: (none)
 ```
 
-An edit to `text` inside a claim group applies only to the proposal
-being edited — sibling proposals keep the original text. This is
-deliberate: the human might want to phrase the founding claim
-differently on Theron's page than on Aldara's, and forcing edits to
-propagate across siblings would undercut that. If propagation _is_
-wanted, the user edits each sibling in turn.
-
-### New-entity proposals
-
-For proposals targeting a proposed new entity that does not yet exist
-on disk:
+A row pointing at an entity created earlier in the same review session
+renders as:
 
 ```
-Target entity: War of the Dusk (NEW — events, will be created on approval)
-  Proposed aliases: (none)
+  [x] War of the Dusk (events)
+        Created earlier in this review session
 ```
 
-For proposals targeting an entity created earlier in the same review
-session:
-
-```
-Target entity: War of the Dusk (events)
-  Created earlier in this review session
-```
-
-This note is derived at display time by comparing the entity's
-`created_by_ingest` to the current ingest ID — no extra state
-required.
+The "created earlier" note is derived at display time by comparing the
+entity's `created_by_ingest` to the current ingest ID — no extra state
+required. Unchecking a NEW row before approval is equivalent to
+rejecting just that target; if every approved bundle ends up
+unchecking a given proposed entity, no stub is ever written.
 
 ### Alias confirmation
 
-For proposals where the planner matched via a mention that isn't yet
-an alias, the display offers alias confirmation:
+When any target in the bundle was matched via a mention that isn't yet
+an alias, the row carries an alias-confirmation sub-prompt resolved
+before the bundle decision is taken:
 
 ```
-Target entity: Aldara (existing)
-  Matched via: "the Realm" (not currently an alias)
-  Add "the Realm" as alias? [y/n]
+  [x] Aldara (existing) — founding
+        Matched via: "the Realm" (not currently an alias)
+        Add "the Realm" as alias? [y/n]
 ```
 
-Alias confirmation is a sub-prompt, not a main action. It applies
-immediately on `y` and is recorded in the entity YAML as an alias
-record with `source: alias-confirmation` and `added_by_ingest` set to
-the current ingest — or merged into the stub at creation time if the
-entity is new and this is its first approval, in which case the source
-on the first-approval aliases is `stub-creation`. Aliases added via
-alias confirmation are cleanly removable by `reject-ingest`.
+Alias confirmation is a per-row sub-prompt, not a main action. It
+applies immediately on `y` and is recorded in the entity YAML as an
+alias record with `source: alias-confirmation` and `added_by_ingest`
+set to the current ingest — or merged into the stub at creation time
+if the entity is new and this is its first approval, in which case the
+source on the first-approval aliases is `stub-creation`. If the user
+later unchecks that target via `[t]argets`, or rejects the bundle
+entirely, the alias write is rolled back along with the rest. Aliases
+added via alias confirmation are cleanly removable by `reject-ingest`.
 
 ### Actions
 
-- **Approve** — proposal becomes a fact, appended to the entity's YAML
-  (creating the YAML if this is the first approval for a new entity),
-  summary regenerated. Proposal file deleted.
-- **Edit** — opens `text` (and optionally other fields) for inline
-  editing. Tracks original as `text_source` on the approved fact.
-  Then approves.
-- **Reject** — proposal discarded.
+- **Approve** — for each checked target, the claim becomes a fact
+  appended to that entity's YAML (creating the YAML if this is the
+  first approval for a new entity), summary regenerated. Sibling
+  proposal files for the bundle are deleted; unchecked targets are
+  treated as rejected and their proposal files are also deleted.
+- **Edit** — opens `text` for inline editing; the edit applies to
+  every checked target in the bundle. Original is tracked as
+  `text_source` on each approved fact. Then approves.
+- **Targets** — opens the route checklist so individual destinations
+  can be unchecked (or re-checked) before the bundle decision. Status,
+  speaker, and section overrides are taken per row from this
+  sub-prompt; defaults come from the planner.
+- **Reject** — entire bundle discarded; every sibling proposal file
+  deleted.
 - **Play** — prints the URL; user clicks through to verify against
   audio. Play is not a decision — after playing, the user still must
-  approve, edit, or reject the current proposal.
+  approve, edit, or reject the current bundle.
 
-Status, speaker, and section can all be overridden during review.
-Text edits are supported but optional — approving as-is is fine since
-the summarizer produces readable prose downstream.
+Per-target status, speaker, and section overrides live behind
+`[t]argets`. Text edits are supported but optional — approving as-is
+is fine since the summarizer produces readable prose downstream.
 
 ## No skip, no defer
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -84,9 +84,19 @@ Promote a per-source name correction to the global
 ## Entities
 
 ```bash
+auto-lorebook entities list [--category <cat>] [--created-by <ingest_id>]
+auto-lorebook entities show <slug-or-name>
+auto-lorebook entities new --category <cat> --name <name> [--slug <slug>]
 auto-lorebook entities rebuild-index
-auto-lorebook entities list [--created-by <ingest_id>]
 ```
+
+`list` prints a category/name/slug/alias-count table; filters compose.
+`show` resolves the query against slugs first, then canonical names
+(case-insensitive), then aliases. `new` writes a minimum-viable stub;
+slug defaults to a slugified `--name`. `rebuild-index` is a placeholder
+until an on-disk cache exists — today the in-memory index is rebuilt on
+every command anyway. See
+[hand-creating entities](../getting-started/entities.md).
 
 ```bash
 auto-lorebook reject-ingest <ingest_id>

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -6,17 +6,20 @@ implementation status.
 
 !!! info "Current status"
 
-    Phase 1 substantially landed. The reading pipeline is runnable end
-    to end against a real OpenRouter backend: `ingest` fetches
-    YouTube transcripts via `yt-dlp`, `generate-reading` runs Stage 1a
-    (structure + mechanical validation) and Stage 1b (per-segment
-    summarize, parallelized) to produce a draft `reading.md`, the
-    mechanical gap check surfaces low-yield stretches during review,
-    `approve-reading` flips the draft into the wiki, and
-    `regenerate-reading --from=structure|summarize [--segments]`
-    supports targeted re-runs. Remaining Phase 1 polish: live
+    Phase 1 substantially landed; the reading pipeline is runnable end
+    to end against a real OpenRouter backend (Stage 1a + 1b, gap
+    check, approve, targeted re-runs). Remaining Phase 1 polish: live
     end-to-end validation against a real source and tuning the 1a/1b
     prompts based on that run.
+
+    Phase 2 (entity scaffolding) landed: schema-validated entity YAML
+    read/write (`auto_lorebook.entity_yaml`), the existing in-memory
+    `EntityIndex` migrated onto it, and an `entities` subcommand
+    group (`list`, `show`, `new`, `rebuild-index`). Hand-creating
+    entities is documented at
+    [hand-creating entities](../getting-started/entities.md);
+    `entities rebuild-index` is a placeholder until a disk cache
+    materialises.
 
 ## Phase 1: Reading stage
 
@@ -72,7 +75,7 @@ fires at least once on real content and the warning is actionable.
 Total human review time for a two-hour source fits inside the
 10–20 min/hour target on a representative session.
 
-## Phase 2: Entity scaffolding
+## Phase 2: Entity scaffolding (landed)
 
 **Scope**
 
@@ -84,7 +87,11 @@ Total human review time for a two-hour source fits inside the
   are normally created via approved facts).
 
 **Exit criterion** — hand-create a few entities; tool lists them and
-exposes them to the next stage as an entity index.
+exposes them to the next stage as an entity index. ✓
+
+`entities rename` and `wiki list` / `wiki show` were spec'd alongside
+this phase but are deferred — `rename` to whenever a real need surfaces,
+`wiki *` to Phase 5/6 where they overlap with summary rendering.
 
 ## Phase 3: Planner
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -21,6 +21,13 @@ implementation status.
     `entities rebuild-index` is a placeholder until a disk cache
     materialises.
 
+    Phase 3 (planner) landed: Stage 2 LLM planner runs automatically
+    after `approve-reading`, writes `pending/<source_id>/plan.yaml`
+    with no filesystem side effects (new entities and aliases are
+    proposals only), supports multi-target routing per claim, and
+    exposes `plans list` / `plans show` for inspection. `replan` is
+    deferred to Phase 4.
+
 ## Phase 1: Reading stage
 
 **Goal** — ingest a YouTube URL, gather context, produce a reviewable,
@@ -93,7 +100,7 @@ exposes them to the next stage as an entity index. ✓
 this phase but are deferred — `rename` to whenever a real need surfaces,
 `wiki *` to Phase 5/6 where they overlap with summary rendering.
 
-## Phase 3: Planner
+## Phase 3: Planner (landed)
 
 **Scope**
 
@@ -112,7 +119,10 @@ this phase but are deferred — `rename` to whenever a real need surfaces,
 automatically and produces a plan. New entities are _proposals on the
 plan_, not files in the wiki. Aliases are proposed, not yet written.
 At least one planned claim in a representative session routes to
-multiple targets.
+multiple targets. ✓
+
+`replan` was spec'd alongside this phase but is deferred to Phase 4
+where the extractor + review loop give it something to discard.
 
 ## Phase 4: Extractor + review
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
   - Getting started:
       - getting-started/installation.md
       - getting-started/first-ingest.md
+      - getting-started/entities.md
   - Architecture:
       - architecture/overview.md
       - architecture/repository-layout.md

--- a/src/auto_lorebook/cli.py
+++ b/src/auto_lorebook/cli.py
@@ -16,6 +16,7 @@ from auto_lorebook.commands import (
     entities_cmd,
     generate_reading_cmd,
     ingest_cmd,
+    plans_cmd,
     regenerate_reading_cmd,
     version_cmd,
 )
@@ -102,6 +103,7 @@ def create_parser() -> argparse.ArgumentParser:
     approve_reading_cmd.add_parser(subparsers, common_parser)
     regenerate_reading_cmd.add_parser(subparsers, common_parser)
     entities_cmd.add_parser(subparsers, common_parser)
+    plans_cmd.add_parser(subparsers, common_parser)
 
     return parser
 

--- a/src/auto_lorebook/cli.py
+++ b/src/auto_lorebook/cli.py
@@ -13,6 +13,7 @@ from auto_lorebook import __version__
 from auto_lorebook.commands import (
     approve_reading_cmd,
     configure_context_cmd,
+    entities_cmd,
     generate_reading_cmd,
     ingest_cmd,
     regenerate_reading_cmd,
@@ -100,6 +101,7 @@ def create_parser() -> argparse.ArgumentParser:
     generate_reading_cmd.add_parser(subparsers, common_parser)
     approve_reading_cmd.add_parser(subparsers, common_parser)
     regenerate_reading_cmd.add_parser(subparsers, common_parser)
+    entities_cmd.add_parser(subparsers, common_parser)
 
     return parser
 

--- a/src/auto_lorebook/commands/__init__.py
+++ b/src/auto_lorebook/commands/__init__.py
@@ -10,6 +10,7 @@ from auto_lorebook.commands import configure_context as configure_context_cmd
 from auto_lorebook.commands import entities as entities_cmd
 from auto_lorebook.commands import generate_reading as generate_reading_cmd
 from auto_lorebook.commands import ingest as ingest_cmd
+from auto_lorebook.commands import plans as plans_cmd
 from auto_lorebook.commands import regenerate_reading as regenerate_reading_cmd
 from auto_lorebook.commands import version as version_cmd
 
@@ -19,6 +20,7 @@ __all__ = [
     "entities_cmd",
     "generate_reading_cmd",
     "ingest_cmd",
+    "plans_cmd",
     "regenerate_reading_cmd",
     "version_cmd",
 ]

--- a/src/auto_lorebook/commands/__init__.py
+++ b/src/auto_lorebook/commands/__init__.py
@@ -7,6 +7,7 @@ Each subcommand is defined in its own module and exports:
 
 from auto_lorebook.commands import approve_reading as approve_reading_cmd
 from auto_lorebook.commands import configure_context as configure_context_cmd
+from auto_lorebook.commands import entities as entities_cmd
 from auto_lorebook.commands import generate_reading as generate_reading_cmd
 from auto_lorebook.commands import ingest as ingest_cmd
 from auto_lorebook.commands import regenerate_reading as regenerate_reading_cmd
@@ -15,6 +16,7 @@ from auto_lorebook.commands import version as version_cmd
 __all__ = [
     "approve_reading_cmd",
     "configure_context_cmd",
+    "entities_cmd",
     "generate_reading_cmd",
     "ingest_cmd",
     "regenerate_reading_cmd",

--- a/src/auto_lorebook/commands/approve_reading.py
+++ b/src/auto_lorebook/commands/approve_reading.py
@@ -50,4 +50,12 @@ def run(args: argparse.Namespace) -> int:
         return 1
 
     print(f"Approved: {approved}")  # noqa: T201
+
+    try:
+        plan_result = pipeline.plan(cfg, args.source_id)
+    except pipeline.ReadingPipelineError as e:
+        _logger.error("planner failed: %s", e)
+        return 1
+
+    print(f"Plan: {plan_result.plan_path}")  # noqa: T201
     return 0

--- a/src/auto_lorebook/commands/entities.py
+++ b/src/auto_lorebook/commands/entities.py
@@ -1,0 +1,230 @@
+"""auto-lorebook entities subcommand group.
+
+First nested subparser in the project: `entities <list|show|new|rebuild-index>`.
+Subcommands all dispatch through `run()`, branching on `args.entities_action`.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import entity_index, entity_yaml
+from auto_lorebook.timestamps import format_iso_now
+
+if TYPE_CHECKING:
+    import argparse
+
+    from auto_lorebook.entity_yaml import Entity
+
+_logger = logging.getLogger(__name__)
+
+_SLUG_STRIP_RE = re.compile(r"[^a-z0-9-]+")
+_SLUG_DASH_RE = re.compile(r"-+")
+
+
+def add_parser(
+    subparsers: argparse._SubParsersAction,
+    common_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Register the `entities` subcommand group."""
+    parser = subparsers.add_parser(
+        "entities",
+        parents=[common_parser],
+        help="List, show, or hand-create entities in the wiki",
+        description=(
+            "Inspect and bootstrap entities. Hand-creation is a "
+            "bootstrapping aid; the normal path is approval of facts "
+            "in the review loop (Phase 4)."
+        ),
+    )
+    sub = parser.add_subparsers(
+        dest="entities_action",
+        required=True,
+        help="entities subcommand",
+    )
+
+    p_list = sub.add_parser(
+        "list",
+        parents=[common_parser],
+        help="List entities in the wiki",
+    )
+    p_list.add_argument(
+        "--category",
+        choices=entity_yaml.CATEGORIES,
+        help="Filter by category",
+    )
+    p_list.add_argument(
+        "--created-by",
+        dest="created_by",
+        help="Filter by created_by_ingest",
+    )
+    p_list.set_defaults(func=run)
+
+    p_show = sub.add_parser(
+        "show",
+        parents=[common_parser],
+        help="Show one entity (resolved by slug, name, or alias)",
+    )
+    p_show.add_argument(
+        "query",
+        help="Entity slug, canonical name, or alias",
+    )
+    p_show.set_defaults(func=run)
+
+    p_new = sub.add_parser(
+        "new",
+        parents=[common_parser],
+        help="Hand-create a minimal entity stub",
+    )
+    p_new.add_argument(
+        "--category",
+        required=True,
+        choices=entity_yaml.CATEGORIES,
+    )
+    p_new.add_argument("--name", required=True, help="Canonical entity name")
+    p_new.add_argument(
+        "--slug",
+        default=None,
+        help="Optional slug; defaults to a slugified --name",
+    )
+    p_new.set_defaults(func=run)
+
+    p_rebuild = sub.add_parser(
+        "rebuild-index",
+        parents=[common_parser],
+        help="Rebuild the in-memory entity index (no cache yet; placeholder)",
+    )
+    p_rebuild.set_defaults(func=run)
+
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Dispatch to the matching `_run_*` based on `entities_action`."""
+    action = args.entities_action
+    cfg = cfg_mod.load_config()
+    wiki = cfg.wiki_repo_path
+
+    if action == "list":
+        return _run_list(args, wiki)
+    if action == "show":
+        return _run_show(args, wiki)
+    if action == "new":
+        return _run_new(args, wiki)
+    if action == "rebuild-index":
+        return _run_rebuild_index(wiki)
+    msg = f"unknown entities action: {action}"
+    raise ValueError(msg)
+
+
+def _run_list(args: argparse.Namespace, wiki) -> int:  # noqa: ANN001
+    entities = entity_yaml.scan(wiki)
+    if args.category:
+        entities = [e for e in entities if e.category == args.category]
+    if args.created_by:
+        entities = [e for e in entities if e.created_by_ingest == args.created_by]
+    if not entities:
+        print("(no entities)")  # noqa: T201
+        return 0
+
+    entities.sort(key=lambda e: (e.category, e.entity.casefold()))
+    # column widths
+    cat_w = max(len("CATEGORY"), *(len(e.category) for e in entities))
+    name_w = max(len("NAME"), *(len(e.entity) for e in entities))
+    slug_w = max(len("SLUG"), *(len(e.slug) for e in entities))
+    header = f"{'CATEGORY':<{cat_w}}  {'NAME':<{name_w}}  {'SLUG':<{slug_w}}  ALIASES"
+    print(header)  # noqa: T201
+    for e in entities:
+        print(  # noqa: T201
+            f"{e.category:<{cat_w}}  {e.entity:<{name_w}}  {e.slug:<{slug_w}}  "
+            f"{len(e.aliases)}"
+        )
+    return 0
+
+
+def _resolve(entities: list[Entity], query: str) -> list[Entity]:
+    """Return matches in resolution order: slug → name → alias."""
+    q_norm = entity_yaml.normalize_alias_name(query)
+    by_slug = [e for e in entities if e.slug == query]
+    if by_slug:
+        return by_slug
+    by_name = [e for e in entities if e.entity.casefold() == query.casefold()]
+    if by_name:
+        return by_name
+    return [
+        e
+        for e in entities
+        if any(entity_yaml.normalize_alias_name(a.name) == q_norm for a in e.aliases)
+    ]
+
+
+def _run_show(args: argparse.Namespace, wiki) -> int:  # noqa: ANN001
+    entities = entity_yaml.scan(wiki)
+    matches = _resolve(entities, args.query)
+    if not matches:
+        print(f"No entity matching {args.query!r}")  # noqa: T201
+        return 1
+    if len(matches) > 1:
+        print(f"Multiple matches for {args.query!r}:")  # noqa: T201
+        for e in matches:
+            print(f"  - {e.category}/{e.slug}  ({e.entity})")  # noqa: T201
+        return 1
+
+    e = matches[0]
+    print(f"entity:    {e.entity}")  # noqa: T201
+    print(f"category:  {e.category}")  # noqa: T201
+    print(f"slug:      {e.slug}")  # noqa: T201
+    if e.superseded_by:
+        print(f"superseded_by: {e.superseded_by}")  # noqa: T201
+    if e.created_by_ingest:
+        print(f"created_by_ingest: {e.created_by_ingest}")  # noqa: T201
+    if e.created_at:
+        print(f"created_at: {e.created_at}")  # noqa: T201
+    if e.aliases:
+        print("aliases:")  # noqa: T201
+        for a in e.aliases:
+            tag = f" ({a.source})" if a.source else ""
+            print(f"  - {a.name}{tag}")  # noqa: T201
+    else:
+        print("aliases: (none)")  # noqa: T201
+    print("facts: (no facts yet — populated in Phase 4)")  # noqa: T201
+    return 0
+
+
+def _slugify(name: str) -> str:
+    s = name.strip().casefold().replace(" ", "-")
+    s = _SLUG_STRIP_RE.sub("-", s)
+    return _SLUG_DASH_RE.sub("-", s).strip("-")
+
+
+def _run_new(args: argparse.Namespace, wiki) -> int:  # noqa: ANN001
+    slug = args.slug or _slugify(args.name)
+    if not slug:
+        print(f"error: could not derive a slug from {args.name!r}; pass --slug")  # noqa: T201
+        return 1
+    cat_dir = wiki / args.category
+    cat_dir.mkdir(parents=True, exist_ok=True)
+    target = cat_dir / f"{slug}.yaml"
+    if target.exists():
+        print(  # noqa: T201
+            f"error: {target} already exists; use `entities show {slug}` to inspect it"
+        )
+        return 1
+    e = entity_yaml.Entity(
+        entity=args.name,
+        category=args.category,
+        slug=slug,
+        created_at=format_iso_now(),
+    )
+    entity_yaml.write(e, target)
+    print(f"created {target}")  # noqa: T201
+    return 0
+
+
+def _run_rebuild_index(wiki) -> int:  # noqa: ANN001
+    entity_index.build(wiki)
+    print("(index rebuilt from filesystem; no cache in use)")  # noqa: T201
+    return 0

--- a/src/auto_lorebook/commands/plans.py
+++ b/src/auto_lorebook/commands/plans.py
@@ -1,0 +1,168 @@
+"""auto-lorebook plans subcommand group.
+
+Inspection-only commands. Mirrors `entities` shape: nested subparser
+with action dispatch on `args.plans_action`. Plans are intermediate
+artifacts in `~/.auto-lorebook/pending/<source_id>/plan.yaml` — there
+is no approval gate at this stage.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import plan_yaml
+
+if TYPE_CHECKING:
+    import argparse
+    from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+
+def add_parser(
+    subparsers: argparse._SubParsersAction,
+    common_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Register the `plans` subcommand group."""
+    parser = subparsers.add_parser(
+        "plans",
+        parents=[common_parser],
+        help="List or show pending Stage 2 plans",
+        description=(
+            "Inspect Stage 2 plans. Plans are intermediate artifacts; the "
+            "planner runs automatically after `approve-reading`. There is "
+            "no approval gate."
+        ),
+    )
+    sub = parser.add_subparsers(
+        dest="plans_action",
+        required=True,
+        help="plans subcommand",
+    )
+
+    p_list = sub.add_parser(
+        "list",
+        parents=[common_parser],
+        help="List pending plans across all ingests",
+    )
+    p_list.set_defaults(func=run)
+
+    p_show = sub.add_parser(
+        "show",
+        parents=[common_parser],
+        help="Show one plan by source/ingest id",
+    )
+    p_show.add_argument("source_id", help="source/ingest id")
+    p_show.set_defaults(func=run)
+
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Dispatch to the matching `_run_*` based on `plans_action`."""
+    action = args.plans_action
+    if action == "list":
+        return _run_list()
+    if action == "show":
+        return _run_show(args.source_id)
+    msg = f"unknown plans action: {action}"
+    raise ValueError(msg)
+
+
+def _pending_root() -> Path:
+    return cfg_mod.config_dir() / "pending"
+
+
+def _run_list() -> int:
+    root = _pending_root()
+    if not root.is_dir():
+        print("(no plans)")  # noqa: T201
+        return 0
+    rows: list[tuple[str, str, int, int]] = []
+    for sub in sorted(root.iterdir()):
+        plan_path = sub / "plan.yaml"
+        if not plan_path.is_file():
+            continue
+        try:
+            plan = plan_yaml.read(plan_path)
+        except plan_yaml.PlanError:
+            _logger.warning("plans list: could not parse %s; skipping", plan_path)
+            continue
+        rows.append((
+            plan.source_id,
+            plan.planned_at,
+            len(plan.planned_claims),
+            len(plan.new_entities),
+        ))
+    if not rows:
+        print("(no plans)")  # noqa: T201
+        return 0
+    sid_w = max(len("SOURCE"), *(len(r[0]) for r in rows))
+    when_w = max(len("PLANNED_AT"), *(len(r[1]) for r in rows))
+    header = f"{'SOURCE':<{sid_w}}  {'PLANNED_AT':<{when_w}}  CLAIMS  NEW_ENTITIES"
+    print(header)  # noqa: T201
+    for sid, when, claims, new_e in rows:
+        print(  # noqa: T201
+            f"{sid:<{sid_w}}  {when:<{when_w}}  {claims:>6}  {new_e:>12}"
+        )
+    return 0
+
+
+def _run_show(source_id: str) -> int:
+    plan_path = _pending_root() / source_id / "plan.yaml"
+    if not plan_path.is_file():
+        print(f"No plan for {source_id!r}")  # noqa: T201
+        return 1
+    try:
+        plan = plan_yaml.read(plan_path)
+    except plan_yaml.PlanError as e:
+        print(f"error: {e}")  # noqa: T201
+        return 1
+
+    print(f"source_id:  {plan.source_id}")  # noqa: T201
+    print(f"planned_at: {plan.planned_at}")  # noqa: T201
+
+    print()  # noqa: T201
+    print(f"entity_resolutions ({len(plan.entity_resolutions)}):")  # noqa: T201
+    for r in plan.entity_resolutions:
+        target = (
+            r.matched_entity
+            if r.resolution == "existing"
+            else r.proposed_entity_name
+            if r.resolution == "new"
+            else "(ambiguous)"
+        )
+        flag = " [review-needed]" if r.human_review_needed else ""
+        print(f"  - {r.mention!r} → {r.resolution}: {target}{flag}")  # noqa: T201
+        if r.rationale:
+            print(f"      rationale: {r.rationale}")  # noqa: T201
+
+    print()  # noqa: T201
+    print(f"new_entities ({len(plan.new_entities)}):")  # noqa: T201
+    for n in plan.new_entities:
+        aliases = (
+            f" (aliases: {', '.join(n.aliases_suggested)})"
+            if n.aliases_suggested
+            else ""
+        )
+        print(f"  - {n.category}/{n.name}{aliases}")  # noqa: T201
+
+    print()  # noqa: T201
+    print(f"planned_claims ({len(plan.planned_claims)}):")  # noqa: T201
+    for c in plan.planned_claims:
+        print(  # noqa: T201
+            f"  - {c.claim_group_id} {c.reading_section} "
+            f"[{c.locator}] {c.proposed_status}"
+        )
+        for t in c.targets:
+            tag = f" (new: {t.proposed_category})" if t.entity_state == "new" else ""
+            print(f"      → {t.entity}/{t.proposed_section}{tag}")  # noqa: T201
+
+    print()  # noqa: T201
+    print(f"unresolved ({len(plan.unresolved)}):")  # noqa: T201
+    for u in plan.unresolved:
+        print(f"  - {u.reading_section} [{u.locator}] {u.issue}")  # noqa: T201
+
+    return 0

--- a/src/auto_lorebook/config.py
+++ b/src/auto_lorebook/config.py
@@ -34,6 +34,7 @@ class ModelsConfig:
     primary: str = "anthropic/claude-sonnet-4-5"
     primary_context_window: int = 200_000
     extractor: str | None = None
+    planner: str | None = None
 
 
 @dataclass
@@ -125,6 +126,7 @@ def load_config(home: Path | None = None) -> Config:
         primary=models_raw.get("primary", "anthropic/claude-sonnet-4-5"),
         primary_context_window=int(models_raw.get("primary_context_window", 200_000)),
         extractor=models_raw.get("extractor"),
+        planner=models_raw.get("planner"),
     )
     preamble = PreambleConfig(
         budget_fraction=float(preamble_raw.get("budget_fraction", 0.8)),

--- a/src/auto_lorebook/entity_index.py
+++ b/src/auto_lorebook/entity_index.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+from auto_lorebook import entity_yaml
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-import yaml
-
 _logger = logging.getLogger(__name__)
 
-_CATEGORIES = ("characters", "locations", "factions", "events", "items", "concepts")
+_CATEGORIES = entity_yaml.CATEGORIES
 
 
 @dataclass
@@ -57,24 +57,17 @@ class EntityIndex:
 def _load_entry(path: Path) -> EntityEntry | None:
     """Parse a single entity YAML; return None on error or if superseded."""
     try:
-        raw: Any = yaml.safe_load(path.read_text(encoding="utf-8"))
-    except Exception:  # noqa: BLE001
+        e = entity_yaml.read(path)
+    except entity_yaml.EntityError:
         _logger.warning("entity_index: could not parse %s; skipping", path)
         return None
-    if not isinstance(raw, dict):
+    if e.superseded_by is not None:
         return None
-    if raw.get("superseded_by") is not None:
-        return None
-    entity = raw.get("entity")
-    category = raw.get("category")
-    slug = raw.get("slug")
-    if not entity or not category or not slug:
-        _logger.warning("entity_index: missing required fields in %s; skipping", path)
-        return None
-    aliases_raw: list[Any] = raw.get("aliases") or []
-    aliases = [a["name"] for a in aliases_raw if isinstance(a, dict) and a.get("name")]
     return EntityEntry(
-        entity=str(entity), category=str(category), slug=str(slug), aliases=aliases
+        entity=e.entity,
+        category=e.category,
+        slug=e.slug,
+        aliases=[a.name for a in e.aliases],
     )
 
 

--- a/src/auto_lorebook/entity_yaml.py
+++ b/src/auto_lorebook/entity_yaml.py
@@ -1,0 +1,237 @@
+"""Entity YAML read/write with schema validation.
+
+Mirrors `info_yaml.py` shape; preserves unknown top-level keys on
+write-back so Phase 4 facts written by future code survive a Phase 2
+read→write round-trip.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from auto_lorebook._io import atomic_write_text
+from auto_lorebook.schema import SchemaVersionError, read_schema_version
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+_MAX_SCHEMA = 1
+
+# the six entity categories; mirrors `entity_index._CATEGORIES`
+CATEGORIES: tuple[str, ...] = (
+    "characters",
+    "locations",
+    "factions",
+    "events",
+    "items",
+    "concepts",
+)
+
+# top-level keys this module knows about; everything else lands in `Entity.extra`
+_KNOWN_KEYS = frozenset(
+    {
+        "schema_version",
+        "entity",
+        "category",
+        "slug",
+        "aliases",
+        "superseded_by",
+        "created_at",
+        "created_by_ingest",
+        "updated_at",
+        "facts",
+    },
+)
+
+
+class EntityError(ValueError):
+    """Raised when entity YAML is missing or malformed."""
+
+
+@dataclass
+class Alias:
+    """Single alias record on an entity.
+
+    See `docs/architecture/entity-model.md` for `source` enum values.
+    """
+
+    name: str
+    added_by_ingest: str | None = None
+    added_at: str | None = None
+    source: str | None = None
+
+
+@dataclass
+class Entity:
+    """In-memory representation of `<category>/<slug>.yaml`."""
+
+    entity: str
+    category: str
+    slug: str
+    aliases: list[Alias] = field(default_factory=list)
+    superseded_by: str | None = None
+    created_at: str | None = None
+    created_by_ingest: str | None = None
+    updated_at: str | None = None
+    # facts are kept as raw dicts in Phase 2; Phase 4 models them properly.
+    facts: list[dict[str, Any]] = field(default_factory=list)
+    # unrecognized top-level keys; preserved on write-back.
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def normalize_alias_name(name: str) -> str:
+    """Case-fold + whitespace-trim for dedup and lookup comparisons."""
+    return name.strip().casefold()
+
+
+def _alias_from_dict(data: Any) -> Alias | None:  # noqa: ANN401
+    if not isinstance(data, dict):
+        return None
+    name = data.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    return Alias(
+        name=name,
+        added_by_ingest=data.get("added_by_ingest") or None,
+        added_at=data.get("added_at") or None,
+        source=data.get("source") or None,
+    )
+
+
+def _alias_to_dict(alias: Alias) -> dict[str, Any]:
+    return {
+        "name": alias.name,
+        "added_by_ingest": alias.added_by_ingest,
+        "added_at": alias.added_at,
+        "source": alias.source,
+    }
+
+
+def _dedup_aliases(aliases: list[Alias]) -> list[Alias]:
+    """Drop later records sharing a normalized name with an earlier one."""
+    seen: set[str] = set()
+    out: list[Alias] = []
+    for a in aliases:
+        key = normalize_alias_name(a.name)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(a)
+    return out
+
+
+def _from_dict(data: dict[str, Any], file_label: str) -> Entity:
+    for required in ("entity", "category", "slug"):
+        if not data.get(required):
+            msg = f"{file_label}: missing required field {required!r}"
+            raise EntityError(msg)
+    category = str(data["category"])
+    if category not in CATEGORIES:
+        allowed = ", ".join(CATEGORIES)
+        msg = f"{file_label}: category {category!r} not one of: {allowed}"
+        raise EntityError(msg)
+
+    raw_aliases = data.get("aliases") or []
+    if not isinstance(raw_aliases, list):
+        msg = f"{file_label}: aliases must be a list"
+        raise EntityError(msg)
+    aliases: list[Alias] = []
+    for raw in raw_aliases:
+        a = _alias_from_dict(raw)
+        if a is not None:
+            aliases.append(a)
+    aliases = _dedup_aliases(aliases)
+
+    facts = data.get("facts") or []
+    if not isinstance(facts, list):
+        msg = f"{file_label}: facts must be a list"
+        raise EntityError(msg)
+
+    extra = {k: v for k, v in data.items() if k not in _KNOWN_KEYS}
+
+    return Entity(
+        entity=str(data["entity"]),
+        category=category,
+        slug=str(data["slug"]),
+        aliases=aliases,
+        superseded_by=data.get("superseded_by") or None,
+        created_at=data.get("created_at") or None,
+        created_by_ingest=data.get("created_by_ingest") or None,
+        updated_at=data.get("updated_at") or None,
+        facts=list(facts),
+        extra=extra,
+    )
+
+
+def _to_dict(entity: Entity) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "schema_version": 1,
+        "entity": entity.entity,
+        "category": entity.category,
+        "slug": entity.slug,
+        "aliases": [_alias_to_dict(a) for a in _dedup_aliases(entity.aliases)],
+        "superseded_by": entity.superseded_by,
+        "created_at": entity.created_at,
+        "created_by_ingest": entity.created_by_ingest,
+        "updated_at": entity.updated_at,
+        "facts": list(entity.facts),
+    }
+    # preserved keys appended after known ones; ignore any collisions
+    for k, v in entity.extra.items():
+        if k not in out:
+            out[k] = v
+    return out
+
+
+def read(path: Path) -> Entity:
+    """Read and validate an entity YAML.
+
+    :raises EntityError: missing file, non-mapping root, or invalid contents
+    """
+    if not path.exists():
+        msg = f"{path}: file not found"
+        raise EntityError(msg)
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        msg = f"{path}: expected a YAML mapping"
+        raise EntityError(msg)
+    try:
+        read_schema_version(raw, str(path), max_supported=_MAX_SCHEMA)
+    except SchemaVersionError as e:
+        raise EntityError(str(e)) from e
+    return _from_dict(raw, str(path))
+
+
+def write(entity: Entity, path: Path) -> None:
+    """Atomically write entity to path; schema_version always first key."""
+    text = yaml.safe_dump(
+        _to_dict(entity),
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    )
+    atomic_write_text(path, text)
+
+
+def scan(wiki_repo: Path) -> list[Entity]:
+    """Read every entity YAML under `wiki_repo`; skip malformed with warning.
+
+    Sorted by category (per `CATEGORIES` order), then slug.
+    """
+    out: list[Entity] = []
+    for cat in CATEGORIES:
+        cat_dir = wiki_repo / cat
+        if not cat_dir.is_dir():
+            continue
+        for yaml_path in sorted(cat_dir.glob("*.yaml")):
+            try:
+                out.append(read(yaml_path))
+            except EntityError:
+                _logger.warning("entity_yaml: could not parse %s; skipping", yaml_path)
+    return out

--- a/src/auto_lorebook/plan_yaml.py
+++ b/src/auto_lorebook/plan_yaml.py
@@ -1,0 +1,393 @@
+"""Stage 2 `plan.yaml`: schema, read/write.
+
+Mirrors `structure.py` shape: dataclasses + ``_to_dict`` + ``_parse_*``
++ ``read``/``write``. Optional fields are written only when set so the
+on-disk YAML stays close to the spec in ``docs/pipeline/planner.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from auto_lorebook._io import atomic_write_text
+from auto_lorebook.entity_yaml import CATEGORIES
+from auto_lorebook.schema import SchemaVersionError, read_schema_version
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_MAX_SCHEMA = 1
+
+RESOLUTION_KINDS = frozenset({"existing", "new", "ambiguous"})
+ENTITY_STATES = frozenset({"existing", "new"})
+
+
+class PlanError(ValueError):
+    """plan.yaml is missing or malformed on read."""
+
+
+@dataclass(frozen=True)
+class EntityResolution:
+    """Routes one mention to existing entity, new proposal, or ambiguous."""
+
+    mention: str
+    mention_locations: list[str] = field(default_factory=list)
+    resolution: str = "ambiguous"
+    rationale: str = ""
+    matched_entity: str | None = None
+    proposed_entity_name: str | None = None
+    proposed_category: str | None = None
+    suggested_aliases_to_add: list[str] = field(default_factory=list)
+    human_review_needed: bool = False
+
+
+@dataclass(frozen=True)
+class NewEntityProposal:
+    """Proposed-but-not-yet-created entity surfaced by the planner."""
+
+    name: str
+    category: str
+    aliases_suggested: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ClaimTarget:
+    """One target of a planned claim (multi-target routing supported)."""
+
+    entity: str
+    entity_state: str  # existing | new
+    proposed_section: str
+    rationale: str = ""
+    proposed_category: str | None = None  # required iff entity_state == new
+
+
+@dataclass(frozen=True)
+class PlannedClaim:
+    """One reading bullet routed to one or more entities."""
+
+    claim_group_id: str
+    reading_section: str
+    reading_bullet_index: int
+    locator: str
+    locator_hint: str
+    proposed_speaker: str
+    proposed_status: str
+    proposed_status_reason: str | None = None
+    targets: list[ClaimTarget] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Unresolved:
+    """Reading-flagged uncertainty surfaced from structure to the plan."""
+
+    reading_section: str
+    locator: str
+    issue: str
+
+
+@dataclass
+class Plan:
+    """In-memory representation of pending/<id>/plan.yaml."""
+
+    source_id: str
+    planned_at: str
+    entity_resolutions: list[EntityResolution] = field(default_factory=list)
+    new_entities: list[NewEntityProposal] = field(default_factory=list)
+    planned_claims: list[PlannedClaim] = field(default_factory=list)
+    unresolved: list[Unresolved] = field(default_factory=list)
+
+
+# ------------- to_dict ----------------------------------------------------
+
+
+def _resolution_to_dict(r: EntityResolution) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "mention": r.mention,
+        "mention_locations": list(r.mention_locations),
+        "resolution": r.resolution,
+    }
+    if r.matched_entity is not None:
+        out["matched_entity"] = r.matched_entity
+    if r.proposed_entity_name is not None:
+        out["proposed_entity_name"] = r.proposed_entity_name
+    if r.proposed_category is not None:
+        out["proposed_category"] = r.proposed_category
+    if r.rationale:
+        out["rationale"] = r.rationale
+    if r.suggested_aliases_to_add:
+        out["suggested_aliases_to_add"] = list(r.suggested_aliases_to_add)
+    if r.human_review_needed:
+        out["human_review_needed"] = True
+    return out
+
+
+def _new_entity_to_dict(n: NewEntityProposal) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": n.name, "category": n.category}
+    if n.aliases_suggested:
+        out["aliases_suggested"] = list(n.aliases_suggested)
+    return out
+
+
+def _target_to_dict(t: ClaimTarget) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "entity": t.entity,
+        "entity_state": t.entity_state,
+        "proposed_section": t.proposed_section,
+    }
+    if t.proposed_category is not None:
+        out["proposed_category"] = t.proposed_category
+    if t.rationale:
+        out["rationale"] = t.rationale
+    return out
+
+
+def _claim_to_dict(c: PlannedClaim) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "claim_group_id": c.claim_group_id,
+        "reading_section": c.reading_section,
+        "reading_bullet_index": c.reading_bullet_index,
+        "locator": c.locator,
+        "locator_hint": c.locator_hint,
+        "proposed_speaker": c.proposed_speaker,
+        "proposed_status": c.proposed_status,
+    }
+    if c.proposed_status_reason is not None:
+        out["proposed_status_reason"] = c.proposed_status_reason
+    out["targets"] = [_target_to_dict(t) for t in c.targets]
+    return out
+
+
+def _unresolved_to_dict(u: Unresolved) -> dict[str, Any]:
+    return {
+        "reading_section": u.reading_section,
+        "locator": u.locator,
+        "issue": u.issue,
+    }
+
+
+def _to_dict(p: Plan) -> dict[str, Any]:
+    return {
+        "schema_version": _MAX_SCHEMA,
+        "source_id": p.source_id,
+        "planned_at": p.planned_at,
+        "entity_resolutions": [_resolution_to_dict(r) for r in p.entity_resolutions],
+        "new_entities": [_new_entity_to_dict(n) for n in p.new_entities],
+        "planned_claims": [_claim_to_dict(c) for c in p.planned_claims],
+        "unresolved": [_unresolved_to_dict(u) for u in p.unresolved],
+    }
+
+
+# ------------- parse_* (used by stage2 too) ------------------------------
+
+
+def _str_list(raw: object, field_label: str) -> list[str]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        msg = f"{field_label}: expected a list, got {type(raw).__name__}"
+        raise PlanError(msg)
+    return [str(x) for x in raw]
+
+
+def parse_resolution(raw: dict[str, Any]) -> EntityResolution:
+    """Build an EntityResolution from a JSON/YAML mapping."""
+    if not isinstance(raw, dict):
+        msg = f"entity_resolutions: expected mapping, got {type(raw).__name__}"
+        raise PlanError(msg)
+    resolution = str(raw.get("resolution") or "")
+    if resolution not in RESOLUTION_KINDS:
+        msg = (
+            f"entity_resolutions: resolution must be one of "
+            f"{sorted(RESOLUTION_KINDS)}, got {resolution!r}"
+        )
+        raise PlanError(msg)
+    proposed_category = raw.get("proposed_category")
+    if proposed_category is not None and proposed_category not in CATEGORIES:
+        msg = (
+            f"entity_resolutions: proposed_category must be one of "
+            f"{list(CATEGORIES)}, got {proposed_category!r}"
+        )
+        raise PlanError(msg)
+    return EntityResolution(
+        mention=str(raw.get("mention") or ""),
+        mention_locations=_str_list(raw.get("mention_locations"), "mention_locations"),
+        resolution=resolution,
+        rationale=str(raw.get("rationale") or ""),
+        matched_entity=(raw.get("matched_entity") or None),
+        proposed_entity_name=(raw.get("proposed_entity_name") or None),
+        proposed_category=proposed_category,
+        suggested_aliases_to_add=_str_list(
+            raw.get("suggested_aliases_to_add"), "suggested_aliases_to_add"
+        ),
+        human_review_needed=bool(raw.get("human_review_needed")),
+    )
+
+
+def parse_new_entity(raw: dict[str, Any]) -> NewEntityProposal:
+    """Build a NewEntityProposal from a JSON/YAML mapping."""
+    if not isinstance(raw, dict):
+        msg = f"new_entities: expected mapping, got {type(raw).__name__}"
+        raise PlanError(msg)
+    name = str(raw.get("name") or "").strip()
+    if not name:
+        msg = "new_entities: empty name"
+        raise PlanError(msg)
+    category = str(raw.get("category") or "")
+    if category not in CATEGORIES:
+        msg = (
+            f"new_entities: category must be one of {list(CATEGORIES)}, "
+            f"got {category!r}"
+        )
+        raise PlanError(msg)
+    return NewEntityProposal(
+        name=name,
+        category=category,
+        aliases_suggested=_str_list(raw.get("aliases_suggested"), "aliases_suggested"),
+    )
+
+
+def parse_target(raw: dict[str, Any]) -> ClaimTarget:
+    """Build a ClaimTarget from a JSON/YAML mapping."""
+    if not isinstance(raw, dict):
+        msg = f"targets: expected mapping, got {type(raw).__name__}"
+        raise PlanError(msg)
+    entity_state = str(raw.get("entity_state") or "")
+    if entity_state not in ENTITY_STATES:
+        msg = (
+            f"targets: entity_state must be one of {sorted(ENTITY_STATES)}, "
+            f"got {entity_state!r}"
+        )
+        raise PlanError(msg)
+    proposed_category = raw.get("proposed_category")
+    if entity_state == "new":
+        if not proposed_category:
+            msg = "targets: entity_state=new requires proposed_category"
+            raise PlanError(msg)
+        if proposed_category not in CATEGORIES:
+            msg = (
+                f"targets: proposed_category must be one of {list(CATEGORIES)}, "
+                f"got {proposed_category!r}"
+            )
+            raise PlanError(msg)
+    elif proposed_category is not None and proposed_category not in CATEGORIES:
+        msg = (
+            f"targets: proposed_category must be one of {list(CATEGORIES)}, "
+            f"got {proposed_category!r}"
+        )
+        raise PlanError(msg)
+    entity = str(raw.get("entity") or "").strip()
+    if not entity:
+        msg = "targets: empty entity"
+        raise PlanError(msg)
+    proposed_section = str(raw.get("proposed_section") or "").strip()
+    if not proposed_section:
+        msg = "targets: empty proposed_section"
+        raise PlanError(msg)
+    return ClaimTarget(
+        entity=entity,
+        entity_state=entity_state,
+        proposed_section=proposed_section,
+        rationale=str(raw.get("rationale") or ""),
+        proposed_category=proposed_category or None,
+    )
+
+
+def parse_claim(raw: dict[str, Any]) -> PlannedClaim:
+    """Build a PlannedClaim from a JSON/YAML mapping."""
+    if not isinstance(raw, dict):
+        msg = f"planned_claims: expected mapping, got {type(raw).__name__}"
+        raise PlanError(msg)
+    targets_raw = raw.get("targets") or []
+    if not isinstance(targets_raw, list) or not targets_raw:
+        msg = "planned_claims: 'targets' must be a non-empty list"
+        raise PlanError(msg)
+    targets = [parse_target(t) for t in targets_raw]
+    bullet_idx_raw = raw.get("reading_bullet_index")
+    if not isinstance(bullet_idx_raw, int) or bullet_idx_raw < 0:
+        msg = (
+            f"planned_claims: reading_bullet_index must be non-negative int, "
+            f"got {bullet_idx_raw!r}"
+        )
+        raise PlanError(msg)
+    return PlannedClaim(
+        claim_group_id=str(raw.get("claim_group_id") or ""),
+        reading_section=str(raw.get("reading_section") or ""),
+        reading_bullet_index=bullet_idx_raw,
+        locator=str(raw.get("locator") or ""),
+        locator_hint=str(raw.get("locator_hint") or ""),
+        proposed_speaker=str(raw.get("proposed_speaker") or ""),
+        proposed_status=str(raw.get("proposed_status") or ""),
+        proposed_status_reason=(raw.get("proposed_status_reason") or None),
+        targets=targets,
+    )
+
+
+def parse_unresolved(raw: dict[str, Any]) -> Unresolved:
+    """Build an Unresolved from a JSON/YAML mapping."""
+    if not isinstance(raw, dict):
+        msg = f"unresolved: expected mapping, got {type(raw).__name__}"
+        raise PlanError(msg)
+    return Unresolved(
+        reading_section=str(raw.get("reading_section") or ""),
+        locator=str(raw.get("locator") or ""),
+        issue=str(raw.get("issue") or ""),
+    )
+
+
+# ------------- read / write ----------------------------------------------
+
+
+def read(path: Path) -> Plan:
+    """Read and parse plan.yaml.
+
+    :raises PlanError: missing / malformed / unsupported schema
+    """
+    if not path.exists():
+        msg = f"{path}: file not found"
+        raise PlanError(msg)
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        msg = f"{path}: expected a YAML mapping"
+        raise PlanError(msg)
+    try:
+        read_schema_version(raw, str(path), max_supported=_MAX_SCHEMA)
+    except SchemaVersionError as e:
+        raise PlanError(str(e)) from e
+    source_id_raw = raw.get("source_id")
+    planned_at_raw = raw.get("planned_at")
+    if not source_id_raw:
+        msg = f"{path}: missing source_id"
+        raise PlanError(msg)
+    if not planned_at_raw:
+        msg = f"{path}: missing planned_at"
+        raise PlanError(msg)
+    try:
+        return Plan(
+            source_id=str(source_id_raw),
+            planned_at=str(planned_at_raw),
+            entity_resolutions=[
+                parse_resolution(r) for r in (raw.get("entity_resolutions") or [])
+            ],
+            new_entities=[parse_new_entity(n) for n in (raw.get("new_entities") or [])],
+            planned_claims=[parse_claim(c) for c in (raw.get("planned_claims") or [])],
+            unresolved=[parse_unresolved(u) for u in (raw.get("unresolved") or [])],
+        )
+    except PlanError:
+        raise
+    except (KeyError, ValueError, TypeError) as e:
+        msg = f"{path}: malformed plan ({e})"
+        raise PlanError(msg) from e
+
+
+def write(plan: Plan, path: Path) -> None:
+    """Atomically write plan.yaml."""
+    text = yaml.safe_dump(
+        _to_dict(plan),
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    )
+    atomic_write_text(path, text)

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -20,10 +20,12 @@ from auto_lorebook import (
 )
 from auto_lorebook import gap_check as gap_check_mod
 from auto_lorebook import info_yaml as info_yaml_mod
+from auto_lorebook import plan_yaml as plan_yaml_mod
 from auto_lorebook import preamble as preamble_mod
 from auto_lorebook import reading as reading_mod
 from auto_lorebook import stage1a as stage1a_mod
 from auto_lorebook import stage1b as stage1b_mod
+from auto_lorebook import stage2 as stage2_mod
 from auto_lorebook import structure as structure_mod
 from auto_lorebook import transcript as transcript_mod
 from auto_lorebook import wiki_context as wiki_context_mod
@@ -34,6 +36,7 @@ if TYPE_CHECKING:
 
     from auto_lorebook.gap_check import GapWarning
     from auto_lorebook.info_yaml import Info
+    from auto_lorebook.plan_yaml import Plan
 
 _logger = logging.getLogger(__name__)
 
@@ -50,6 +53,14 @@ class GenerateResult:
     structure_path: Path
     bullets_path: Path
     gap_warnings: list[GapWarning]
+
+
+@dataclass
+class PlanResult:
+    """Plan written by a Stage 2 run."""
+
+    plan_path: Path
+    plan: Plan
 
 
 def generate(cfg: cfg_mod.Config, source_id: str) -> GenerateResult:
@@ -106,6 +117,93 @@ def pending_structure_path(source_id: str) -> Path:
 
 def pending_bullets_path(source_id: str) -> Path:
     return pending_dir(source_id) / "bullets.yaml"
+
+
+def pending_plan_path(source_id: str) -> Path:
+    """Plan artifact path. Sibling to the `reading/` subdir."""
+    return cfg_mod.config_dir() / "pending" / source_id / "plan.yaml"
+
+
+def plan(cfg: cfg_mod.Config, source_id: str) -> PlanResult:
+    """Run Stage 2 on an approved reading and write `plan.yaml`.
+
+    :raises ReadingPipelineError: reading not approved, prior pipeline
+        artifacts missing, or planner / preamble failure.
+    """
+    wiki_repo = cfg.wiki_repo_path
+    approved_path = wiki_repo / "sources" / source_id / "reading.md"
+    if not approved_path.exists():
+        msg = (
+            f"No approved reading at {approved_path}. "
+            f"Run `approve-reading {source_id}` first."
+        )
+        raise ReadingPipelineError(msg)
+    try:
+        fm = reading_mod.read_frontmatter(approved_path)
+    except reading_mod.ReadingError as e:
+        raise ReadingPipelineError(str(e)) from e
+    if fm.get("reading_status") != "approved":
+        msg = (
+            f"Reading at {approved_path} is not approved "
+            f"(reading_status={fm.get('reading_status')!r})."
+        )
+        raise ReadingPipelineError(msg)
+
+    structure_path = pending_structure_path(source_id)
+    bullets_path = pending_bullets_path(source_id)
+    if not structure_path.exists() or not bullets_path.exists():
+        msg = (
+            f"Missing prior pipeline artifacts for {source_id!r}. "
+            "Re-run `regenerate-reading` to repopulate "
+            f"{pending_dir(source_id)}."
+        )
+        raise ReadingPipelineError(msg)
+    try:
+        structure = structure_mod.read(structure_path)
+    except structure_mod.StructureError as e:
+        raise ReadingPipelineError(str(e)) from e
+    try:
+        bullets = stage1b_mod.read_bullets(bullets_path)
+    except stage1b_mod.Stage1bError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    info_path = wiki_repo / "sources" / source_id / "info.yaml"
+    try:
+        info = info_yaml_mod.read(info_path)
+    except info_yaml_mod.InfoError as e:
+        raise ReadingPipelineError(str(e)) from e
+    wc = wiki_context_mod.read(wiki_repo / ".wiki-context.yaml")
+    cors = corrections_mod.read(wiki_repo / ".transcription-corrections.yaml")
+    idx = entity_index_mod.build(wiki_repo)
+    p = preamble_mod.assemble(info, wc, cors, idx, reduced=False)
+    try:
+        p.check_budget(
+            context_window=cfg.models.primary_context_window,
+            budget_fraction=cfg.preamble.budget_fraction,
+        )
+    except preamble_mod.PreambleTooLargeError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    client = _build_client(cfg)
+    model = cfg.models.planner or cfg.models.primary
+
+    reading_text = approved_path.read_text(encoding="utf-8")
+    try:
+        result_plan = stage2_mod.run(
+            reading_text=reading_text,
+            structure=structure,
+            bullets=bullets,
+            preamble_text=p.text,
+            source_id=source_id,
+            client=client,
+            model=model,
+        )
+    except stage2_mod.Stage2Error as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    plan_path = pending_plan_path(source_id)
+    plan_yaml_mod.write(result_plan, plan_path)
+    return PlanResult(plan_path=plan_path, plan=result_plan)
 
 
 def _run_full(cfg: cfg_mod.Config, source_id: str) -> GenerateResult:

--- a/src/auto_lorebook/stage2.py
+++ b/src/auto_lorebook/stage2.py
@@ -1,0 +1,205 @@
+"""Stage 2: Planner.
+
+Routes claims from an approved reading to one or more entities and
+emits a `Plan` ready to write to ``pending/<source_id>/plan.yaml``.
+
+No filesystem side effects in this module — orchestration writes the
+artifact via :func:`auto_lorebook.plan_yaml.write`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from auto_lorebook import plan_yaml
+from auto_lorebook.llm_helpers import build_system_prompt, parse_json_object
+from auto_lorebook.plan_yaml import Plan
+from auto_lorebook.timestamps import format_iso_now
+
+if TYPE_CHECKING:
+    from auto_lorebook.openrouter import OpenRouterClient
+    from auto_lorebook.stage1b import ReadingBullets
+    from auto_lorebook.structure import Structure
+
+_logger = logging.getLogger(__name__)
+
+_TASK_INSTRUCTIONS = """\
+You are routing claim bullets from an approved wiki reading to entities
+in a worldbuilding wiki. The entity index in the preamble lists every
+existing entity with its category and aliases. Read the reading body and
+its bullets and emit a single JSON object matching this schema exactly:
+
+{
+  "entity_resolutions": [
+    {
+      "mention": "<text as it appears>",
+      "mention_locations": ["[h:mm:ss-h:mm:ss] short context"],
+      "resolution": "existing" | "new" | "ambiguous",
+      "matched_entity": null | "<canonical name from the index>",
+      "proposed_entity_name": null | "<name>",
+      "proposed_category": null | "characters" | "locations" | "factions"
+                                | "events" | "items" | "concepts",
+      "rationale": "<one sentence>",
+      "suggested_aliases_to_add": [],
+      "human_review_needed": false
+    }
+  ],
+  "new_entities": [
+    {"name": "<name>", "category": "<category>", "aliases_suggested": []}
+  ],
+  "planned_claims": [
+    {
+      "claim_group_id": "cg-001",
+      "reading_section": "[h:mm:ss-h:mm:ss] <segment title>",
+      "reading_bullet_index": 0,
+      "locator": "h:mm:ss",
+      "locator_hint": "h:mm:ss-h:mm:ss",
+      "proposed_speaker": "<speaker name>",
+      "proposed_status": "authoritative" | "hearsay" | "speculation",
+      "proposed_status_reason": null | "<note>",
+      "targets": [
+        {
+          "entity": "<canonical name>",
+          "entity_state": "existing" | "new",
+          "proposed_section": "<short section name>",
+          "proposed_category": null | "<category if entity_state=new>",
+          "rationale": "<why this claim concerns this entity>"
+        }
+      ]
+    }
+  ],
+  "unresolved": [
+    {
+      "reading_section": "[h:mm:ss-h:mm:ss] <segment title>",
+      "locator": "h:mm:ss",
+      "issue": "<short note>"
+    }
+  ]
+}
+
+Hard rules:
+- Route a claim to a target entity only when the claim CONCERNS that
+  entity, not merely mentions it. "Theron met Aelindra at the Festival
+  of Masks" routes to Theron and Aelindra, NOT to the Festival.
+- Single-target routing is the common case; use multi-target only when
+  the claim genuinely carries information about more than one entity.
+- `claim_group_id` MUST be unique per claim across the plan
+  (cg-001, cg-002, ...). Sibling targets sharing one bullet share one id.
+- `matched_entity` (when resolution=existing) MUST be a canonical name
+  shown in the entity index. If you can't find a clean match, prefer
+  resolution=new or resolution=ambiguous.
+- `entity_state=new` targets MUST also appear in `new_entities` with a
+  matching name and category, and the target MUST set `proposed_category`.
+- `mention_locations` should be drawn from the reading sections /
+  bullet anchors so a human can audit the routing.
+- Mirror reading-flagged uncertainty (uncertain names, attribution) into
+  `unresolved` with the original locator.
+- Every `entity_resolutions[i]` whose resolution is "ambiguous" MUST set
+  human_review_needed=true.
+
+Emit ONLY the JSON object. No prose, no code fences, no commentary.
+"""
+
+
+class Stage2Error(RuntimeError):
+    """Stage 2 failed: bad JSON or schema violation."""
+
+
+def run(
+    *,
+    reading_text: str,
+    structure: Structure,
+    bullets: ReadingBullets,
+    preamble_text: str,
+    source_id: str,
+    client: OpenRouterClient,
+    model: str,
+) -> Plan:
+    """Run Stage 2 against an approved reading and produce a Plan.
+
+    :param reading_text: full ``reading.md`` body (frontmatter included)
+    :param structure: Stage 1a output (segment ids, uncertainty flags)
+    :param bullets: Stage 1b output (per-segment claims with anchors)
+    :raises Stage2Error: bad LLM output or schema violation
+    """
+    user_msg = _build_user(reading_text, structure, bullets)
+    messages = [
+        {
+            "role": "system",
+            "content": build_system_prompt(preamble_text, _TASK_INSTRUCTIONS),
+        },
+        {"role": "user", "content": user_msg},
+    ]
+    resp = client.complete(
+        messages,
+        model=model,
+        response_format={"type": "json_object"},
+    )
+    try:
+        payload = parse_json_object(resp.text, "Stage 2")
+    except ValueError as e:
+        raise Stage2Error(str(e)) from e
+    return _payload_to_plan(payload, source_id=source_id)
+
+
+def _build_user(
+    reading_text: str,
+    structure: Structure,
+    bullets: ReadingBullets,
+) -> str:
+    """Assemble the user message from reading + structure + bullets."""
+    parts: list[str] = [
+        "Approved reading:",
+        "",
+        reading_text.rstrip(),
+        "",
+        "Bullet index per segment (use these for reading_bullet_index):",
+    ]
+    for seg in structure.segments:
+        seg_bullets = bullets.segments.get(seg.id, [])
+        if not seg_bullets:
+            parts.append(f"- {seg.id} {seg.title!r}: (no bullets)")
+            continue
+        parts.append(f"- {seg.id} {seg.title!r}:")
+        parts.extend(f"    [{idx}] {b.text}" for idx, b in enumerate(seg_bullets))
+    if structure.uncertainty_flags:
+        parts.extend([
+            "",
+            "Reading-flagged uncertainty (mirror into `unresolved` as appropriate):",
+        ])
+        for flag in structure.uncertainty_flags:
+            note = f"; {flag.note}" if flag.note else ""
+            parts.append(
+                f"- locator={flag.locator:.0f}s kind={flag.kind} "
+                f"span={flag.span!r}{note}"
+            )
+    return "\n".join(parts)
+
+
+def _payload_to_plan(payload: dict[str, Any], *, source_id: str) -> Plan:
+    try:
+        resolutions = [
+            plan_yaml.parse_resolution(r)
+            for r in (payload.get("entity_resolutions") or [])
+        ]
+        new_entities = [
+            plan_yaml.parse_new_entity(n) for n in (payload.get("new_entities") or [])
+        ]
+        claims = [
+            plan_yaml.parse_claim(c) for c in (payload.get("planned_claims") or [])
+        ]
+        unresolved = [
+            plan_yaml.parse_unresolved(u) for u in (payload.get("unresolved") or [])
+        ]
+    except plan_yaml.PlanError as e:
+        msg = f"Stage 2 schema violation: {e}"
+        raise Stage2Error(msg) from e
+    return Plan(
+        source_id=source_id,
+        planned_at=format_iso_now(),
+        entity_resolutions=resolutions,
+        new_entities=new_entities,
+        planned_claims=claims,
+        unresolved=unresolved,
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,6 +60,7 @@ def test_load_config_with_all_fields(tmp_path: Path) -> None:
                 "primary": "anthropic/claude-opus-4-7",
                 "primary_context_window": 100_000,
                 "extractor": "anthropic/claude-haiku-4-5",
+                "planner": "anthropic/claude-sonnet-4-5",
             },
             "preamble": {"budget_fraction": 0.6},
         },
@@ -67,6 +68,7 @@ def test_load_config_with_all_fields(tmp_path: Path) -> None:
     cfg = load_config(home=tmp_path)
     assert cfg.models.primary_context_window == 100_000
     assert cfg.models.extractor == "anthropic/claude-haiku-4-5"
+    assert cfg.models.planner == "anthropic/claude-sonnet-4-5"
     assert cfg.preamble.budget_fraction == pytest.approx(0.6)
 
 

--- a/tests/test_entities_cmd.py
+++ b/tests/test_entities_cmd.py
@@ -1,0 +1,303 @@
+"""Tests for the `entities` subcommand group."""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from auto_lorebook.cli import create_parser
+from auto_lorebook.commands import entities_cmd
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def configured_wiki(tmp_wiki: Path, tmp_home: Path) -> Path:
+    """tmp_wiki + a config.yaml pointing at it."""
+    (tmp_home / "config.yaml").write_text(
+        f"schema_version: 1\nwiki_repo_path: {tmp_wiki}\n",
+        encoding="utf-8",
+    )
+    return tmp_wiki
+
+
+def _write_entity(
+    wiki: Path,
+    *,
+    category: str,
+    slug: str,
+    name: str,
+    aliases: list[str] | None = None,
+    created_by_ingest: str | None = None,
+    superseded_by: str | None = None,
+) -> None:
+    data: dict[str, object] = {
+        "schema_version": 1,
+        "entity": name,
+        "category": category,
+        "slug": slug,
+        "aliases": [{"name": a} for a in (aliases or [])],
+        "superseded_by": superseded_by,
+    }
+    if created_by_ingest is not None:
+        data["created_by_ingest"] = created_by_ingest
+    (wiki / category / f"{slug}.yaml").write_text(
+        yaml.safe_dump(data, sort_keys=False), encoding="utf-8"
+    )
+
+
+def _ns(action: str, **kwargs: object) -> argparse.Namespace:
+    base: dict[str, object] = {
+        "entities_action": action,
+        "category": None,
+        "created_by": None,
+        "query": None,
+        "name": None,
+        "slug": None,
+    }
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+class TestList:
+    def test_empty_wiki(
+        self,
+        configured_wiki: Path,  # noqa: ARG002
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = entities_cmd.run(_ns("list"))
+        assert rc == 0
+        assert "(no entities)" in capsys.readouterr().out
+
+    def test_lists_entities(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki, category="characters", slug="theron", name="Theron"
+        )
+        _write_entity(
+            configured_wiki, category="locations", slug="aldara", name="Aldara"
+        )
+        rc = entities_cmd.run(_ns("list"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "CATEGORY" in out
+        assert "Theron" in out
+        assert "Aldara" in out
+        # category-then-name sort: characters/Theron before locations/Aldara
+        assert out.index("Theron") < out.index("Aldara")
+
+    def test_filter_by_category(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki, category="characters", slug="theron", name="Theron"
+        )
+        _write_entity(
+            configured_wiki, category="locations", slug="aldara", name="Aldara"
+        )
+        rc = entities_cmd.run(_ns("list", category="characters"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Theron" in out
+        assert "Aldara" not in out
+
+    def test_filter_by_created_by(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki,
+            category="characters",
+            slug="alpha",
+            name="Alpha",
+            created_by_ingest="ingest-001",
+        )
+        _write_entity(
+            configured_wiki,
+            category="characters",
+            slug="beta",
+            name="Beta",
+            created_by_ingest="ingest-002",
+        )
+        rc = entities_cmd.run(_ns("list", created_by="ingest-001"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Alpha" in out
+        assert "Beta" not in out
+
+
+class TestShow:
+    def test_by_slug(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki,
+            category="characters",
+            slug="theron",
+            name="Theron",
+            aliases=["King Theron"],
+        )
+        rc = entities_cmd.run(_ns("show", query="theron"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "entity:    Theron" in out
+        assert "King Theron" in out
+        assert "no facts yet" in out
+
+    def test_by_name_case_insensitive(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki, category="characters", slug="theron", name="Theron"
+        )
+        rc = entities_cmd.run(_ns("show", query="THERON"))
+        assert rc == 0
+        assert "Theron" in capsys.readouterr().out
+
+    def test_by_alias(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki,
+            category="locations",
+            slug="aldara",
+            name="Aldara",
+            aliases=["Kingdom of Aldara"],
+        )
+        rc = entities_cmd.run(_ns("show", query="kingdom of aldara"))
+        assert rc == 0
+        assert "Aldara" in capsys.readouterr().out
+
+    def test_miss(
+        self,
+        configured_wiki: Path,  # noqa: ARG002
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = entities_cmd.run(_ns("show", query="nope"))
+        assert rc == 1
+        assert "No entity matching" in capsys.readouterr().out
+
+    def test_ambiguous(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki,
+            category="characters",
+            slug="aldara-c",
+            name="Aldara",
+        )
+        _write_entity(
+            configured_wiki,
+            category="locations",
+            slug="aldara-l",
+            name="Aldara",
+        )
+        rc = entities_cmd.run(_ns("show", query="Aldara"))
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Multiple matches" in out
+        assert "characters/aldara-c" in out
+        assert "locations/aldara-l" in out
+
+
+class TestNew:
+    def test_default_slug(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = entities_cmd.run(
+            _ns("new", category="characters", name="King Theron the Brave")
+        )
+        assert rc == 0
+        target = configured_wiki / "characters" / "king-theron-the-brave.yaml"
+        assert target.exists()
+        data = yaml.safe_load(target.read_text(encoding="utf-8"))
+        assert data["entity"] == "King Theron the Brave"
+        assert data["category"] == "characters"
+        assert data["slug"] == "king-theron-the-brave"
+        assert data["schema_version"] == 1
+        assert data["created_at"]
+        assert "created" in capsys.readouterr().out
+
+    def test_explicit_slug(self, configured_wiki: Path) -> None:
+        rc = entities_cmd.run(
+            _ns("new", category="locations", name="Aldara", slug="my-aldara")
+        )
+        assert rc == 0
+        assert (configured_wiki / "locations" / "my-aldara.yaml").exists()
+
+    def test_collision_refused(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(
+            configured_wiki, category="characters", slug="theron", name="Theron"
+        )
+        rc = entities_cmd.run(
+            _ns("new", category="characters", name="Theron", slug="theron")
+        )
+        assert rc == 1
+        assert "already exists" in capsys.readouterr().out
+
+    def test_unslugifiable_name_rejected(
+        self,
+        configured_wiki: Path,  # noqa: ARG002
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = entities_cmd.run(_ns("new", category="characters", name="!!!"))
+        assert rc == 1
+        assert "could not derive a slug" in capsys.readouterr().out
+
+
+class TestRebuildIndex:
+    def test_smoke(
+        self,
+        configured_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_entity(configured_wiki, category="characters", slug="x", name="X")
+        rc = entities_cmd.run(_ns("rebuild-index"))
+        assert rc == 0
+        assert "no cache in use" in capsys.readouterr().out
+
+
+def test_argparse_requires_subaction() -> None:
+    parser = create_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["entities"])
+
+
+def test_argparse_routes_list() -> None:
+    parser = create_parser()
+    args = parser.parse_args(["entities", "list", "--category", "characters"])
+    assert args.entities_action == "list"
+    assert args.category == "characters"
+    assert args.func is entities_cmd.run

--- a/tests/test_entity_index.py
+++ b/tests/test_entity_index.py
@@ -9,6 +9,8 @@ import yaml
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
 from auto_lorebook.entity_index import build
 
 
@@ -115,3 +117,19 @@ def test_render_deterministic(tmp_wiki: Path) -> None:
     r1 = build(tmp_wiki).render_for_preamble()
     r2 = build(tmp_wiki).render_for_preamble()
     assert r1 == r2
+
+
+def test_malformed_entity_skipped_with_warning(
+    tmp_wiki: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _write_entity(tmp_wiki, "characters", "good", "Good")
+    # missing schema_version: rejected by entity_yaml reader
+    (tmp_wiki / "characters" / "bad.yaml").write_text(
+        "entity: Bad\ncategory: characters\nslug: bad\n", encoding="utf-8"
+    )
+    with caplog.at_level("WARNING"):
+        idx = build(tmp_wiki)
+    rendered = idx.render_for_preamble()
+    assert "Good" in rendered
+    assert "Bad" not in rendered
+    assert any("could not parse" in r.message for r in caplog.records)

--- a/tests/test_entity_yaml.py
+++ b/tests/test_entity_yaml.py
@@ -1,0 +1,240 @@
+"""Tests for entity_yaml.py."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from auto_lorebook.entity_yaml import (
+    Alias,
+    Entity,
+    EntityError,
+    normalize_alias_name,
+    read,
+    write,
+)
+from auto_lorebook.schema import SchemaVersionError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_yaml(path: Path, data: dict[str, object]) -> None:
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _minimal_dict(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "schema_version": 1,
+        "entity": "Aldara",
+        "category": "locations",
+        "slug": "aldara",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_read_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(EntityError, match="file not found"):
+        read(tmp_path / "nope.yaml")
+
+
+def test_read_non_mapping_root(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    p.write_text("- just a list\n", encoding="utf-8")
+    with pytest.raises(EntityError, match="expected a YAML mapping"):
+        read(p)
+
+
+def test_read_missing_schema_version(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(p, {"entity": "X", "category": "characters", "slug": "x"})
+    with pytest.raises(EntityError, match="schema_version"):
+        read(p)
+
+
+def test_read_future_schema_version(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(p, _minimal_dict(schema_version=99))
+    with pytest.raises(EntityError):
+        read(p)
+
+
+def test_read_missing_required_field(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(p, {"schema_version": 1, "entity": "X", "category": "characters"})
+    with pytest.raises(EntityError, match="slug"):
+        read(p)
+
+
+def test_read_bad_category(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(p, _minimal_dict(category="weapons"))
+    with pytest.raises(EntityError, match="category"):
+        read(p)
+
+
+def test_read_bad_aliases_type(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(p, _minimal_dict(aliases="not a list"))
+    with pytest.raises(EntityError, match="aliases"):
+        read(p)
+
+
+def test_read_minimal_entity(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(p, _minimal_dict())
+    e = read(p)
+    assert e.entity == "Aldara"
+    assert e.category == "locations"
+    assert e.slug == "aldara"
+    assert e.aliases == []
+    assert e.facts == []
+    assert e.extra == {}
+
+
+def test_read_full_entity(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(
+        p,
+        _minimal_dict(
+            aliases=[
+                {
+                    "name": "Kingdom of Aldara",
+                    "added_by_ingest": "ingest-001",
+                    "added_at": "2026-01-16T14:32:11Z",
+                    "source": "hand-edited",
+                },
+            ],
+            superseded_by=None,
+            created_at="2026-01-16T14:32:11Z",
+            created_by_ingest="ingest-001",
+            updated_at="2026-02-03T19:14:55Z",
+            facts=[{"id": "aldara-f001", "text": "founded in the Second Age"}],
+        ),
+    )
+    e = read(p)
+    assert len(e.aliases) == 1
+    assert e.aliases[0].name == "Kingdom of Aldara"
+    assert e.aliases[0].source == "hand-edited"
+    assert e.created_by_ingest == "ingest-001"
+    assert e.facts[0]["id"] == "aldara-f001"
+
+
+def test_read_drops_malformed_alias(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(
+        p,
+        _minimal_dict(
+            aliases=[
+                {"name": "valid"},
+                "not-a-dict",
+                {"missing_name": True},
+                {"name": ""},
+            ],
+        ),
+    )
+    e = read(p)
+    assert [a.name for a in e.aliases] == ["valid"]
+
+
+def test_read_dedups_aliases_keeping_earliest(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(
+        p,
+        _minimal_dict(
+            aliases=[
+                {"name": "the Realm", "added_by_ingest": "ingest-A"},
+                {"name": "  the realm ", "added_by_ingest": "ingest-B"},
+                {"name": "THE REALM", "added_by_ingest": "ingest-C"},
+            ],
+        ),
+    )
+    e = read(p)
+    assert len(e.aliases) == 1
+    assert e.aliases[0].name == "the Realm"
+    assert e.aliases[0].added_by_ingest == "ingest-A"
+
+
+def test_read_preserves_unknown_keys(tmp_path: Path) -> None:
+    p = tmp_path / "e.yaml"
+    _write_yaml(
+        p,
+        _minimal_dict(future_field={"foo": 1}, another_unknown=[1, 2, 3]),
+    )
+    e = read(p)
+    assert e.extra == {"future_field": {"foo": 1}, "another_unknown": [1, 2, 3]}
+
+
+def test_write_round_trip(tmp_path: Path) -> None:
+    src = Entity(
+        entity="Theron",
+        category="characters",
+        slug="theron",
+        aliases=[Alias(name="King Theron", source="hand-edited")],
+        created_at="2026-01-16T14:32:11Z",
+    )
+    p = tmp_path / "theron.yaml"
+    write(src, p)
+    got = read(p)
+    assert got.entity == "Theron"
+    assert got.aliases[0].name == "King Theron"
+
+
+def test_write_schema_version_first(tmp_path: Path) -> None:
+    e = Entity(entity="X", category="characters", slug="x")
+    p = tmp_path / "x.yaml"
+    write(e, p)
+    text = p.read_text(encoding="utf-8")
+    first_line = text.splitlines()[0]
+    assert first_line.startswith("schema_version:")
+
+
+def test_write_preserves_unknown_keys(tmp_path: Path) -> None:
+    e = Entity(
+        entity="X",
+        category="characters",
+        slug="x",
+        extra={"future_facts_v2": [{"a": 1}]},
+    )
+    p = tmp_path / "x.yaml"
+    write(e, p)
+    raw = yaml.safe_load(p.read_text(encoding="utf-8"))
+    assert raw["future_facts_v2"] == [{"a": 1}]
+    # round-trip stays preserved
+    got = read(p)
+    assert got.extra == {"future_facts_v2": [{"a": 1}]}
+
+
+def test_write_dedups_aliases(tmp_path: Path) -> None:
+    e = Entity(
+        entity="X",
+        category="characters",
+        slug="x",
+        aliases=[Alias(name="Foo"), Alias(name="foo"), Alias(name="FOO")],
+    )
+    p = tmp_path / "x.yaml"
+    write(e, p)
+    got = read(p)
+    assert len(got.aliases) == 1
+
+
+def test_write_atomic(tmp_path: Path) -> None:
+    e = Entity(entity="X", category="characters", slug="x")
+    nested = tmp_path / "deep" / "deeper"
+    p = nested / "x.yaml"
+    write(e, p)  # should create parents
+    assert p.exists()
+
+
+def test_normalize_alias_name_casefold_and_strip() -> None:
+    assert normalize_alias_name("  The Realm ") == "the realm"
+    assert normalize_alias_name("THE REALM") == "the realm"
+
+
+def test_schema_version_error_subclass() -> None:
+    # SchemaVersionError underlies our errors; this is just a sanity check
+    # that it's importable from where we expect.
+    assert issubclass(SchemaVersionError, ValueError)

--- a/tests/test_plan_yaml.py
+++ b/tests/test_plan_yaml.py
@@ -1,0 +1,289 @@
+"""Tests for plan_yaml.py — Stage 2 plan.yaml read/write."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from auto_lorebook.plan_yaml import (
+    ClaimTarget,
+    EntityResolution,
+    NewEntityProposal,
+    Plan,
+    PlanError,
+    PlannedClaim,
+    Unresolved,
+    read,
+    write,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _full_plan() -> Plan:
+    return Plan(
+        source_id="yt-abc123",
+        planned_at="2026-04-20T14:58:33Z",
+        entity_resolutions=[
+            EntityResolution(
+                mention="the Aldaran Realm",
+                mention_locations=["[4:30-8:00] founding"],
+                resolution="existing",
+                matched_entity="Aldara",
+                rationale="Listed in Aldara's aliases.",
+            ),
+            EntityResolution(
+                mention="the War of the Dusk",
+                mention_locations=["[8:00-12:00] war"],
+                resolution="new",
+                proposed_entity_name="War of the Dusk",
+                proposed_category="events",
+                rationale="No existing entity matches.",
+            ),
+            EntityResolution(
+                mention="the elven sorceress",
+                mention_locations=["[1:23:40-1:24:15] hearsay"],
+                resolution="ambiguous",
+                rationale="Unnamed referent.",
+                human_review_needed=True,
+            ),
+        ],
+        new_entities=[
+            NewEntityProposal(name="War of the Dusk", category="events"),
+        ],
+        planned_claims=[
+            PlannedClaim(
+                claim_group_id="cg-001",
+                reading_section="[4:30-8:00] Founding of Aldara",
+                reading_bullet_index=0,
+                locator="0:04:32",
+                locator_hint="0:04:25-0:04:50",
+                proposed_speaker="DM",
+                proposed_status="authoritative",
+                proposed_status_reason=None,
+                targets=[
+                    ClaimTarget(
+                        entity="Aldara",
+                        entity_state="existing",
+                        proposed_section="founding",
+                        rationale="Claim concerns Aldara's founding.",
+                    ),
+                    ClaimTarget(
+                        entity="Theron",
+                        entity_state="existing",
+                        proposed_section="lineage",
+                        rationale="Establishes grandfather as founder.",
+                    ),
+                    ClaimTarget(
+                        entity="Second Age",
+                        entity_state="new",
+                        proposed_section="events-in-era",
+                        proposed_category="events",
+                        rationale="Dates founding to the Second Age.",
+                    ),
+                ],
+            ),
+        ],
+        unresolved=[
+            Unresolved(
+                reading_section="[8:00-12:00] The War of the Dusk",
+                locator="0:09:12",
+                issue="Reading flagged uncertain place name.",
+            ),
+        ],
+    )
+
+
+class TestRoundTrip:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        plan = _full_plan()
+        path = tmp_path / "plan.yaml"
+        write(plan, path)
+        loaded = read(path)
+        assert loaded == plan
+
+    def test_schema_version_first_key(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        write(_full_plan(), path)
+        # First non-blank key must be schema_version, value 1
+        first_line = next(ln for ln in path.read_text().splitlines() if ln.strip())
+        assert first_line.startswith("schema_version:")
+        assert first_line.split(":", 1)[1].strip() == "1"
+
+    def test_multi_target_claim_round_trips(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        write(_full_plan(), path)
+        loaded = read(path)
+        assert len(loaded.planned_claims[0].targets) == 3
+        states = {t.entity_state for t in loaded.planned_claims[0].targets}
+        assert states == {"existing", "new"}
+
+
+class TestSchemaValidation:
+    def test_unsupported_schema_version_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text(
+            yaml.safe_dump({
+                "schema_version": 2,
+                "source_id": "yt-x",
+                "planned_at": "2026-04-20T00:00:00Z",
+            })
+        )
+        with pytest.raises(PlanError, match="schema_version"):
+            read(path)
+
+    def test_missing_schema_version_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text(
+            yaml.safe_dump({
+                "source_id": "yt-x",
+                "planned_at": "2026-04-20T00:00:00Z",
+            })
+        )
+        with pytest.raises(PlanError, match="schema_version"):
+            read(path)
+
+    def test_missing_source_id_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text(
+            yaml.safe_dump({
+                "schema_version": 1,
+                "planned_at": "2026-04-20T00:00:00Z",
+            })
+        )
+        with pytest.raises(PlanError, match="source_id"):
+            read(path)
+
+    def test_missing_planned_at_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text(
+            yaml.safe_dump({
+                "schema_version": 1,
+                "source_id": "yt-x",
+            })
+        )
+        with pytest.raises(PlanError, match="planned_at"):
+            read(path)
+
+    def test_unknown_resolution_kind_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text(
+            yaml.safe_dump({
+                "schema_version": 1,
+                "source_id": "yt-x",
+                "planned_at": "2026-04-20T00:00:00Z",
+                "entity_resolutions": [
+                    {"mention": "x", "resolution": "wat"},
+                ],
+            })
+        )
+        with pytest.raises(PlanError, match="resolution"):
+            read(path)
+
+    def test_unknown_target_state_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text(
+            yaml.safe_dump({
+                "schema_version": 1,
+                "source_id": "yt-x",
+                "planned_at": "2026-04-20T00:00:00Z",
+                "planned_claims": [
+                    {
+                        "claim_group_id": "cg-1",
+                        "reading_section": "[0-1]",
+                        "reading_bullet_index": 0,
+                        "locator": "0:00:00",
+                        "locator_hint": "0:00:00-0:00:01",
+                        "proposed_speaker": "DM",
+                        "proposed_status": "authoritative",
+                        "targets": [
+                            {
+                                "entity": "X",
+                                "entity_state": "wat",
+                                "proposed_section": "foo",
+                            }
+                        ],
+                    }
+                ],
+            })
+        )
+        with pytest.raises(PlanError, match="entity_state"):
+            read(path)
+
+    def test_new_entity_target_requires_category(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text(
+            yaml.safe_dump({
+                "schema_version": 1,
+                "source_id": "yt-x",
+                "planned_at": "2026-04-20T00:00:00Z",
+                "planned_claims": [
+                    {
+                        "claim_group_id": "cg-1",
+                        "reading_section": "[0-1]",
+                        "reading_bullet_index": 0,
+                        "locator": "0:00:00",
+                        "locator_hint": "0:00:00-0:00:01",
+                        "proposed_speaker": "DM",
+                        "proposed_status": "authoritative",
+                        "targets": [
+                            {
+                                "entity": "Brand New",
+                                "entity_state": "new",
+                                "proposed_section": "overview",
+                            }
+                        ],
+                    }
+                ],
+            })
+        )
+        with pytest.raises(PlanError, match="proposed_category"):
+            read(path)
+
+    def test_invalid_category_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text(
+            yaml.safe_dump({
+                "schema_version": 1,
+                "source_id": "yt-x",
+                "planned_at": "2026-04-20T00:00:00Z",
+                "new_entities": [
+                    {"name": "Foo", "category": "not-a-category"},
+                ],
+            })
+        )
+        with pytest.raises(PlanError, match="category"):
+            read(path)
+
+    def test_empty_targets_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text(
+            yaml.safe_dump({
+                "schema_version": 1,
+                "source_id": "yt-x",
+                "planned_at": "2026-04-20T00:00:00Z",
+                "planned_claims": [
+                    {
+                        "claim_group_id": "cg-1",
+                        "reading_section": "[0-1]",
+                        "reading_bullet_index": 0,
+                        "locator": "0:00:00",
+                        "locator_hint": "0:00:00-0:00:01",
+                        "proposed_speaker": "DM",
+                        "proposed_status": "authoritative",
+                        "targets": [],
+                    }
+                ],
+            })
+        )
+        with pytest.raises(PlanError, match="targets"):
+            read(path)
+
+
+class TestReadMissing:
+    def test_read_missing_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(PlanError, match="not found"):
+            read(tmp_path / "missing.yaml")

--- a/tests/test_plans_cmd.py
+++ b/tests/test_plans_cmd.py
@@ -1,0 +1,170 @@
+"""Tests for the `plans` subcommand group."""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING
+
+import pytest
+
+from auto_lorebook import plan_yaml
+from auto_lorebook.commands import plans_cmd
+from auto_lorebook.plan_yaml import (
+    ClaimTarget,
+    EntityResolution,
+    NewEntityProposal,
+    Plan,
+    PlannedClaim,
+    Unresolved,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    return home
+
+
+def _args(**kwargs: object) -> argparse.Namespace:
+    return argparse.Namespace(**kwargs)
+
+
+def _write_plan(home: Path, source_id: str) -> Path:
+    plan = Plan(
+        source_id=source_id,
+        planned_at="2026-04-20T14:58:33Z",
+        entity_resolutions=[
+            EntityResolution(
+                mention="Aldara",
+                resolution="existing",
+                matched_entity="Aldara",
+                rationale="Mentioned.",
+            ),
+        ],
+        new_entities=[NewEntityProposal(name="Second Age", category="events")],
+        planned_claims=[
+            PlannedClaim(
+                claim_group_id="cg-001",
+                reading_section="[0:00:00-0:01:00] Founding",
+                reading_bullet_index=0,
+                locator="0:00:30",
+                locator_hint="0:00:20-0:00:45",
+                proposed_speaker="DM",
+                proposed_status="authoritative",
+                proposed_status_reason=None,
+                targets=[
+                    ClaimTarget(
+                        entity="Aldara",
+                        entity_state="existing",
+                        proposed_section="founding",
+                    ),
+                    ClaimTarget(
+                        entity="Second Age",
+                        entity_state="new",
+                        proposed_section="events-in-era",
+                        proposed_category="events",
+                    ),
+                ],
+            )
+        ],
+        unresolved=[
+            Unresolved(
+                reading_section="[0:01:00-0:02:00]",
+                locator="0:01:10",
+                issue="Uncertain name.",
+            )
+        ],
+    )
+    path = home / "pending" / source_id / "plan.yaml"
+    plan_yaml.write(plan, path)
+    return path
+
+
+class TestPlansList:
+    def test_empty(
+        self,
+        tmp_home: Path,  # noqa: ARG002
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = plans_cmd.run(_args(plans_action="list"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "(no plans)" in out
+
+    def test_lists_pending(
+        self,
+        tmp_home: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_plan(tmp_home, "yt-aaa")
+        _write_plan(tmp_home, "yt-bbb")
+        rc = plans_cmd.run(_args(plans_action="list"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "yt-aaa" in out
+        assert "yt-bbb" in out
+        assert "PLANNED_AT" in out
+
+    def test_skips_non_plan_dirs(
+        self,
+        tmp_home: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # An ingest dir without plan.yaml should be ignored
+        (tmp_home / "pending" / "yt-no-plan").mkdir(parents=True)
+        rc = plans_cmd.run(_args(plans_action="list"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "(no plans)" in out
+
+
+class TestPlansShow:
+    def test_renders_summary(
+        self,
+        tmp_home: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_plan(tmp_home, "yt-aaa")
+        rc = plans_cmd.run(_args(plans_action="show", source_id="yt-aaa"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "yt-aaa" in out
+        assert "entity_resolutions" in out
+        assert "Aldara" in out
+        assert "Second Age" in out
+        assert "founding" in out
+        assert "Uncertain name" in out
+
+    def test_unknown_id_returns_1(
+        self,
+        tmp_home: Path,  # noqa: ARG002
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = plans_cmd.run(_args(plans_action="show", source_id="yt-missing"))
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "No plan" in out
+
+
+class TestParserRegistration:
+    def test_parser_registered(self) -> None:
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers()
+        common = argparse.ArgumentParser(add_help=False)
+        plans_cmd.add_parser(sub, common)
+        # Should parse without error
+        args = parser.parse_args(["plans", "list"])
+        assert args.plans_action == "list"
+
+    def test_show_requires_source_id(self) -> None:
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers()
+        common = argparse.ArgumentParser(add_help=False)
+        plans_cmd.add_parser(sub, common)
+        with pytest.raises(SystemExit):
+            parser.parse_args(["plans", "show"])

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+from auto_lorebook import plan_yaml
 from auto_lorebook.commands import (
     approve_reading_cmd,
     generate_reading_cmd,
@@ -77,8 +78,53 @@ def _seg_bullets_payload(segment_id: str) -> str:
     return json.dumps({"bullets": per_seg.get(segment_id, [])})
 
 
+def _stub_plan_payload() -> str:
+    return json.dumps({
+        "entity_resolutions": [
+            {
+                "mention": "Aldara",
+                "mention_locations": ["[0:02:00-0:10:00] founding"],
+                "resolution": "existing",
+                "matched_entity": "Aldara",
+                "rationale": "Direct mention.",
+            },
+        ],
+        "new_entities": [
+            {"name": "Second Age", "category": "events"},
+        ],
+        "planned_claims": [
+            {
+                "claim_group_id": "cg-001",
+                "reading_section": "[0:02:00-0:10:00] Founding of Aldara",
+                "reading_bullet_index": 0,
+                "locator": "0:02:30",
+                "locator_hint": "0:02:20-0:02:45",
+                "proposed_speaker": "DM",
+                "proposed_status": "authoritative",
+                "proposed_status_reason": None,
+                "targets": [
+                    {
+                        "entity": "Aldara",
+                        "entity_state": "existing",
+                        "proposed_section": "founding",
+                        "rationale": "Founding fact.",
+                    },
+                    {
+                        "entity": "Second Age",
+                        "entity_state": "new",
+                        "proposed_section": "events-in-era",
+                        "proposed_category": "events",
+                        "rationale": "Dates the founding.",
+                    },
+                ],
+            }
+        ],
+        "unresolved": [],
+    })
+
+
 def _wire_client_responses(client_mock: MagicMock) -> None:
-    """Route client.complete by message content (structure vs per-segment)."""
+    """Route client.complete by message content (structure / 1b / planner)."""
 
     def side_effect(
         messages: list[dict[str, str]], **_kwargs: object
@@ -90,6 +136,8 @@ def _wire_client_responses(client_mock: MagicMock) -> None:
 
         if "segmenting" in system_text:
             text = _stub_structure_payload()
+        elif "routing claim bullets" in system_text:
+            text = _stub_plan_payload()
         else:
             # stage 1b: find which segment id is in user_text
             for seg_id in ("seg-001", "seg-002"):
@@ -234,6 +282,37 @@ class TestApproveReading:
         assert "reading_status: approved" in approved.read_text(encoding="utf-8")
         out = capsys.readouterr().out
         assert "Approved" in out
+
+    def test_writes_plan_yaml_with_multi_target_claim(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678"))
+
+        assert rc == 0
+        plan_path = tmp_home / "pending" / "yt-abc12345678" / "plan.yaml"
+        assert plan_path.exists()
+        first_line = next(ln for ln in plan_path.read_text().splitlines() if ln.strip())
+        assert first_line.startswith("schema_version:")
+
+        plan = plan_yaml.read(plan_path)
+        # Exit-criterion: at least one claim routes to multiple targets
+        assert any(len(c.targets) > 1 for c in plan.planned_claims)
+
+        out = capsys.readouterr().out
+        assert "Plan:" in out
 
     def test_no_draft_errors(self, tmp_home: Path, ingested_wiki: Path) -> None:
         _write_user_config(tmp_home, ingested_wiki)

--- a/tests/test_stage2.py
+++ b/tests/test_stage2.py
@@ -1,0 +1,288 @@
+"""Tests for stage2.py — Stage 2 planner."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from auto_lorebook.openrouter import OpenRouterResponse
+from auto_lorebook.stage1b import Bullet, ReadingBullets
+from auto_lorebook.stage2 import Stage2Error, run
+from auto_lorebook.structure import Segment, Structure, UncertaintyFlag
+
+
+def _mock_client(text: str) -> MagicMock:
+    client = MagicMock()
+    client.complete.return_value = OpenRouterResponse(
+        text=text, model="m/one", tokens_in=10, tokens_out=20
+    )
+    return client
+
+
+def _structure() -> Structure:
+    return Structure(
+        source_id="yt-x",
+        generated_at="2026-04-20T00:00:00Z",
+        default_speaker="DM",
+        segments=[
+            Segment(
+                id="seg-001",
+                start=0.0,
+                end=60.0,
+                title="Founding of Aldara",
+                speaker="DM",
+            ),
+            Segment(
+                id="seg-002",
+                start=60.0,
+                end=120.0,
+                title="The War of the Dusk",
+                speaker="DM",
+            ),
+        ],
+        uncertainty_flags=[
+            UncertaintyFlag(
+                locator=70.0,
+                span="elven sorceress",
+                kind="name",
+                note="unnamed",
+            )
+        ],
+    )
+
+
+def _bullets() -> ReadingBullets:
+    return ReadingBullets(
+        source_id="yt-x",
+        generated_at="2026-04-20T00:00:00Z",
+        segments={
+            "seg-001": [
+                Bullet(
+                    text=(
+                        "Aldara was founded in the Second Age by Theron's grandfather."
+                    ),
+                    anchor=30.0,
+                    locator_hint_start=20.0,
+                    locator_hint_end=45.0,
+                ),
+            ],
+            "seg-002": [
+                Bullet(
+                    text="The War of the Dusk lasted seven years.",
+                    anchor=80.0,
+                    locator_hint_start=70.0,
+                    locator_hint_end=95.0,
+                ),
+            ],
+        },
+    )
+
+
+def _well_formed_payload() -> str:
+    return json.dumps({
+        "entity_resolutions": [
+            {
+                "mention": "Aldara",
+                "mention_locations": ["[0:00:00-0:01:00] founding"],
+                "resolution": "existing",
+                "matched_entity": "Aldara",
+                "rationale": "Direct mention.",
+            },
+            {
+                "mention": "the War of the Dusk",
+                "mention_locations": ["[0:01:00-0:02:00] war"],
+                "resolution": "new",
+                "proposed_entity_name": "War of the Dusk",
+                "proposed_category": "events",
+                "rationale": "No existing match.",
+            },
+            {
+                "mention": "the elven sorceress",
+                "mention_locations": ["[0:01:10] hearsay"],
+                "resolution": "ambiguous",
+                "rationale": "Unnamed referent.",
+                "human_review_needed": True,
+            },
+        ],
+        "new_entities": [
+            {"name": "War of the Dusk", "category": "events"},
+        ],
+        "planned_claims": [
+            {
+                "claim_group_id": "cg-001",
+                "reading_section": "[0:00:00-0:01:00] Founding of Aldara",
+                "reading_bullet_index": 0,
+                "locator": "0:00:30",
+                "locator_hint": "0:00:20-0:00:45",
+                "proposed_speaker": "DM",
+                "proposed_status": "authoritative",
+                "proposed_status_reason": None,
+                "targets": [
+                    {
+                        "entity": "Aldara",
+                        "entity_state": "existing",
+                        "proposed_section": "founding",
+                        "rationale": "Founding fact.",
+                    },
+                    {
+                        "entity": "Theron",
+                        "entity_state": "existing",
+                        "proposed_section": "lineage",
+                        "rationale": "Names grandfather as founder.",
+                    },
+                    {
+                        "entity": "Second Age",
+                        "entity_state": "new",
+                        "proposed_section": "events-in-era",
+                        "proposed_category": "events",
+                        "rationale": "Dates the founding.",
+                    },
+                ],
+            },
+            {
+                "claim_group_id": "cg-002",
+                "reading_section": "[0:01:00-0:02:00] The War of the Dusk",
+                "reading_bullet_index": 0,
+                "locator": "0:01:20",
+                "locator_hint": "0:01:10-0:01:35",
+                "proposed_speaker": "DM",
+                "proposed_status": "authoritative",
+                "proposed_status_reason": None,
+                "targets": [
+                    {
+                        "entity": "War of the Dusk",
+                        "entity_state": "new",
+                        "proposed_section": "overview",
+                        "proposed_category": "events",
+                        "rationale": "Duration of the war.",
+                    },
+                ],
+            },
+        ],
+        "unresolved": [
+            {
+                "reading_section": "[0:01:00-0:02:00] The War of the Dusk",
+                "locator": "0:01:10",
+                "issue": "Reading flagged uncertain name.",
+            }
+        ],
+    })
+
+
+class TestRun:
+    def test_happy_path(self) -> None:
+        client = _mock_client(_well_formed_payload())
+        plan = run(
+            reading_text="# Reading\n\n## Segment\n\n- claim",
+            structure=_structure(),
+            bullets=_bullets(),
+            preamble_text="## Setting\n(none)",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+        )
+        assert plan.source_id == "yt-x"
+        assert plan.planned_at  # set by stage2 (ISO now)
+        assert len(plan.entity_resolutions) == 3
+        assert len(plan.new_entities) == 1
+        assert plan.new_entities[0].name == "War of the Dusk"
+        assert len(plan.planned_claims) == 2
+        assert len(plan.unresolved) == 1
+
+    def test_routes_one_claim_to_multiple_targets(self) -> None:
+        client = _mock_client(_well_formed_payload())
+        plan = run(
+            reading_text="# Reading",
+            structure=_structure(),
+            bullets=_bullets(),
+            preamble_text="",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+        )
+        first = plan.planned_claims[0]
+        assert len(first.targets) == 3
+        assert {t.entity for t in first.targets} == {
+            "Aldara",
+            "Theron",
+            "Second Age",
+        }
+        # The new-entity target carries proposed_category
+        new_targets = [t for t in first.targets if t.entity_state == "new"]
+        assert len(new_targets) == 1
+        assert new_targets[0].proposed_category == "events"
+
+    def test_sends_preamble_and_bullets(self) -> None:
+        client = _mock_client(_well_formed_payload())
+        run(
+            reading_text="# Reading body",
+            structure=_structure(),
+            bullets=_bullets(),
+            preamble_text="## Setting\n(none)",
+            source_id="yt-x",
+            client=client,
+            model="m/seven",
+        )
+        client.complete.assert_called_once()
+        call = client.complete.call_args
+        messages = call.args[0]
+        kwargs = call.kwargs
+        assert kwargs["model"] == "m/seven"
+        assert kwargs["response_format"] == {"type": "json_object"}
+        assert any(
+            m["role"] == "system" and "Setting" in m["content"] for m in messages
+        )
+        user_msg = next(m["content"] for m in messages if m["role"] == "user")
+        assert "Reading body" in user_msg
+        # bullet text + segment ids surfaced for the model
+        assert "seg-001" in user_msg
+        assert "Aldara was founded" in user_msg
+
+    def test_invalid_json_raises(self) -> None:
+        client = _mock_client("not valid json at all")
+        with pytest.raises(Stage2Error, match="JSON"):
+            run(
+                reading_text="",
+                structure=_structure(),
+                bullets=_bullets(),
+                preamble_text="",
+                source_id="yt-x",
+                client=client,
+                model="m/one",
+            )
+
+    def test_unknown_resolution_raises(self) -> None:
+        bad = json.dumps({
+            "entity_resolutions": [
+                {"mention": "X", "resolution": "wat"},
+            ],
+        })
+        client = _mock_client(bad)
+        with pytest.raises(Stage2Error, match="resolution"):
+            run(
+                reading_text="",
+                structure=_structure(),
+                bullets=_bullets(),
+                preamble_text="",
+                source_id="yt-x",
+                client=client,
+                model="m/one",
+            )
+
+    def test_empty_plan_is_valid(self) -> None:
+        client = _mock_client(json.dumps({}))
+        plan = run(
+            reading_text="",
+            structure=_structure(),
+            bullets=_bullets(),
+            preamble_text="",
+            source_id="yt-x",
+            client=client,
+            model="m/one",
+        )
+        assert plan.entity_resolutions == []
+        assert plan.new_entities == []
+        assert plan.planned_claims == []
+        assert plan.unresolved == []


### PR DESCRIPTION
## Summary

Implements Stage 2 of the reading pipeline: the planner that routes approved reading claims to entities and produces `plan.yaml` artifacts. Includes entity YAML schema/I/O, entity management CLI commands, and plan inspection commands.

## Key Changes

- **Stage 2 Planner** (`stage2.py`): LLM-driven claim routing that takes approved readings and structures and produces a `Plan` with entity resolutions, new entity proposals, and multi-target claim routing. Integrates with the reading pipeline via `reading_pipeline.py`.

- **Entity YAML Schema** (`entity_yaml.py`): Full read/write support for entity files with schema validation, alias deduplication, and preservation of unknown fields for forward compatibility with Phase 4 facts.

- **Plan YAML Schema** (`plan_yaml.py`): Mirrors entity YAML structure with dataclasses, serialization, and validation for the intermediate `plan.yaml` artifact. Supports multi-target claim routing and entity resolution tracking.

- **Entity Management CLI** (`commands/entities.py`): New `entities` subcommand group with:
  - `list` — filter by category or created_by_ingest
  - `show` — resolve by slug, name, or alias
  - `new` — hand-create minimal entity stubs for bootstrapping
  - `rebuild-index` — placeholder for cache invalidation

- **Plan Inspection CLI** (`commands/plans.py`): New `plans` subcommand group with:
  - `list` — show all pending plans
  - `show` — display one plan by source_id

- **Pipeline Integration**: Updated `reading_pipeline.py` to add `plan()` function and `PlanResult` dataclass; `approve_reading_cmd.py` now triggers Stage 2 after approval.

- **Configuration**: Added `planner` model field to `ModelsConfig` for LLM selection.

- **Documentation**: Added entity bootstrapping guide and updated CLI reference and roadmap.

## Implementation Details

- Entity resolution supports three states: `existing` (matched to wiki entity), `new` (proposed entity), `ambiguous` (human review needed).
- Claims can route to multiple entities when they carry information about more than one; each target specifies entity state, proposed section, and rationale.
- Optional YAML fields are omitted on write to keep on-disk artifacts close to spec.
- Alias deduplication uses case-folded, whitespace-trimmed names to prevent duplicates.
- Entity index now sourced from `entity_yaml.CATEGORIES` constant for consistency.

https://claude.ai/code/session_01UejUPZECx8cuYN3GxX4Jko