### PR TITLE
Bundle multi-target claims into single review screen

### DIFF
--- a/docs/pipeline/planner.md
+++ b/docs/pipeline/planner.md
@@ -89,9 +89,11 @@ unresolved:
 A single claim can route to multiple entities when it carries
 information about more than one. The example above routes one claim to
 Aldara (founding), Theron (lineage), and the Second Age
-(events-in-era). Each target gets its own proposal; approvals are
-per-target, so the human can accept the claim onto Aldara and Theron
-but reject it from the Second Age page without affecting the others.
+(events-in-era). Targets sharing a `claim_group_id` are reviewed as
+**one bundle** with a single approve / edit / reject decision; the
+[`[t]argets`](review.md#actions) action drops individual destinations
+before approval, so the human can accept the claim onto Aldara and
+Theron but skip the Second Age page without affecting the others.
 
 Targets sharing a `claim_group_id` share the same
 `raw_transcript_span`, `locator`, and extracted `text` — the

--- a/docs/pipeline/review.md
+++ b/docs/pipeline/review.md
@@ -38,19 +38,20 @@ defer. If the user exits (Ctrl-C or closes the terminal), untouched
 proposal files remain in `pending/<ingest_id>/proposals/`, and the
 next invocation of `review` resumes with the first remaining file.
 
-### Claim-group ordering
+### Claim-group bundling
 
-Proposals sharing a `claim_group_id` are shown in a contiguous block,
-so the human reads the claim once and then decides per-target. The
-header names the group's position and size. Review order within a
-group is arbitrary; across groups, order follows transcript position.
+Proposals sharing a `claim_group_id` are shown as **one bundle
+screen**: the claim text appears once, followed by a numbered
+checklist of routes — one row per target. A single
+approve / edit / reject decision covers every checked route. The
+`[t]argets` action toggles individual routes on or off and is also
+the home for per-target `section` / `speaker` overrides. Singletons
+(claim groups with only one target) render the same screen with one
+checked row and no `[t]` clutter; bundles span across groups in
+transcript order.
 
 ```
-─── Proposal 1 of 12  ·  Claim group cg-001 (1 of 3 targets) ────────
-
-Target entity: Aldara (existing)
-  Matched via: alias "the Aldaran Realm"
-Section: founding
+─── Bundle 1 of 8  ·  Claim group cg-001 (3 of 3 routes selected) ────────
 
 Proposed text:
   "Theron's grandfather founded Aldara in the Second Age."
@@ -64,7 +65,6 @@ Corrections applied:
 
 Source: Worldbuilding Session 3
 Locator: 0:04:32-0:04:41  → https://youtube.com/watch?v=abc123&t=272
-Speaker: DM
 Status: authoritative
 Session date: 2026-01-15
 
@@ -72,53 +72,38 @@ Context:
   Before: "So let's talk about the founding of Aldara."
   After:  "And that's why the Theron name matters so much now."
 
-Also routes to:
-  → Theron (lineage)              — next
-  → Second Age (events-in-era)    — then
+Routes:
+  1. [x] Aldara (existing)            section=founding         speaker=DM
+        Matched via: alias "the Aldaran Realm"
+  2. [x] Theron (existing)            section=lineage          speaker=DM
+  3. [x] Second Age (NEW — events, will be created on approval)
+                                       section=events-in-era    speaker=DM
 
-[a]pprove  [e]dit  [r]eject  [p]lay (open URL)
+[a]pprove  [e]dit  [r]eject  [p]lay  [t]argets
 >
 ```
 
-After approval or rejection, the next claim-group sibling shows with
-an abbreviated header — the claim text and locator are unchanged; only
-the target and section differ:
+Bundle-level edits to `text`, `status`, or `status_reason` propagate
+to every checked route — those are claim-level facts about the world,
+so they should agree across siblings. Per-target overrides for
+`section` and `speaker` live in the `[t]argets` sub-prompt because
+they're inherently route-shaped (different entities have different
+sections).
+
+### New-entity routes
+
+A route targeting a proposed new entity that does not yet exist on
+disk renders inline in the checklist:
 
 ```
-─── Proposal 2 of 12  ·  Claim group cg-001 (2 of 3 targets) ────────
-
-Target entity: Theron (existing)
-Section: lineage
-
-(Same claim text, locator, and context as previous proposal.)
-
-[a]pprove  [e]dit  [r]eject  [p]lay (open URL)
->
+  3. [x] War of the Dusk (NEW — events, will be created on approval)
+        Suggested aliases: "the Dusk War"
 ```
 
-An edit to `text` inside a claim group applies only to the proposal
-being edited — sibling proposals keep the original text. This is
-deliberate: the human might want to phrase the founding claim
-differently on Theron's page than on Aldara's, and forcing edits to
-propagate across siblings would undercut that. If propagation _is_
-wanted, the user edits each sibling in turn.
-
-### New-entity proposals
-
-For proposals targeting a proposed new entity that does not yet exist
-on disk:
+A route whose entity was created earlier in the same review session:
 
 ```
-Target entity: War of the Dusk (NEW — events, will be created on approval)
-  Proposed aliases: (none)
-```
-
-For proposals targeting an entity created earlier in the same review
-session:
-
-```
-Target entity: War of the Dusk (events)
-  Created earlier in this review session
+  2. [x] War of the Dusk (events) — created earlier this session
 ```
 
 This note is derived at display time by comparing the entity's
@@ -127,39 +112,42 @@ required.
 
 ### Alias confirmation
 
-For proposals where the planner matched via a mention that isn't yet
-an alias, the display offers alias confirmation:
+For checked routes whose planner matched via a mention that isn't yet
+an alias, alias confirmation fires as a per-route sub-prompt **after**
+the user picks approve / edit, **before** any writes:
 
 ```
-Target entity: Aldara (existing)
-  Matched via: "the Realm" (not currently an alias)
-  Add "the Realm" as alias? [y/n]
+  Add "the Realm" as alias for Aldara? [y/n]
 ```
 
-Alias confirmation is a sub-prompt, not a main action. It applies
-immediately on `y` and is recorded in the entity YAML as an alias
-record with `source: alias-confirmation` and `added_by_ingest` set to
-the current ingest — or merged into the stub at creation time if the
-entity is new and this is its first approval, in which case the source
-on the first-approval aliases is `stub-creation`. Aliases added via
-alias confirmation are cleanly removable by `reject-ingest`.
+Alias confirmation only fires for routes that survived the bundle
+selection — dropping a route via `[t]argets` skips its alias prompt.
+Confirmed aliases are recorded with `source: alias-confirmation` and
+`added_by_ingest` set to the current ingest — or merged into the
+stub at creation time if the entity is new and this is its first
+approval, in which case the source on the first-approval aliases is
+`stub-creation`. Aliases added via alias confirmation are cleanly
+removable by `reject-ingest`. On Ctrl-C resume, prompts already
+answered earlier in the same ingest are not re-asked: the engine
+seeds its dedup set from on-disk alias records whose
+`added_by_ingest` matches the current source.
 
 ### Actions
 
-- **Approve** — proposal becomes a fact, appended to the entity's YAML
-  (creating the YAML if this is the first approval for a new entity),
-  summary regenerated. Proposal file deleted.
-- **Edit** — opens `text` (and optionally other fields) for inline
-  editing. Tracks original as `text_source` on the approved fact.
-  Then approves.
-- **Reject** — proposal discarded.
+- **Approve** — every checked route becomes a fact, appended to its
+  target entity's YAML (creating the YAML if this is the first
+  approval for a new entity); summary regenerated. Unchecked routes
+  are dropped — their proposal files are deleted.
+- **Edit** — bundle-level edits to `text`, `status`, and
+  `status_reason` propagate to every checked route. Tracks original
+  text as `text_source` on each affected fact.
+- **Reject** — discards the whole bundle: every route's proposal
+  file is removed, no entity is touched.
 - **Play** — prints the URL; user clicks through to verify against
-  audio. Play is not a decision — after playing, the user still must
-  approve, edit, or reject the current proposal.
-
-Status, speaker, and section can all be overridden during review.
-Text edits are supported but optional — approving as-is is fine since
-the summarizer produces readable prose downstream.
+  audio. Play is not a decision.
+- **Targets** — sub-prompt to toggle individual routes on / off and
+  to set per-target `section` / `speaker` overrides on kept rows.
+  Returns to the main prompt; the bundle then re-renders.
 
 ## No skip, no defer
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -38,17 +38,23 @@ implementation status.
     fan-out.
 
     Phase 4 review loop also landed: `auto-lorebook review <id>` walks
