### PR TITLE
Add live integration tests for external services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ Always follow red/green TDD:
 
 **Import errors do not count as red.** A test that fails due to an `ImportError` or `ModuleNotFoundError` is not a valid red test — the module/function must exist before the test can legitimately fail for the right reason.
 
+**Live integration tests.** Code that talks to a real external service (OpenRouter, yt-dlp/YouTube, future providers) gets a `@pytest.mark.live` test in `tests/test_live_integration.py` alongside its mocked unit tests. These are skipped by default and never run in CI; opt in locally with `uv run pytest --run-live`. Whenever you add or change a real-world integration boundary, add or update the matching live test in the same commit.
+
 ## After Every Code Assignment
 
 1. Run `uv sync --dev` to keep dependencies up to date

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,6 +24,29 @@ Always follow red/green TDD:
 module or function must exist before the test can legitimately fail for
 the right reason.
 
+## Live integration tests
+
+Code that talks to a real external service (OpenRouter, yt-dlp /
+YouTube, future providers) gets a `@pytest.mark.live` test in
+`tests/test_live_integration.py` alongside its mocked unit tests.
+
+Live tests are skipped by default and **not run in CI**: they cost real
+money (OpenRouter) and depend on third-party availability (YouTube).
+Opt in locally:
+
+```bash
+uv run pytest --run-live
+```
+
+Each test additionally skips if its required env var is missing
+(`OPENROUTER_API_KEY` for OpenRouter), so `--run-live` on a fresh
+checkout still passes for whatever subset the runner has credentials
+for. Override the OpenRouter model with `LIVE_TEST_MODEL=...` to run
+against a cheaper model than the project default.
+
+When you add or change a real-world integration boundary, add or
+update the matching live test in the same commit.
+
 ## After every code assignment
 
 Run these in order:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ fallback-version = "0.1.0"
 [tool.hatch.build.hooks.vcs]
 version-file = "src/auto_lorebook/_version.py"
 
+[tool.pytest.ini_options]
+markers = [
+    "live: hits real external services (OpenRouter, YouTube). Skipped unless --run-live; never in CI.",
+]
+
 [tool.uv]
 exclude-newer = "7d"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,32 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+_LIVE_OPT = "--run-live"
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register --run-live to opt in to live integration tests."""
+    parser.addoption(
+        _LIVE_OPT,
+        action="store_true",
+        default=False,
+        help="run @pytest.mark.live tests (real external services; costs money)",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Skip @pytest.mark.live tests unless --run-live passed."""
+    if config.getoption(_LIVE_OPT):
+        return
+    skip_live = pytest.mark.skip(reason=f"need {_LIVE_OPT} to run")
+    for item in items:
+        if "live" in item.keywords:
+            item.add_marker(skip_live)
+
+
 @pytest.fixture
 def package_name() -> str:
     """Return the package name (snake_case for imports)."""

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -45,6 +45,9 @@ ENV_VAR_ALLOWLIST: frozenset[str] = frozenset({
     # the OpenRouter client. Read path lands with Phase 1's config
     # module.
     "OPENROUTER_API_KEY",
+    # Test-only: read in tests/test_live_integration.py to override the
+    # model used by live OpenRouter tests. Not a runtime config knob.
+    "LIVE_TEST_MODEL",
 })
 
 #: Markdown files under ``docs/`` intentionally outside the published