-    each pending proposal, prompts approve / edit / reject / play, and
-    on approval atomically creates the entity stub (for proposed-new
-    entities) or appends a fact to the existing entity YAML.
-    Inline alias-confirmation sub-prompts merge planner-suggested
-    aliases as `stub-creation` (first-approval batch) or
-    `alias-confirmation` (later additions). The in-memory entity
-    index refreshes after each approval so siblings created earlier in
-    the same session resolve as existing. `--auto-approve` provides
-    non-interactive bulk approval (and explicitly *declines* alias
-    suggestions) for CI. Ctrl-C leaves untouched proposal files in
-    place so the next invocation resumes.
+    each pending claim group as **one bundle** with a route checklist,
+    prompts approve / edit / reject / play / targets, and on approval
+    atomically creates the entity stub (for proposed-new entities) or
+    appends a fact to the existing entity YAML for every checked
+    route. Bundle-level text edits propagate to all checked siblings;
+    per-target `section` / `speaker` overrides live in the `[t]argets`
+    sub-prompt. Inline alias-confirmation sub-prompts merge
+    planner-suggested aliases as `stub-creation` (first-approval
+    batch) or `alias-confirmation` (later additions). The in-memory
+    entity index refreshes after each approval so siblings created
+    earlier in the same session resolve as existing. On resume, the
+    engine seeds its alias-dedup set from on-disk aliases tagged with
+    the current ingest, so already-confirmed aliases are not
+    re-prompted after Ctrl-C. `--auto-approve` provides non-interactive
+    bulk approval (and explicitly *declines* alias suggestions) for
+    CI. Ctrl-C leaves untouched proposal files in place so the next
+    invocation resumes.
 
     Phase 4 closeout landed: `auto-lorebook replan <id>` discards
     unreviewed proposals and re-runs planner + extractor against the
@@ -174,20 +180,23 @@ once the extractor + review loop gave it something to discard.
   proposals.
 - Post-extraction mechanical verification that `raw_transcript_span`
   is a real substring.
-- Terminal review loop with approve / edit / reject actions, with
-  claim-group siblings shown contiguously.
+- Terminal review loop with approve / edit / reject / targets actions
+  driven per **bundle**: targets sharing a `claim_group_id` render
+  as one screen with a route checklist.
 - **Atomic entity stub creation on first approval for a proposed
   new entity**, with `created_by_ingest` set to the current ingest.
-- Routing metadata surfaced per-proposal (matched_via,
+- Routing metadata surfaced per-route inside the bundle (matched_via,
   new-vs-existing, proposed aliases, "created earlier this session"
-  for in-review creations, sibling targets for multi-target claims).
-- Inline alias-confirmation sub-prompt; aliases merged into stub at
-  creation or appended on update.
+  for in-review creations).
+- Inline alias-confirmation sub-prompt for each checked route;
+  aliases merged into stub at creation or appended on update; the
+  engine seeds its alias-dedup set from on-disk records on resume so
+  Ctrl-C resumes don't re-prompt.
 - In-memory entity index refresh after each approval.
-- Per-fact approval → fact appended to entity YAML, carrying
-  `claim_group_id` when applicable.
-- Handling for edited text (edits scoped to the proposal being
-  edited, not propagated to claim-group siblings).
+- Per-route approval → fact appended to entity YAML, carrying
+  `claim_group_id`. Bundle-level text edits propagate across all
+  checked siblings; per-target section / speaker overrides apply
+  only to their route.
 - `replan` command (discard unreviewed proposals, re-run planner +
   extractor; already-approved entities visible to the new plan as
   existing).

--- a/src/auto_lorebook/commands/review.py
+++ b/src/auto_lorebook/commands/review.py
@@ -18,10 +18,11 @@ from auto_lorebook import review as review_mod
 from auto_lorebook.interactive import _is_interactive
 from auto_lorebook.review import (
     ApproveDecision,
-    Decision,
+    BundleDecision,
+    BundleView,
     EditDecision,
-    ProposalView,
     RejectDecision,
+    TargetView,
 )
 from auto_lorebook.timestamps import TimestampError, parse_locator_hint
 
@@ -111,49 +112,65 @@ def run(args: argparse.Namespace) -> int:
 
 
 class AutoApproveReviewer:
-    """Approves everything; declines every alias suggestion."""
+    """Approves every bundle; declines every alias suggestion."""
 
     by_label = "auto-approve"
 
-    def decide(self, view: ProposalView) -> Decision:  # noqa: ARG002
-        return ApproveDecision()
+    def decide_bundle(self, view: BundleView) -> BundleDecision:
+        return BundleDecision(
+            decision=ApproveDecision(),
+            selected_indices=tuple(range(len(view.targets))),
+        )
 
     def confirm_alias(self, entity: str, mention: str) -> bool:  # noqa: ARG002
         return False
 
 
 class InteractiveReviewer:
-    """Renders the spec'd display and prompts for the next action."""
+    """Renders one bundle screen and prompts for the next action."""
 
     by_label = "human-review"
 
-    def decide(self, view: ProposalView) -> Decision:
-        _render(view)
+    def decide_bundle(self, view: BundleView) -> BundleDecision:
+        # `selected[i]` toggles route i. Default: every route checked.
+        selected = [True] * len(view.targets)
+        # Per-target overrides accumulated via `[t]`.
+        overrides: dict[int, EditDecision] = {}
+        bundle_edits: EditDecision | None = None
+        _render_bundle(view, selected, overrides, bundle_edits)
         while True:
             try:
-                choice = (
-                    input("[a]pprove  [e]dit  [r]eject  [p]lay (open URL)\n> ")
-                    .strip()
-                    .lower()
-                )
+                choice = input(_prompt_line(view)).strip().lower()
             except EOFError:
                 # No more stdin (non-interactive harness w/o --auto-approve);
                 # treat as reject so we don't loop forever.
-                return RejectDecision()
+                return BundleDecision(decision=RejectDecision(), selected_indices=())
             if choice in {"a", "approve"}:
-                return ApproveDecision()
-            if choice in {"r", "reject"}:
-                return RejectDecision()
-            if choice in {"e", "edit"}:
-                edits = self._gather_edits(view)
-                if edits.is_noop():
-                    print("  (no edits; re-prompting)")  # noqa: T201
+                indices = tuple(i for i, on in enumerate(selected) if on)
+                if not indices:
+                    print("  No routes selected; toggle with [t] or reject.")  # noqa: T201
                     continue
-                return edits
+                return BundleDecision(
+                    decision=bundle_edits or ApproveDecision(),
+                    selected_indices=indices,
+                    per_target_overrides={
+                        i: ov for i, ov in overrides.items() if selected[i]
+                    },
+                )
+            if choice in {"r", "reject"}:
+                return BundleDecision(decision=RejectDecision(), selected_indices=())
+            if choice in {"e", "edit"}:
+                bundle_edits = _gather_bundle_edits(view, bundle_edits)
+                _render_bundle(view, selected, overrides, bundle_edits)
+                continue
+            if choice in {"t", "targets"}:
+                _gather_target_toggles(view, selected, overrides)
+                _render_bundle(view, selected, overrides, bundle_edits)
+                continue
             if choice in {"p", "play"}:
                 _print_play(view)
                 continue
-            print(f"  unknown choice {choice!r}; try a/e/r/p")  # noqa: T201
+            print(f"  unknown choice {choice!r}; try a/e/r/p/t")  # noqa: T201
 
     def confirm_alias(self, entity: str, mention: str) -> bool:
         while True:
@@ -171,22 +188,102 @@ class InteractiveReviewer:
                 return False
             print("  please answer y or n")  # noqa: T201
 
-    def _gather_edits(self, view: ProposalView) -> EditDecision:
-        """Walk each editable field; blank input keeps the current value."""
-        p = view.proposal
-        print("  Edit (Enter to keep current value):")  # noqa: T201
-        new_text = _prompt_optional("text", p.text)
-        new_speaker = _prompt_optional("speaker", p.speaker)
-        new_status = _prompt_status(p.status)
-        new_status_reason = _prompt_optional("status_reason", p.status_reason or "")
-        new_section = _prompt_optional("section", p.section)
-        return EditDecision(
-            new_text=new_text,
-            new_speaker=new_speaker,
-            new_status=new_status,
-            new_status_reason=new_status_reason,
-            new_section=new_section,
+
+def _gather_bundle_edits(
+    view: BundleView, current: EditDecision | None
+) -> EditDecision | None:
+    """Bundle-level edits: text / status / status_reason only.
+
+    `section` and `speaker` vary per route, so they live in the
+    `[t]argets` sub-prompt as per-target overrides.
+    """
+    sample = view.targets[0].proposal
+    print("  Bundle edit (Enter to keep current value; applies to checked routes):")  # noqa: T201
+    new_text = _prompt_optional(
+        "text", current.new_text if current and current.new_text else sample.text
+    )
+    new_status = _prompt_status(
+        current.new_status if current and current.new_status else sample.status
+    )
+    new_status_reason = _prompt_optional(
+        "status_reason",
+        (
+            current.new_status_reason
+            if current and current.new_status_reason is not None
+            else sample.status_reason or ""
+        ),
+    )
+    edits = EditDecision(
+        new_text=new_text,
+        new_status=new_status,
+        new_status_reason=new_status_reason,
+    )
+    return None if edits.is_noop() else edits
+
+
+def _gather_target_toggles(
+    view: BundleView,
+    selected: list[bool],
+    overrides: dict[int, EditDecision],
+) -> None:
+    """Toggle inclusion per route; for kept rows, override section / speaker."""
+    print("  Targets (per route):")  # noqa: T201
+    for i, target in enumerate(view.targets):
+        mark = "[x]" if selected[i] else "[ ]"
+        print(  # noqa: T201
+            f"    {i + 1}. {mark} {target.proposal.target_entity}  "
+            f"(section={target.proposal.section}, speaker={target.proposal.speaker})"
         )
+    while True:
+        try:
+            raw = input("    toggle # / edit # / done: ").strip().lower()
+        except EOFError:
+            return
+        if raw in {"", "done", "d"}:
+            return
+        parts = raw.split()
+        if len(parts) == 2 and parts[0] in {"toggle", "t"} and parts[1].isdigit():
+            idx = int(parts[1]) - 1
+            if 0 <= idx < len(selected):
+                selected[idx] = not selected[idx]
+                mark = "[x]" if selected[idx] else "[ ]"
+                print(  # noqa: T201
+                    f"    {mark} {view.targets[idx].proposal.target_entity}"
+                )
+            continue
+        if len(parts) == 2 and parts[0] in {"edit", "e"} and parts[1].isdigit():
+            idx = int(parts[1]) - 1
+            if 0 <= idx < len(view.targets):
+                _edit_target_override(view.targets[idx], idx, overrides)
+            continue
+        print("    expected: 'toggle N' / 'edit N' / 'done'")  # noqa: T201
+
+
+def _edit_target_override(
+    target: TargetView, idx: int, overrides: dict[int, EditDecision]
+) -> None:
+    """Prompt for per-target section / speaker; merge into overrides."""
+    p = target.proposal
+    current = overrides.get(idx)
+    new_section = _prompt_optional(
+        "section",
+        current.new_section if current and current.new_section else p.section,
+    )
+    new_speaker = _prompt_optional(
+        "speaker",
+        current.new_speaker if current and current.new_speaker else p.speaker,
+    )
+    edits = EditDecision(new_section=new_section, new_speaker=new_speaker)
+    if edits.is_noop():
+        overrides.pop(idx, None)
+    else:
+        overrides[idx] = edits
+
+
+def _prompt_line(view: BundleView) -> str:
+    if len(view.targets) > 1:
+        return "[a]pprove  [e]dit  [r]eject  [p]lay  [t]argets\n> "
+    return "[a]pprove  [e]dit  [r]eject  [p]lay (open URL)\n> "
 
 
 # ---------------------------------------------------------------------------
@@ -194,83 +291,120 @@ class InteractiveReviewer:
 # ---------------------------------------------------------------------------
 
 
-def _render(view: ProposalView) -> None:
-    p = view.proposal
-    print(  # noqa: T201
-        f"\n─── Proposal {view.proposal_index} of {view.proposal_total}  ·  "
-        f"Claim group {p.claim_group_id} "
-        f"({view.group_position} of {view.group_size} targets) {_SEP[:8]}"
+def _render_bundle(
+    view: BundleView,
+    selected: list[bool],
+    overrides: dict[int, EditDecision],
+    bundle_edits: EditDecision | None,
+) -> None:
+    """Render one claim-group bundle.
+
+    Singletons render an abbreviated form (no checklist). Multi-target
+    bundles show the claim text once, then a numbered route checklist
+    with per-row entity / category / section / matched_via.
+    """
+    head_proposal = view.targets[0].proposal
+    text = (
+        bundle_edits.new_text
+        if bundle_edits and bundle_edits.new_text
+        else head_proposal.text
     )
-    print(_target_line(view))  # noqa: T201
-    if view.matched_via:
-        print(f"  Matched via: {view.matched_via}")  # noqa: T201
-    if p.extractor_flagged:
-        print(f"  Flagged: {p.flag_reason or 'extractor flagged this proposal'}")  # noqa: T201
-    if p.hint_widened:
-        print("  Hint widened to parent segment")  # noqa: T201
-    print(f"Section: {p.section}")  # noqa: T201
-    print()  # noqa: T201
-    print(f"Proposed text:\n  {p.text!r}")  # noqa: T201
-    print(f"\nRaw transcript:\n  {p.raw_transcript_span!r}")  # noqa: T201
-    if p.corrections_applied:
+    status = (
+        bundle_edits.new_status
+        if bundle_edits and bundle_edits.new_status
+        else head_proposal.status
+    )
+    status_reason = (
+        bundle_edits.new_status_reason
+        if bundle_edits and bundle_edits.new_status_reason is not None
+        else head_proposal.status_reason
+    )
+    is_singleton = len(view.targets) == 1
+    header_kind = "Proposal" if is_singleton else "Bundle"
+    route_count = len(view.targets)
+    selected_count = sum(1 for b in selected if b)
+    print(  # noqa: T201
+        f"\n─── {header_kind} {view.bundle_index} of {view.bundle_total}  ·  "
+        f"Claim group {view.claim_group_id} "
+        f"({selected_count} of {route_count} routes selected) {_SEP[:8]}"
+    )
+    print(f"Proposed text:\n  {text!r}")  # noqa: T201
+    print(f"\nRaw transcript:\n  {head_proposal.raw_transcript_span!r}")  # noqa: T201
+    if head_proposal.corrections_applied:
         print("\nCorrections applied:")  # noqa: T201
-        for c in p.corrections_applied:
+        for c in head_proposal.corrections_applied:
             print(f'  • "{c.from_}" → "{c.to}"  ({c.source})')  # noqa: T201
     print()  # noqa: T201
-    print(f"Source: {view.source_title or view.proposal.source_id}")  # noqa: T201
-    print(f"Locator: {p.locator}  → {_play_url(view) or '(no source URL)'}")  # noqa: T201
-    print(f"Speaker: {p.speaker}")  # noqa: T201
-    status_line = f"Status: {p.status}"
-    if p.status_reason:
-        status_line += f"  ({p.status_reason})"
+    print(f"Source: {view.source_title or head_proposal.source_id}")  # noqa: T201
+    print(  # noqa: T201
+        f"Locator: {head_proposal.locator}  → {_play_url(view) or '(no source URL)'}"
+    )
+    status_line = f"Status: {status}"
+    if status_reason:
+        status_line += f"  ({status_reason})"
     print(status_line)  # noqa: T201
-    if p.session_date:
-        print(f"Session date: {p.session_date}")  # noqa: T201
-    if p.context_before or p.context_after:
+    if head_proposal.session_date:
+        print(f"Session date: {head_proposal.session_date}")  # noqa: T201
+    if head_proposal.context_before or head_proposal.context_after:
         print("\nContext:")  # noqa: T201
-        if p.context_before:
-            print(f"  Before: {p.context_before!r}")  # noqa: T201
-        if p.context_after:
-            print(f"  After:  {p.context_after!r}")  # noqa: T201
-    if p.claim_group_siblings:
-        print("\nAlso routes to:")  # noqa: T201
-        for s in p.claim_group_siblings:
-            print(f"  → {s.entity}  ({s.proposed_id})")  # noqa: T201
+        if head_proposal.context_before:
+            print(f"  Before: {head_proposal.context_before!r}")  # noqa: T201
+        if head_proposal.context_after:
+            print(f"  After:  {head_proposal.context_after!r}")  # noqa: T201
+    if head_proposal.extractor_flagged:
+        print(  # noqa: T201
+            f"Flagged: {head_proposal.flag_reason or 'extractor flagged this'}"
+        )
+    if head_proposal.hint_widened:
+        print("Hint widened to parent segment")  # noqa: T201
+
+    print()  # noqa: T201
+    print("Routes:")  # noqa: T201
+    for i, target in enumerate(view.targets):
+        mark = "[x]" if selected[i] else "[ ]"
+        ov = overrides.get(i)
+        section = ov.new_section if ov and ov.new_section else target.proposal.section
+        speaker = ov.new_speaker if ov and ov.new_speaker else target.proposal.speaker
+        prefix = "  " if is_singleton else f"  {i + 1}. "
+        print(  # noqa: T201
+            f"{prefix}{mark} {_route_label(target)}  "
+            f"section={section}  speaker={speaker}"
+        )
+        if target.matched_via:
+            print(f"      Matched via: {target.matched_via}")  # noqa: T201
+        if target.suggested_aliases:
+            joined = ", ".join(f'"{a}"' for a in target.suggested_aliases)
+            print(f"      Suggested aliases: {joined}")  # noqa: T201
     print()  # noqa: T201
 
 
-def _target_line(view: ProposalView) -> str:
-    if view.is_new_entity:
-        cat = view.new_entity_category or "?"
-        if view.created_earlier_in_session:
-            return (
-                f"Target entity: {view.proposal.target_entity} ({cat})\n"
-                f"  Created earlier in this review session"
-            )
-        return (
-            f"Target entity: {view.proposal.target_entity} "
-            f"(NEW — {cat}, will be created on approval)"
-        )
-    return f"Target entity: {view.proposal.target_entity} (existing)"
+def _route_label(target: TargetView) -> str:
+    name = target.proposal.target_entity
+    if target.is_new_entity:
+        cat = target.new_entity_category or "?"
+        if target.created_earlier_in_session:
+            return f"{name} ({cat}) — created earlier this session"
+        return f"{name} (NEW — {cat}, will be created on approval)"
+    return f"{name} (existing)"
 
 
-def _play_url(view: ProposalView) -> str | None:
-    """Return a URL with the start timestamp tacked on, or None."""
+def _play_url(view: BundleView) -> str | None:
+    """URL with start timestamp tacked on, derived from the head target."""
     if not view.source_url:
         return None
     try:
-        start_seconds, _ = parse_locator_hint(view.proposal.locator)
+        start_seconds, _ = parse_locator_hint(view.targets[0].proposal.locator)
     except TimestampError:
         return view.source_url
     return reading_mod.linkify_timestamp(view.source_url, start_seconds)
 
 
-def _print_play(view: ProposalView) -> None:
+def _print_play(view: BundleView) -> None:
     url = _play_url(view)
     if url:
         print(f"  → {url}")  # noqa: T201
     else:
-        print("  (no source URL for this proposal)")  # noqa: T201
+        print("  (no source URL for this bundle)")  # noqa: T201
 
 
 # ---------------------------------------------------------------------------

--- a/src/auto_lorebook/review.py
+++ b/src/auto_lorebook/review.py
@@ -1,4 +1,4 @@
-"""Stage 4 (review) engine: walk proposals, mutate entity YAMLs.
+"""Stage 4 (review) engine: walk bundles, mutate entity YAMLs.
 
 Pure-logic module. No `input()` calls. Display + prompt I/O lives in
 `commands/review.py` and is injected via the `Reviewer` protocol. Tests
@@ -7,9 +7,9 @@ script a `Reviewer` to drive the engine deterministically.
 Walk order is authoritative from the plan: we iterate
 `plan.planned_claims` then `claim.targets`, looking up each
 `(claim_group_id, target_entity)` against the on-disk proposal files.
-This preserves the spec's "siblings shown contiguously, transcript
-order across groups" no matter how proposed_id slugs sort
-lexicographically.
+Consecutive proposals sharing a `claim_group_id` are surfaced as one
+`BundleView`; the reviewer decides once per bundle and may drop
+individual routes before approval via `BundleDecision.selected_indices`.
 """
 
 from __future__ import annotations
@@ -92,21 +92,43 @@ Decision = ApproveDecision | EditDecision | RejectDecision
 
 
 @dataclass(frozen=True)
-class ProposalView:
-    """All display-relevant data for one proposal."""
+class TargetView:
+    """Per-route display data inside a bundle."""
 
     proposal: Proposal
-    proposal_index: int  # 1-of-N across this run
-    proposal_total: int
-    group_position: int  # 1-of-K within claim group
-    group_size: int
     is_new_entity: bool
     new_entity_category: str | None
     created_earlier_in_session: bool
     suggested_aliases: tuple[str, ...]
     matched_via: str | None
+
+
+@dataclass(frozen=True)
+class BundleView:
+    """One claim-group, shown as a single review screen."""
+
+    bundle_index: int  # 1-of-N bundles
+    bundle_total: int
+    claim_group_id: str
+    targets: tuple[TargetView, ...]  # plan order
     source_url: str | None
     source_title: str | None
+
+
+@dataclass(frozen=True)
+class BundleDecision:
+    """Result of one `decide_bundle` call.
+
+    `decision` is bundle-wide. `selected_indices` lists which target
+    rows the user kept checked. Unselected targets are dropped on
+    Approve / Edit. Reject discards the whole bundle (selection
+    ignored). `per_target_overrides[i]` overlays an `EditDecision`
+    on top of the bundle-level edit, last-write-wins per field.
+    """
+
+    decision: ApproveDecision | EditDecision | RejectDecision
+    selected_indices: tuple[int, ...]
+    per_target_overrides: dict[int, EditDecision] = field(default_factory=dict)
 
 
 class Reviewer(Protocol):
@@ -117,7 +139,7 @@ class Reviewer(Protocol):
         """Recorded as `status_history[].by` on approved facts."""
         ...
 
-    def decide(self, view: ProposalView) -> Decision: ...
+    def decide_bundle(self, view: BundleView) -> BundleDecision: ...
 
     def confirm_alias(self, entity: str, mention: str) -> bool: ...
 
@@ -387,15 +409,8 @@ def _reject(proposal_path: Path) -> None:
 # ------------- main loop -------------------------------------------------
 
 
-def _build_view(
-    ctx: _ApprovalContext,
-    proposal: Proposal,
-    *,
-    proposal_index: int,
-    proposal_total: int,
-    group_position: int,
-    group_size: int,
-) -> ProposalView:
+def _build_target_view(ctx: _ApprovalContext, proposal: Proposal) -> TargetView:
+    """Per-target slice of a `BundleView`; filters aliases via merged_aliases."""
     is_new = proposal.proposal_type == "new_entity_with_facts"
     category = _category_for_new(ctx.plan, proposal.target_entity) if is_new else None
     suggested = _suggested_aliases_for(ctx.plan, proposal)
@@ -406,8 +421,6 @@ def _build_view(
         if (target_key, normalize_alias_name(a)) not in ctx.merged_aliases
     )
     matched_via = _matched_via_for(ctx.plan, proposal)
-    # "created earlier in session": entity exists on disk and was created
-    # by this same ingest run.
     created_earlier = False
     if is_new:
         existing_entry = ctx.index.lookup(proposal.target_entity)
@@ -423,20 +436,120 @@ def _build_view(
                     created_earlier = True
             except entity_yaml_mod.EntityError:
                 pass
-    return ProposalView(
+    return TargetView(
         proposal=proposal,
-        proposal_index=proposal_index,
-        proposal_total=proposal_total,
-        group_position=group_position,
-        group_size=group_size,
         is_new_entity=is_new,
         new_entity_category=category,
         created_earlier_in_session=created_earlier,
         suggested_aliases=suggested,
         matched_via=matched_via,
+    )
+
+
+def _build_bundle_view(
+    ctx: _ApprovalContext,
+    proposals: list[Proposal],
+    *,
+    bundle_index: int,
+    bundle_total: int,
+) -> BundleView:
+    """Wrap claim-group `proposals` (plan order) into a `BundleView`."""
+    targets = tuple(_build_target_view(ctx, p) for p in proposals)
+    return BundleView(
+        bundle_index=bundle_index,
+        bundle_total=bundle_total,
+        claim_group_id=proposals[0].claim_group_id,
+        targets=targets,
         source_url=ctx.info.source_url,
         source_title=ctx.info.title,
     )
+
+
+def _bundle_proposals(ordered: list[Proposal]) -> list[list[Proposal]]:
+    """Group proposals into runs of consecutive matching `claim_group_id`.
+
+    Input is already in plan order (siblings contiguous), so a single
+    pass collecting consecutive runs preserves both within-bundle and
+    cross-bundle order.
+    """
+    if not ordered:
+        return []
+    bundles: list[list[Proposal]] = [[ordered[0]]]
+    for p in ordered[1:]:
+        if p.claim_group_id == bundles[-1][0].claim_group_id:
+            bundles[-1].append(p)
+        else:
+            bundles.append([p])
+    return bundles
+
+
+def _merge_edits(
+    bundle_decision: ApproveDecision | EditDecision,
+    override: EditDecision | None,
+) -> EditDecision | None:
+    """Layer per-target override on top of bundle-level edit.
+
+    Per-target wins per field. Returns None when both are absent /
+    no-op so `_approve` takes the plain-approve path.
+    """
+    if isinstance(bundle_decision, ApproveDecision):
+        if override is None or override.is_noop():
+            return None
+        return override
+    if override is None:
+        return bundle_decision if not bundle_decision.is_noop() else None
+    merged = EditDecision(
+        new_text=override.new_text or bundle_decision.new_text,
+        new_speaker=override.new_speaker or bundle_decision.new_speaker,
+        new_status=override.new_status or bundle_decision.new_status,
+        new_status_reason=(
+            override.new_status_reason
+            if override.new_status_reason is not None
+            else bundle_decision.new_status_reason
+        ),
+        new_section=override.new_section or bundle_decision.new_section,
+    )
+    return None if merged.is_noop() else merged
+
+
+def _count_remaining(source_id: str) -> int:
+    """Count proposal files still on disk. Used for KI accounting."""
+    proposals_dir = reading_pipeline.pending_proposals_dir(source_id)
+    if not proposals_dir.is_dir():
+        return 0
+    return sum(1 for _ in proposals_dir.glob("*.yaml"))
+
+
+def _seed_merged_aliases_from_disk(ctx: _ApprovalContext) -> None:
+    """Seed `ctx.merged_aliases` with aliases this ingest already wrote.
+
+    Without this, Ctrl-C resume re-prompts for aliases the user
+    already confirmed earlier in the same ingest. Walks each entity
+    referenced by the plan; cheap because plan size bounds the scan.
+    """
+    seen: set[str] = set()
+    for claim in ctx.plan.planned_claims:
+        for target in claim.targets:
+            if target.entity in seen:
+                continue
+            seen.add(target.entity)
+            entry = ctx.index.lookup(target.entity)
+            if entry is None:
+                continue
+            path = ctx.cfg.wiki_repo_path / entry.category / f"{entry.slug}.yaml"
+            if not path.exists():
+                continue
+            try:
+                entity = entity_yaml_mod.read(path)
+            except entity_yaml_mod.EntityError:
+                continue
+            target_key = target.entity.casefold()
+            for alias in entity.aliases:
+                if alias.added_by_ingest == ctx.source_id:
+                    ctx.merged_aliases.add((
+                        target_key,
+                        normalize_alias_name(alias.name),
+                    ))
 
 
 def run(
@@ -445,10 +558,12 @@ def run(
     source_id: str,
     reviewer: Reviewer,
 ) -> ReviewResult:
-    """Walk pending proposals; mutate entity YAMLs; return counts.
+    """Walk pending bundles; mutate entity YAMLs; return counts.
 
-    KeyboardInterrupt from `reviewer.decide` propagates after marking
-    the not-yet-decided proposals as `remaining`.
+    Multi-target claims share one `claim_group_id` and surface as a
+    single `BundleView`; one `decide_bundle` call covers every checked
+    route. KeyboardInterrupt propagates after recording the count of
+    proposal files left on disk as `remaining`.
     """
     wiki_repo = cfg.wiki_repo_path
     info_path = wiki_repo / "sources" / source_id / "info.yaml"
@@ -462,55 +577,92 @@ def run(
     ctx = _ApprovalContext(
         cfg=cfg, source_id=source_id, info=info, plan=plan, index=index
     )
+    _seed_merged_aliases_from_disk(ctx)
 
     ordered = sorted_proposals(plan, source_id)
     if not ordered:
         return ReviewResult()
-
-    # claim-group sizes for "K of M" header
-    group_sizes: dict[str, int] = {}
-    for p in ordered:
-        group_sizes[p.claim_group_id] = group_sizes.get(p.claim_group_id, 0) + 1
-    group_seen: dict[str, int] = {}
+    bundles = _bundle_proposals(ordered)
+    bundle_total = len(bundles)
 
     result = ReviewResult()
-    total = len(ordered)
-    for i, proposal in enumerate(ordered, start=1):
-        group_seen[proposal.claim_group_id] = (
-            group_seen.get(proposal.claim_group_id, 0) + 1
-        )
-        view = _build_view(
-            ctx,
-            proposal,
-            proposal_index=i,
-            proposal_total=total,
-            group_position=group_seen[proposal.claim_group_id],
-            group_size=group_sizes[proposal.claim_group_id],
-        )
+    for bundle_idx, bundle in enumerate(bundles, start=1):
         try:
-            decision = reviewer.decide(view)
+            _process_bundle(
+                ctx,
+                bundle,
+                reviewer=reviewer,
+                bundle_index=bundle_idx,
+                bundle_total=bundle_total,
+                result=result,
+            )
         except KeyboardInterrupt:
-            result.remaining = total - (i - 1)
+            result.remaining = _count_remaining(source_id)
             raise
-        if isinstance(decision, RejectDecision):
+    return result
+
+
+def _process_bundle(
+    ctx: _ApprovalContext,
+    bundle: list[Proposal],
+    *,
+    reviewer: Reviewer,
+    bundle_index: int,
+    bundle_total: int,
+    result: ReviewResult,
+) -> None:
+    """Drive one bundle: ask reviewer, fan out approvals / rejects."""
+    view = _build_bundle_view(
+        ctx, bundle, bundle_index=bundle_index, bundle_total=bundle_total
+    )
+    bundle_decision = reviewer.decide_bundle(view)
+
+    if isinstance(bundle_decision.decision, RejectDecision):
+        for proposal in bundle:
             proposal_path = reading_pipeline.pending_proposal_path(
-                source_id, proposal.proposed_id
+                ctx.source_id, proposal.proposed_id
             )
             _reject(proposal_path)
             result.rejected += 1
+        return
+
+    selected = set(bundle_decision.selected_indices)
+    # drop unselected routes first so they're gone before any writes
+    for i, proposal in enumerate(bundle):
+        if i in selected:
             continue
-        # approve / edit: gather alias confirmations
-        confirmed: list[str] = []
-        for alias in view.suggested_aliases:
-            try:
-                if reviewer.confirm_alias(proposal.target_entity, alias):
-                    confirmed.append(alias)
-            except KeyboardInterrupt:
-                result.remaining = total - (i - 1)
-                raise
-        edits = decision if isinstance(decision, EditDecision) else None
         proposal_path = reading_pipeline.pending_proposal_path(
-            source_id, proposal.proposed_id
+            ctx.source_id, proposal.proposed_id
+        )
+        _reject(proposal_path)
+        result.rejected += 1
+
+    # approve checked routes in plan order so NEW-entity siblings land
+    # before any sibling that depends on the entity existing.
+    for i, proposal in enumerate(bundle):
+        if i not in selected:
+            continue
+        # re-filter aliases against ctx.merged_aliases — earlier
+        # selected siblings in this same bundle may have already merged
+        # an alias that this target also suggests.
+        target_key = proposal.target_entity.casefold()
+        fresh_aliases = tuple(
+            a
+            for a in _suggested_aliases_for(ctx.plan, proposal)
+            if (target_key, normalize_alias_name(a)) not in ctx.merged_aliases
+        )
+        confirmed: list[str] = [
+            alias
+            for alias in fresh_aliases
+            if reviewer.confirm_alias(proposal.target_entity, alias)
+        ]
+
+        edits = _merge_edits(
+            bundle_decision.decision,
+            bundle_decision.per_target_overrides.get(i),
+        )
+        proposal_path = reading_pipeline.pending_proposal_path(
+            ctx.source_id, proposal.proposed_id
         )
         appended = _approve(
             ctx,
@@ -520,9 +672,9 @@ def run(
             confirmed_aliases=confirmed,
             by_label=reviewer.by_label,
         )
-        if appended:
-            if isinstance(decision, EditDecision):
-                result.edited += 1
-            else:
-                result.approved += 1
-    return result
+        if not appended:
+            continue
+        if edits is not None:
+            result.edited += 1
+        else:
+            result.approved += 1

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -17,9 +17,10 @@ from auto_lorebook import (
 )
 from auto_lorebook.review import (
     ApproveDecision,
+    BundleDecision,
+    BundleView,
     Decision,
     EditDecision,
-    ProposalView,
     RejectDecision,
     ReviewResult,
 )
@@ -141,26 +142,43 @@ def _make_claim(
 
 
 class ScriptedReviewer:
-    """Reviewer that yields scripted decisions and alias confirmations."""
+    """Bundle reviewer with scripted bundle decisions and alias responses.
+
+    Existing tests pass a list of `Decision`s — we wrap each as a
+    bundle-wide decision selecting every route. New bundling tests can
+    construct `BundleDecision` directly via `bundle_decisions=`.
+    """
 
     by_label = "human-review"
 
     def __init__(
         self,
-        decisions: list[Decision],
+        decisions: list[Decision] | None = None,
         alias_responses: list[bool] | None = None,
+        *,
+        bundle_decisions: list[BundleDecision] | None = None,
     ) -> None:
-        self._decisions = list(decisions)
+        if decisions is not None and bundle_decisions is not None:
+            msg = "pass decisions OR bundle_decisions, not both"
+            raise AssertionError(msg)
+        self._decisions: list[Decision] = list(decisions or [])
+        self._bundle_decisions: list[BundleDecision] = list(bundle_decisions or [])
         self._alias_responses = list(alias_responses or [])
-        self.decided: list[ProposalView] = []
+        self.decided: list[BundleView] = []
         self.alias_calls: list[tuple[str, str]] = []
 
-    def decide(self, view: ProposalView) -> Decision:
+    def decide_bundle(self, view: BundleView) -> BundleDecision:
         self.decided.append(view)
+        if self._bundle_decisions:
+            return self._bundle_decisions.pop(0)
         if not self._decisions:
             msg = "ScriptedReviewer ran out of decisions"
             raise AssertionError(msg)
-        return self._decisions.pop(0)
+        decision = self._decisions.pop(0)
+        return BundleDecision(
+            decision=decision,
+            selected_indices=tuple(range(len(view.targets))),
+        )
 
     def confirm_alias(self, entity: str, mention: str) -> bool:
         self.alias_calls.append((entity, mention))
@@ -773,10 +791,10 @@ class TestCreatedEarlierInSession:
         )
         scripted = ScriptedReviewer([ApproveDecision(), ApproveDecision()])
         review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
-        # First view: no on-disk entity yet
-        assert scripted.decided[0].created_earlier_in_session is False
-        # Second view: stub was created in this same run
-        assert scripted.decided[1].created_earlier_in_session is True
+        # Each cg has one target → one TargetView per bundle.
+        assert scripted.decided[0].targets[0].created_earlier_in_session is False
+        # Second bundle: stub was created in this same run
+        assert scripted.decided[1].targets[0].created_earlier_in_session is True
 
 
 # ---------------------------------------------------------------------------
@@ -929,11 +947,14 @@ class _RaisingReviewer:
         self.raise_on = raise_on
         self.calls = 0
 
-    def decide(self, view: ProposalView) -> Decision:  # noqa: ARG002
+    def decide_bundle(self, view: BundleView) -> BundleDecision:
         self.calls += 1
         if self.calls == self.raise_on:
             raise KeyboardInterrupt
-        return ApproveDecision()
+        return BundleDecision(
+            decision=ApproveDecision(),
+            selected_indices=tuple(range(len(view.targets))),
+        )
 
     def confirm_alias(self, entity: str, mention: str) -> bool:  # noqa: ARG002
         return False
@@ -1005,6 +1026,421 @@ class TestResumeAndEmpty:
 # ---------------------------------------------------------------------------
 # Edit path end-to-end
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Bundle behavior (multi-target review screen)
+# ---------------------------------------------------------------------------
+
+
+def _multi_target_setup(
+    cfg: cfg_mod.Config,
+    source_id: str,
+    *,
+    sections: tuple[str, str, str] = ("founding", "lineage", "events-in-era"),
+    aliases_per_entity: dict[str, list[str]] | None = None,
+) -> None:
+    """Plan with one cg routing to (Aldara, Theron, Second Age), all NEW."""
+    aliases_per_entity = aliases_per_entity or {}
+    _write_info(cfg.wiki_repo_path, source_id)
+    cg = "cg-multi"
+    targets = [
+        ("Aldara", "locations", sections[0], "aldara-f001"),
+        ("Theron", "characters", sections[1], "theron-f001"),
+        ("Second Age", "events", sections[2], "second-age-f001"),
+    ]
+    siblings_for = {
+        name: [
+            proposal_yaml.Sibling(entity=other, proposed_id=oid)
+            for other, _, _, oid in targets
+            if other != name
+        ]
+        for name, _, _, _ in targets
+    }
+    for name, _cat, section, pid in targets:
+        _write_proposal(
+            source_id,
+            _make_proposal(
+                target=name,
+                proposed_id=pid,
+                cg=cg,
+                section=section,
+                siblings=siblings_for[name],
+            ),
+        )
+    _write_plan(
+        cfg.wiki_repo_path,
+        source_id,
+        new_entities=[
+            plan_yaml.NewEntityProposal(
+                name=name,
+                category=cat,
+                aliases_suggested=aliases_per_entity.get(name, []),
+            )
+            for name, cat, _, _ in targets
+        ],
+        planned_claims=[
+            _make_claim(
+                cg=cg,
+                targets=[
+                    plan_yaml.ClaimTarget(
+                        entity=name,
+                        entity_state="new",
+                        proposed_section=section,
+                        proposed_category=cat,
+                    )
+                    for name, cat, section, _ in targets
+                ],
+            )
+        ],
+    )
+
+
+class TestBundle:
+    def test_bundle_groups_siblings_into_one_decision(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _multi_target_setup(cfg, source_id)
+        scripted = ScriptedReviewer([ApproveDecision()])
+        result = review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        # ONE decide_bundle call, THREE facts approved.
+        assert len(scripted.decided) == 1
+        assert result.approved == 3
+        assert result.rejected == 0
+        for slug, cat in (
+            ("aldara", "locations"),
+            ("theron", "characters"),
+            ("second-age", "events"),
+        ):
+            assert (cfg.wiki_repo_path / cat / f"{slug}.yaml").exists()
+
+    def test_targets_drop_unchecks_a_route(self, cfg: cfg_mod.Config) -> None:
+        source_id = "yt-x"
+        _multi_target_setup(cfg, source_id)
+        # Drop target index 1 (Theron); keep Aldara and Second Age.
+        scripted = ScriptedReviewer(
+            bundle_decisions=[
+                BundleDecision(
+                    decision=ApproveDecision(),
+                    selected_indices=(0, 2),
+                )
+            ]
+        )
+        result = review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        assert result.approved == 2
+        assert result.rejected == 1
+        assert (cfg.wiki_repo_path / "locations" / "aldara.yaml").exists()
+        assert (cfg.wiki_repo_path / "events" / "second-age.yaml").exists()
+        # Theron stub never created.
+        assert not (cfg.wiki_repo_path / "characters" / "theron.yaml").exists()
+        # Theron proposal file gone.
+        assert not reading_pipeline.pending_proposal_path(
+            source_id, "theron-f001"
+        ).exists()
+
+    def test_edit_text_propagates_across_selected_siblings(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _multi_target_setup(cfg, source_id)
+        scripted = ScriptedReviewer(
+            bundle_decisions=[
+                BundleDecision(
+                    decision=EditDecision(new_text="Edited claim text."),
+                    selected_indices=(0, 1, 2),
+                )
+            ]
+        )
+        result = review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        assert result.edited == 3
+        for slug, cat in (
+            ("aldara", "locations"),
+            ("theron", "characters"),
+            ("second-age", "events"),
+        ):
+            e = entity_yaml.read(cfg.wiki_repo_path / cat / f"{slug}.yaml")
+            assert e.facts[0]["text"] == "Edited claim text."
+            assert e.facts[0]["text_source"] is not None
+            assert e.facts[0]["edited_by_human"] is True
+
+    def test_per_target_override_only_applies_to_that_target(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _multi_target_setup(cfg, source_id)
+        scripted = ScriptedReviewer(
+            bundle_decisions=[
+                BundleDecision(
+                    decision=ApproveDecision(),
+                    selected_indices=(0, 1, 2),
+                    per_target_overrides={
+                        1: EditDecision(new_section="bloodlines"),
+                    },
+                )
+            ]
+        )
+        review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        aldara = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        theron = entity_yaml.read(cfg.wiki_repo_path / "characters" / "theron.yaml")
+        second = entity_yaml.read(cfg.wiki_repo_path / "events" / "second-age.yaml")
+        assert aldara.facts[0]["section"] == "founding"
+        assert theron.facts[0]["section"] == "bloodlines"
+        assert second.facts[0]["section"] == "events-in-era"
+
+    def test_singleton_claim_group_renders_as_single_target(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        _write_proposal(
+            source_id,
+            _make_proposal(target="Aldara", proposed_id="aldara-f001", cg="cg-001"),
+        )
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg="cg-001",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        scripted = ScriptedReviewer([ApproveDecision()])
+        review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        assert len(scripted.decided) == 1
+        assert len(scripted.decided[0].targets) == 1
+
+    def test_reject_discards_whole_bundle(self, cfg: cfg_mod.Config) -> None:
+        source_id = "yt-x"
+        _multi_target_setup(cfg, source_id)
+        scripted = ScriptedReviewer([RejectDecision()])
+        result = review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        assert result.rejected == 3
+        assert result.approved == 0
+        # No entity stubs created.
+        for slug, cat in (
+            ("aldara", "locations"),
+            ("theron", "characters"),
+            ("second-age", "events"),
+        ):
+            assert not (cfg.wiki_repo_path / cat / f"{slug}.yaml").exists()
+        # All proposal files gone.
+        for pid in ("aldara-f001", "theron-f001", "second-age-f001"):
+            assert not reading_pipeline.pending_proposal_path(source_id, pid).exists()
+
+    def test_alias_confirmation_only_fires_for_selected_targets(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        # Each entity has one alias suggestion. Drop Theron — its alias
+        # prompt must NOT fire.
+        _multi_target_setup(
+            cfg,
+            source_id,
+            aliases_per_entity={
+                "Aldara": ["the Realm"],
+                "Theron": ["the King"],
+                "Second Age": ["the Age"],
+            },
+        )
+        scripted = ScriptedReviewer(
+            bundle_decisions=[
+                BundleDecision(
+                    decision=ApproveDecision(),
+                    selected_indices=(0, 2),
+                )
+            ],
+            alias_responses=[True, True, True],
+        )
+        review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        prompted_entities = {entity for entity, _ in scripted.alias_calls}
+        assert "Theron" not in prompted_entities
+        assert prompted_entities == {"Aldara", "Second Age"}
+
+    def test_approve_iterates_targets_in_plan_order(self, cfg: cfg_mod.Config) -> None:
+        """Engine processes targets in plan order regardless of selection order.
+
+        Observe via alias-prompt order: each entity has one alias
+        suggestion; prompts must fire in plan order (Aldara, Theron,
+        Second Age) even when the reviewer returns
+        ``selected_indices`` reversed.
+        """
+        source_id = "yt-x"
+        _multi_target_setup(
+            cfg,
+            source_id,
+            aliases_per_entity={
+                "Aldara": ["the Realm"],
+                "Theron": ["the King"],
+                "Second Age": ["the Age"],
+            },
+        )
+        scripted = ScriptedReviewer(
+            bundle_decisions=[
+                BundleDecision(
+                    decision=ApproveDecision(),
+                    selected_indices=(2, 0, 1),
+                )
+            ],
+            alias_responses=[True, True, True],
+        )
+        review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        prompt_order = [entity for entity, _ in scripted.alias_calls]
+        assert prompt_order == ["Aldara", "Theron", "Second Age"]
+
+    def test_resume_seeds_merged_aliases_from_disk(self, cfg: cfg_mod.Config) -> None:
+        """Alias added by this ingest in a prior run() must not re-prompt."""
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        # Pre-existing entity with an alias added by THIS ingest.
+        prior = entity_yaml.Entity(
+            entity="Aldara",
+            category="locations",
+            slug="aldara",
+            aliases=[
+                entity_yaml.Alias(
+                    name="the Realm",
+                    added_by_ingest=source_id,
+                    added_at="2026-04-20T00:00:00Z",
+                    source="alias-confirmation",
+                ),
+            ],
+            created_at="2026-04-20T00:00:00Z",
+            created_by_ingest=source_id,
+            updated_at="2026-04-20T00:00:00Z",
+            facts=[],
+        )
+        entity_yaml.write(prior, cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        proposal = _make_proposal(
+            target="Aldara",
+            proposed_id="aldara-f002",
+            cg="cg-002",
+            proposal_type="new_fact",
+        )
+        _write_proposal(source_id, proposal)
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            entity_resolutions=[
+                plan_yaml.EntityResolution(
+                    mention="the Realm",
+                    resolution="existing",
+                    matched_entity="Aldara",
+                    suggested_aliases_to_add=["the Realm"],
+                ),
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg="cg-002",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="existing",
+                            proposed_section="founding",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        scripted = ScriptedReviewer([ApproveDecision()])
+        review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        # No alias prompt fired — already seeded from disk.
+        assert scripted.alias_calls == []
+        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        # Still exactly one alias (no double-add).
+        assert len(e.aliases) == 1
+
+    def test_interrupt_mid_bundle_leaves_unwritten_siblings_on_disk(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        """KI mid-bundle leaves unwritten siblings' proposal files on disk."""
+        source_id = "yt-x"
+        _multi_target_setup(cfg, source_id)
+
+        class _AliasInterrupter:
+            by_label = "human-review"
+
+            def __init__(self) -> None:
+                self.alias_calls = 0
+
+            def decide_bundle(self, view: BundleView) -> BundleDecision:
+                return BundleDecision(
+                    decision=ApproveDecision(),
+                    selected_indices=tuple(range(len(view.targets))),
+                )
+
+            def confirm_alias(self, entity: str, mention: str) -> bool:  # noqa: ARG002
+                self.alias_calls += 1
+                # Raise after Aldara approved (no aliases for it in
+                # this setup → no prompt). First alias prompt is for
+                # Theron — raise then to leave Theron + Second Age
+                # files on disk.
+                raise KeyboardInterrupt
+
+        # Re-seed plan with one alias on Theron (proposals already on
+        # disk are unaffected). Aldara has no suggestion → its
+        # confirm_alias is never called → KI fires on Theron's prompt.
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
+                plan_yaml.NewEntityProposal(
+                    name="Theron",
+                    category="characters",
+                    aliases_suggested=["the King"],
+                ),
+                plan_yaml.NewEntityProposal(name="Second Age", category="events"),
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg="cg-multi",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                        plan_yaml.ClaimTarget(
+                            entity="Theron",
+                            entity_state="new",
+                            proposed_section="lineage",
+                            proposed_category="characters",
+                        ),
+                        plan_yaml.ClaimTarget(
+                            entity="Second Age",
+                            entity_state="new",
+                            proposed_section="events-in-era",
+                            proposed_category="events",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        with pytest.raises(KeyboardInterrupt):
+            review.run(cfg=cfg, source_id=source_id, reviewer=_AliasInterrupter())
+        # Aldara approved before the raise.
+        assert not reading_pipeline.pending_proposal_path(
+            source_id, "aldara-f001"
+        ).exists()
+        # Theron + Second Age still pending.
+        assert reading_pipeline.pending_proposal_path(source_id, "theron-f001").exists()
+        assert reading_pipeline.pending_proposal_path(
+            source_id, "second-age-f001"
+        ).exists()
 
 
 class TestEditPath:

--- a/tests/test_review_cmd.py
+++ b/tests/test_review_cmd.py
@@ -15,13 +15,21 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+from auto_lorebook import config as cfg_mod
 from auto_lorebook import entity_yaml
+from auto_lorebook import review as review_mod
 from auto_lorebook.commands import (
     approve_reading_cmd,
     generate_reading_cmd,
     review_cmd,
 )
 from auto_lorebook.openrouter import OpenRouterResponse
+from auto_lorebook.review import (
+    ApproveDecision,
+    BundleDecision,
+    BundleView,
+    RejectDecision,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -128,6 +136,79 @@ def _stub_extractor_payload() -> str:
     })
 
 
+def _stub_multi_target_plan_payload() -> str:
+    """Plan routing cg-001 to three new entities sharing one claim."""
+    return json.dumps({
+        "entity_resolutions": [
+            {
+                "mention": "Aldara",
+                "mention_locations": ["[0:02:00-0:10:00] founding"],
+                "resolution": "new",
+                "proposed_entity_name": "Aldara",
+                "proposed_category": "locations",
+                "rationale": "Location of founding.",
+            },
+            {
+                "mention": "King Theron",
+                "mention_locations": ["[0:02:00-0:10:00] founding"],
+                "resolution": "new",
+                "proposed_entity_name": "Theron",
+                "proposed_category": "characters",
+                "rationale": "King who founded Aldara.",
+            },
+            {
+                "mention": "Second Age",
+                "mention_locations": ["[0:02:00-0:10:00] founding"],
+                "resolution": "new",
+                "proposed_entity_name": "Second Age",
+                "proposed_category": "events",
+                "rationale": "Era during which Aldara was founded.",
+            },
+        ],
+        "new_entities": [
+            {"name": "Aldara", "category": "locations", "aliases_suggested": []},
+            {"name": "Theron", "category": "characters", "aliases_suggested": []},
+            {"name": "Second Age", "category": "events", "aliases_suggested": []},
+        ],
+        "planned_claims": [
+            {
+                "claim_group_id": "cg-001",
+                "reading_section": "[0:02:00-0:10:00] Founding of Aldara",
+                "reading_bullet_index": 0,
+                "locator": "0:02:30",
+                "locator_hint": "0:02:00-0:02:30",
+                "proposed_speaker": "DM",
+                "proposed_status": "authoritative",
+                "proposed_status_reason": None,
+                "targets": [
+                    {
+                        "entity": "Aldara",
+                        "entity_state": "new",
+                        "proposed_section": "founding",
+                        "proposed_category": "locations",
+                        "rationale": "Founding fact.",
+                    },
+                    {
+                        "entity": "Theron",
+                        "entity_state": "new",
+                        "proposed_section": "biography",
+                        "proposed_category": "characters",
+                        "rationale": "Established as founder.",
+                    },
+                    {
+                        "entity": "Second Age",
+                        "entity_state": "new",
+                        "proposed_section": "timeline",
+                        "proposed_category": "events",
+                        "rationale": "Founding dates to this era.",
+                    },
+                ],
+            }
+        ],
+        "unresolved": [],
+    })
+
+
 def _wire_client_responses(client_mock: MagicMock) -> None:
     def side_effect(
         messages: list[dict[str, str]], **_kwargs: object
@@ -141,6 +222,35 @@ def _wire_client_responses(client_mock: MagicMock) -> None:
             text = _stub_structure_payload()
         elif "routing claim bullets" in system_text:
             text = _stub_plan_payload()
+        elif "locate the verbatim transcript span" in system_text:
+            text = _stub_extractor_payload()
+        else:
+            for seg_id in ("seg-001", "seg-002"):
+                if seg_id in user_text:
+                    text = _seg_bullets_payload(seg_id)
+                    break
+            else:
+                text = json.dumps({"bullets": []})
+        return OpenRouterResponse(text=text, model="m", tokens_in=0, tokens_out=0)
+
+    client_mock.complete.side_effect = side_effect
+
+
+def _wire_multi_target_responses(client_mock: MagicMock) -> None:
+    """Like `_wire_client_responses` but uses the 3-target plan payload."""
+
+    def side_effect(
+        messages: list[dict[str, str]], **_kwargs: object
+    ) -> OpenRouterResponse:
+        system = next((m for m in messages if m["role"] == "system"), {})
+        user = next((m for m in messages if m["role"] == "user"), {})
+        system_text = system.get("content", "")
+        user_text = user.get("content", "")
+
+        if "segmenting" in system_text:
+            text = _stub_structure_payload()
+        elif "routing claim bullets" in system_text:
+            text = _stub_multi_target_plan_payload()
         elif "locate the verbatim transcript span" in system_text:
             text = _stub_extractor_payload()
         else:
@@ -284,3 +394,156 @@ class TestEmptyDir:
         assert rc == 0
         out = capsys.readouterr().out
         assert "Nothing to review" in out
+
+
+# ---------------------------------------------------------------------------
+# Multi-target bundle integration tests
+# ---------------------------------------------------------------------------
+
+
+class _DropFirstRouteReviewer:
+    """Scripted reviewer: approves bundles with target 0 deselected."""
+
+    by_label = "scripted"
+
+    def decide_bundle(self, view: BundleView) -> BundleDecision:
+        # Keep all routes except index 0.
+        selected = tuple(i for i in range(len(view.targets)) if i != 0)
+        if not selected:
+            return BundleDecision(decision=ApproveDecision(), selected_indices=(0,))
+        return BundleDecision(decision=ApproveDecision(), selected_indices=selected)
+
+    def confirm_alias(self, entity: str, mention: str) -> bool:  # noqa: ARG002
+        return False
+
+
+class _RejectAllReviewer:
+    """Scripted reviewer: rejects every bundle."""
+
+    by_label = "scripted"
+
+    def decide_bundle(self, view: BundleView) -> BundleDecision:  # noqa: ARG002
+        return BundleDecision(decision=RejectDecision(), selected_indices=())
+
+    def confirm_alias(self, entity: str, mention: str) -> bool:  # noqa: ARG002
+        return False
+
+
+class TestMultiTargetBundle:
+    def test_auto_approve_lands_three_facts_from_one_bundle(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Three-target cg-001 → three stubs, one decide_bundle call."""
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_multi_target_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            assert approve_reading_cmd.run(_args(source_id="yt-abc12345678")) == 0
+            rc = review_cmd.run(_args(source_id="yt-abc12345678", auto_approve=True))
+        assert rc == 0
+
+        # All three stubs created.
+        aldara_path = ingested_wiki / "locations" / "aldara.yaml"
+        theron_path = ingested_wiki / "characters" / "theron.yaml"
+        second_age_path = ingested_wiki / "events" / "second-age.yaml"
+        assert aldara_path.exists(), "Aldara stub missing"
+        assert theron_path.exists(), "Theron stub missing"
+        assert second_age_path.exists(), "Second Age stub missing"
+
+        for path in (aldara_path, theron_path, second_age_path):
+            e = entity_yaml.read(path)
+            assert len(e.facts) == 1
+            assert e.created_by_ingest == "yt-abc12345678"
+            assert e.facts[0]["claim_group_id"] == "cg-001"
+
+        # Proposals dir is empty — all three consumed.
+        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        assert list(proposals_dir.glob("*.yaml")) == []
+
+        # Count: approved=3 (one bundle, three routes).
+        out = capsys.readouterr().out
+        assert "approved=3" in out
+
+    def test_drop_one_route_writes_two_facts_and_deletes_proposal(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Drop route 0 (Aldara) → only Theron + Second Age stubs created."""
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_multi_target_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            assert approve_reading_cmd.run(_args(source_id="yt-abc12345678")) == 0
+
+        result = review_mod.run(
+            cfg=cfg_mod.load_config(),
+            source_id="yt-abc12345678",
+            reviewer=_DropFirstRouteReviewer(),
+        )
+
+        # Theron and Second Age stubs exist; Aldara's proposal was dropped.
+        aldara_path = ingested_wiki / "locations" / "aldara.yaml"
+        theron_path = ingested_wiki / "characters" / "theron.yaml"
+        second_age_path = ingested_wiki / "events" / "second-age.yaml"
+        assert not aldara_path.exists(), "Aldara should not have been created"
+        assert theron_path.exists(), "Theron stub missing"
+        assert second_age_path.exists(), "Second Age stub missing"
+
+        assert result.approved == 2
+        assert result.rejected == 1
+
+        # All proposal files consumed.
+        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        assert list(proposals_dir.glob("*.yaml")) == []
+        capsys.readouterr()
+
+    def test_reject_whole_bundle_leaves_no_stubs(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Reject the 3-target bundle → no entity YAMLs created."""
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_multi_target_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            assert approve_reading_cmd.run(_args(source_id="yt-abc12345678")) == 0
+
+        result = review_mod.run(
+            cfg=cfg_mod.load_config(),
+            source_id="yt-abc12345678",
+            reviewer=_RejectAllReviewer(),
+        )
+
+        assert result.rejected == 3
+        assert result.approved == 0
+        assert not (ingested_wiki / "locations" / "aldara.yaml").exists()
+        assert not (ingested_wiki / "characters" / "theron.yaml").exists()
+        assert not (ingested_wiki / "events" / "second-age.yaml").exists()
+        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        assert list(proposals_dir.glob("*.yaml")) == []
+        capsys.readouterr()


### PR DESCRIPTION
## Summary

Refactor the review stage to group proposals sharing a `claim_group_id` into a single "bundle" screen, allowing the reviewer to approve/edit/reject multiple related targets with one decision and selectively drop individual routes before approval.

## Key Changes

- **New data structures** (`BundleView`, `TargetView`, `BundleDecision`):
  - `BundleView` wraps one claim group with multiple targets rendered as a numbered checklist
  - `TargetView` holds per-route display data (proposal, aliases, entity state)
  - `BundleDecision` captures the reviewer's choice: bundle-level decision, selected route indices, and per-target overrides

- **Reviewer protocol change**:
  - `decide(ProposalView) → Decision` becomes `decide_bundle(BundleView) → BundleDecision`
  - Allows reviewers to see all siblings at once and selectively approve/reject individual routes

- **Bundle-level vs. per-target edits**:
  - Text, status, and status_reason edits propagate to all checked routes (claim-level facts)
  - Section and speaker overrides are per-target via `per_target_overrides` dict (route-shaped data)
  - `_merge_edits()` layers per-target overrides on top of bundle-level decisions

- **Interactive UI enhancements**:
  - New `[t]argets` action to toggle routes on/off and set per-target section/speaker
  - Bundle-level `[e]dit` prompts only text/status/status_reason
  - Per-target edits accessed via `[t]` → `edit N` sub-prompt
  - Singleton bundles (one target) render abbreviated form without checklist clutter

- **Proposal grouping**:
  - `_bundle_proposals()` groups consecutive proposals by `claim_group_id` while preserving plan order
  - Ensures siblings shown contiguously and transcript order maintained across groups

- **Alias handling**:
  - Alias confirmation only fires for selected (checked) targets
  - `_seed_merged_aliases_from_disk()` prevents re-prompting on resume for aliases already confirmed in prior run

- **Test infrastructure**:
  - `ScriptedReviewer` updated to accept `bundle_decisions` parameter for new bundling tests
  - Wraps legacy `decisions` list as bundle-wide decisions selecting all routes for backward compatibility
  - Comprehensive new test suite (`TestBundle`) covering multi-target scenarios: selective approval, per-target overrides, rejection, alias filtering, and resume behavior

## Implementation Details

- Proposals are bundled after loading from disk but before display, preserving the plan's authoritative order
- `_count_remaining()` and `_seed_merged_aliases_from_disk()` support Ctrl-C resume without re-prompting
- `BundleDecision.per_target_overrides` uses last-write-wins semantics when merging with bundle-level edits
- Unselected routes are rejected (counted as rejected) but not written to disk; proposal files are deleted

https://claude.ai/code/session_01Dfm7jdQRygiNafP9JHYgxZ