--- a/tests/test_live_integration.py
+++ b/tests/test_live_integration.py
@@ -1,0 +1,80 @@
+"""Live integration tests against real external services.
+
+Skipped by default. Opt in with `uv run pytest --run-live`. Never run in
+CI: cost money (OpenRouter) and depend on third-party availability
+(YouTube). Each test additionally skips if its required env var is
+missing, so `--run-live` on a fresh checkout still passes cleanly for
+the subset the runner has credentials for.
+
+Add a test here whenever you add or change a real-world integration
+boundary; mirror the unit-test coverage in `test_openrouter.py` /
+`test_ytdlp.py` with one round-trip against the real service.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from auto_lorebook.openrouter import OpenRouterClient, OpenRouterResponse
+from auto_lorebook.ytdlp import fetch
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.live
+
+
+# Stable Rick Astley upload (2009); reliable English captions.
+_LIVE_YOUTUBE_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+_LIVE_YOUTUBE_ID = "dQw4w9WgXcQ"
+
+# Project default model; override with LIVE_TEST_MODEL for cheaper runs.
+_DEFAULT_LIVE_MODEL = "anthropic/claude-sonnet-4-5"
+
+_OPENROUTER_KEY = os.environ.get("OPENROUTER_API_KEY", "")
+
+
+@pytest.mark.skipif(
+    not _OPENROUTER_KEY,
+    reason="set $OPENROUTER_API_KEY to run this live test",
+)
+def test_openrouter_round_trip_live() -> None:
+    """Round-trip a tiny prompt through OpenRouter, verify usage fields."""
+    model = os.environ.get("LIVE_TEST_MODEL", _DEFAULT_LIVE_MODEL)
+    client = OpenRouterClient(api_key=_OPENROUTER_KEY, default_model=model)
+
+    resp = client.complete(
+        [
+            {
+                "role": "user",
+                "content": "Reply with the single word PONG and nothing else.",
+            },
+        ],
+        temperature=0.0,
+    )
+
+    assert isinstance(resp, OpenRouterResponse)
+    assert "PONG" in resp.text.upper()
+    assert resp.model  # provider echoes the model used
+    assert resp.tokens_in is not None
+    assert resp.tokens_in > 0
+    assert resp.tokens_out is not None
+    assert resp.tokens_out > 0
+
+
+def test_ytdlp_fetch_subtitles_live(tmp_path: Path) -> None:
+    """Fetch English SRT for a stable YouTube source via yt-dlp."""
+    result = fetch(_LIVE_YOUTUBE_URL, tmp_path)
+
+    assert result.video_id == _LIVE_YOUTUBE_ID
+    assert result.title
+    assert result.duration > 0
+    assert result.srt_path.exists()
+    assert result.srt_path.suffix == ".srt"
+    body = result.srt_path.read_text(encoding="utf-8")
+    assert body.strip(), "SRT file was empty"
+    # SRT cue blocks contain `-->` between start/end timestamps.
+    assert "-->" in body


### PR DESCRIPTION
## Summary
Introduces a new test suite for live integration testing against real external services (OpenRouter API and YouTube via yt-dlp). These tests are opt-in and never run in CI to avoid costs and third-party dependencies.

## Key Changes
- **New test file** `tests/test_live_integration.py`: Contains round-trip tests for OpenRouter and yt-dlp integrations
  - `test_openrouter_round_trip_live()`: Verifies OpenRouter API communication, response parsing, and token usage tracking
  - `test_ytdlp_fetch_subtitles_live()`: Validates YouTube subtitle fetching and SRT file generation
  
- **Test infrastructure** (`tests/conftest.py`):
  - Added `--run-live` pytest option to explicitly opt in to live tests
  - Implemented `pytest_collection_modifyitems` hook to skip live tests by default unless flag is passed
  - Tests gracefully skip if required environment variables are missing

- **Configuration** (`pyproject.toml`):
  - Registered `live` pytest marker with documentation about cost and CI exclusion

- **Documentation**:
  - Updated `docs/contributing.md` with live testing guidelines, including how to run them locally and override the model for cost savings
  - Updated `AGENTS.md` with live testing requirements
  - Updated `tests/test_docs.py` to recognize `LIVE_TEST_MODEL` as a test-only environment variable

## Implementation Details
- Live tests use stable, reliable sources: Rick Astley's "Never Gonna Give You Up" (2009) for YouTube testing and Claude Sonnet 4.5 as the default model
- Environment variable `LIVE_TEST_MODEL` allows overriding the OpenRouter model for cheaper test runs
- Each test independently skips if its required credentials are missing, allowing `--run-live` to pass on fresh checkouts for available services
- Tests verify both happy-path functionality and response structure (e.g., token counts, file existence)

https://claude.ai/code/session_01MxcmW2tDKMo2WJQG4x1z9Q