### PR TITLE
Add interactive approve-reading session with edit/reject/undo

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -29,7 +29,7 @@ YouTube URL / SRT / text file
   Stage 1b: Summarize (LLM)    per-segment claim bullets
         │
         ▼
-  [Human review gate]   approve reading
+  [Human review gate]   approve / edit / reject reading
         │
         ▼
   Stage 2: Planner (LLM)       route claims → entities

--- a/docs/getting-started/first-ingest.md
+++ b/docs/getting-started/first-ingest.md
@@ -47,24 +47,32 @@ LLM quality but don't block the pipeline. See
 
 ## 3. Review the reading
 
-After Stage 1a (structure) and Stage 1b (summarize) run, the tool opens
-`sources/yt-abc123/reading.md` — a segmented, attributed, claim-bulleted
-version of the transcript. Edit what's wrong:
-
-- Segment boundaries or titles.
-- Speaker attributions.
-- Claim bullets that don't match what was said, are invented, or are
-  missing.
-- Name corrections — add to the `name_corrections` frontmatter map.
-
-When satisfied:
+After Stage 1a (structure) and Stage 1b (summarize) run, you get a
+draft at `pending/yt-abc123/reading/reading.md` — a segmented,
+attributed, claim-bulleted version of the transcript. Open the
+interactive review:
 
 ```bash
 auto-lorebook approve-reading yt-abc123
 ```
 
-This flips `reading_status` from `draft` to `approved` and unlocks the
-downstream stages. See [reading stage](../pipeline/reading.md) for
+The session prints the draft and prompts:
+
+- `a` — approve (flips status, copies to wiki, kicks off plan + extract).
+- `e` — edit in `$EDITOR`. Fix:
+    - Segment boundaries or titles.
+    - Speaker attributions.
+    - Claim bullets that don't match what was said, are invented, or
+      are missing.
+    - `name_corrections` frontmatter map.
+- `r` — queue the draft for deletion.
+- `u` — restore the draft to its session-start contents and clear any
+  queued reject.
+- `q` — quit; commits a queued reject (after a `y/N` confirm) or
+  exits cleanly.
+
+Pass `--yes` to skip the loop and auto-approve (required for
+scripted/CI runs). See [reading stage](../pipeline/reading.md) for
 deeper treatment.
 
 ## 4. Review facts

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ YouTube URL / SRT / text file
   Stage 1b: Summarize (LLM)    per-segment claim bullets
         │
         ▼
-  [Human review gate]   approve reading
+  [Human review gate]   approve / edit / reject reading
         │
         ▼
   Stage 2: Planner (LLM)       route claims → entities

--- a/docs/pipeline/reading.md
+++ b/docs/pipeline/reading.md
@@ -274,6 +274,19 @@ reading.
 auto-lorebook approve-reading <source_id>
 ```
 
+`approve-reading` opens an interactive session over the draft:
+
+| Key | Action |
+|-----|--------|
+| `a` | Approve: flip status to `approved`, copy to wiki, run plan + extract. |
+| `e` | Edit: open the draft in `$EDITOR` (defaults to `vi`); on save, return to the prompt. |
+| `r` | Reject: queue the pending reading dir for deletion. Deferred — nothing happens until you `q`. |
+| `u` | Undo: restore the draft to its session-start contents and clear any queued reject. |
+| `q` | Quit: if a reject is queued, confirm and delete `pending/<id>/reading/`; otherwise no-op. |
+
+`--yes` skips the loop and auto-approves; required for non-TTY runs
+(scripts, CI). Ctrl-C exits 130 with no changes.
+
 After approval, the reading is committed to the wiki alongside the
 raw transcript. The intermediate `structure.yaml` is retained in the
 pending directory as an audit artifact for the lifetime of the ingest,

--- a/src/auto_lorebook/commands/approve_reading.py
+++ b/src/auto_lorebook/commands/approve_reading.py
@@ -3,15 +3,23 @@
 from __future__ import annotations
 
 import logging
+import os
+import shutil
+import subprocess  # noqa: S404
 from typing import TYPE_CHECKING
 
 from auto_lorebook import config as cfg_mod
 from auto_lorebook import reading_pipeline as pipeline
+from auto_lorebook.interactive import _is_interactive
 
 if TYPE_CHECKING:
     import argparse
+    from pathlib import Path
 
 _logger = logging.getLogger(__name__)
+
+_PROMPT = "[a]pprove / [e]dit / [r]eject / [u]ndo / [q]uit > "
+_RENDER_LINES = 40
 
 
 def add_parser(
@@ -22,15 +30,23 @@ def add_parser(
     parser = subparsers.add_parser(
         "approve-reading",
         parents=[common_parser],
-        help="Flip the draft reading to approved and copy it into the wiki",
+        help="Interactively approve, edit, or reject the draft reading",
         description=(
-            "Sets `reading_status: approved` on the draft reading.md under "
-            "~/.auto-lorebook/pending/<source_id>/reading/ and copies it to "
-            "<wiki>/sources/<source_id>/reading.md. Downstream stages refuse "
-            "to run on a draft reading."
+            "Opens an interactive session over the draft reading.md under "
+            "~/.auto-lorebook/pending/<source_id>/reading/. Keys: "
+            "[a]pprove (flip to approved + copy to wiki + run plan/extract), "
+            "[e]dit (open in $EDITOR), [r]eject (queue pending dir for delete), "
+            "[u]ndo (restore to session start, clear reject), "
+            "[q]uit (commit a queued reject after confirmation, else no-op). "
+            "Pass --yes to skip the loop and auto-approve."
         ),
     )
     parser.add_argument("source_id", help="Source ID (e.g. yt-abc12345678)")
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the interactive loop; auto-approve (required for non-TTY runs).",
+    )
     parser.set_defaults(func=run)
     return parser
 
@@ -43,8 +59,20 @@ def run(args: argparse.Namespace) -> int:
         _logger.error("%s", e)
         return 1
 
+    if not args.yes and not _is_interactive():
+        _logger.error("Refusing to approve-reading non-interactively without --yes.")
+        return 1
+
+    if args.yes:
+        return _approve_and_extract(cfg, args.source_id)
+
+    return _interactive_session(cfg, args.source_id)
+
+
+def _approve_and_extract(cfg: cfg_mod.Config, source_id: str) -> int:
+    """Original one-shot flow: approve → plan → extract."""
     try:
-        approved = pipeline.approve(cfg, args.source_id)
+        approved = pipeline.approve(cfg, source_id)
     except pipeline.ReadingPipelineError as e:
         _logger.error("%s", e)
         return 1
@@ -52,7 +80,7 @@ def run(args: argparse.Namespace) -> int:
     print(f"Approved: {approved}")  # noqa: T201
 
     try:
-        plan_result = pipeline.plan(cfg, args.source_id)
+        plan_result = pipeline.plan(cfg, source_id)
     except pipeline.ReadingPipelineError as e:
         _logger.error("planner failed: %s", e)
         return 1
@@ -60,7 +88,7 @@ def run(args: argparse.Namespace) -> int:
     print(f"Plan: {plan_result.plan_path}")  # noqa: T201
 
     try:
-        extract_result = pipeline.extract(cfg, args.source_id)
+        extract_result = pipeline.extract(cfg, source_id)
     except pipeline.ReadingPipelineError as e:
         _logger.error("extractor failed: %s", e)
         return 1
@@ -71,4 +99,74 @@ def run(args: argparse.Namespace) -> int:
         f"Extracted {n} proposal(s) ({flagged} flagged) → "
         f"{extract_result.proposals_dir}"
     )
+    return 0
+
+
+def _interactive_session(cfg: cfg_mod.Config, source_id: str) -> int:
+    pending_path = pipeline.pending_reading_path(source_id)
+    if not pending_path.exists():
+        _logger.error(
+            "No draft reading for %r. Run `generate-reading` first.", source_id
+        )
+        return 1
+
+    original_bytes = pending_path.read_bytes()
+    pending_action = "none"
+
+    while True:
+        _render(pending_path, pending_action, original_bytes)
+        try:
+            choice = input(_PROMPT).strip().lower()
+        except EOFError:
+            print()  # noqa: T201
+            return _commit_quit(source_id, pending_action)
+        except KeyboardInterrupt:
+            print()  # noqa: T201
+            return 130
+
+        if choice == "a":
+            return _approve_and_extract(cfg, source_id)
+        if choice == "q":
+            return _commit_quit(source_id, pending_action)
+        if choice == "r":
+            pending_action = "reject"
+            continue
+        if choice == "u":
+            pending_path.write_bytes(original_bytes)
+            pending_action = "none"
+            continue
+        if choice == "e":
+            editor = os.environ.get("EDITOR", "vi")
+            subprocess.run([editor, str(pending_path)], check=False)  # noqa: S603
+            continue
+        # unrecognized → re-prompt
+
+
+def _render(pending_path: Path, pending_action: str, original_bytes: bytes) -> None:
+    text = pending_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    head = "\n".join(lines[:_RENDER_LINES])
+    suffix = (
+        f"\n  ... ({len(lines) - _RENDER_LINES} more lines, {len(text)} chars total)"
+        if len(lines) > _RENDER_LINES
+        else ""
+    )
+    dirty = " [edited]" if pending_path.read_bytes() != original_bytes else ""
+    print(f"\n--- {pending_path}{dirty} ---")  # noqa: T201
+    print(head + suffix)  # noqa: T201
+    print(f"--- pending action: {pending_action} ---")  # noqa: T201
+
+
+def _commit_quit(source_id: str, pending_action: str) -> int:
+    if pending_action != "reject":
+        return 0
+    pending_dir = pipeline.pending_dir(source_id)
+    try:
+        answer = input(f"Delete {pending_dir}? [y/N] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()  # noqa: T201
+        return 0
+    if answer in {"y", "yes"}:
+        shutil.rmtree(pending_dir, ignore_errors=True)
+        print(f"Deleted {pending_dir}")  # noqa: T201
     return 0

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -285,7 +285,7 @@ class TestApproveReading:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=True))
 
         assert rc == 0
         approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
@@ -310,7 +310,7 @@ class TestApproveReading:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=True))
 
         assert rc == 0
         plan_path = tmp_home / "pending" / "yt-abc12345678" / "plan.yaml"
@@ -327,7 +327,7 @@ class TestApproveReading:
 
     def test_no_draft_errors(self, tmp_home: Path, ingested_wiki: Path) -> None:
         _write_user_config(tmp_home, ingested_wiki)
-        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678"))
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=True))
         assert rc == 1
 
     def test_writes_proposals_via_stage3(
@@ -346,7 +346,7 @@ class TestApproveReading:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=True))
 
         assert rc == 0
         proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
@@ -360,6 +360,266 @@ class TestApproveReading:
         out = capsys.readouterr().out
         assert "Extracted 2 proposal" in out
         assert "(0 flagged)" in out
+
+
+class TestApproveReadingInteractive:
+    """Interactive approve-reading loop ([a]/[e]/[r]/[u]/[q] + --yes)."""
+
+    def _patch_inputs(
+        self, monkeypatch: pytest.MonkeyPatch, answers: list[str]
+    ) -> list[str]:
+        """Feed scripted answers to input(); return mutable record of prompts seen."""
+        prompts: list[str] = []
+        it = iter(answers)
+
+        def fake_input(prompt: str = "") -> str:
+            prompts.append(prompt)
+            try:
+                return next(it)
+            except StopIteration as e:
+                raise EOFError from e
+
+        monkeypatch.setattr("builtins.input", fake_input)
+        return prompts
+
+    def _force_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "auto_lorebook.commands.approve_reading._is_interactive",
+            lambda: True,
+        )
+
+    def test_approve_keystroke_runs_full_pipeline(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+        self._force_tty(monkeypatch)
+        prompts = self._patch_inputs(monkeypatch, ["a"])
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        # Loop must have prompted before approving.
+        assert len(prompts) >= 1
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert approved.exists()
+        assert "reading_status: approved" in approved.read_text(encoding="utf-8")
+        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        assert proposals_dir.is_dir()
+
+    def test_non_tty_without_yes_errors(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+        monkeypatch.setattr(
+            "auto_lorebook.commands.approve_reading._is_interactive",
+            lambda: False,
+        )
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 1
+        # Pipeline must not have copied to wiki.
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert not approved.exists()
+
+    def test_quit_without_action_is_noop(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+        self._force_tty(monkeypatch)
+        self._patch_inputs(monkeypatch, ["q"])
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        # No wiki copy, no plan, pending dir intact.
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert not approved.exists()
+        assert not (tmp_home / "pending" / "yt-abc12345678" / "plan.yaml").exists()
+        assert (
+            tmp_home / "pending" / "yt-abc12345678" / "reading" / "reading.md"
+        ).exists()
+
+    def test_reject_then_quit_with_confirm_deletes_pending(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+        self._force_tty(monkeypatch)
+        self._patch_inputs(monkeypatch, ["r", "q", "y"])
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        assert not (tmp_home / "pending" / "yt-abc12345678" / "reading").exists()
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert not approved.exists()
+
+    def test_reject_then_quit_decline_confirm_keeps_pending(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+        self._force_tty(monkeypatch)
+        self._patch_inputs(monkeypatch, ["r", "q", "n"])
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        assert (
+            tmp_home / "pending" / "yt-abc12345678" / "reading" / "reading.md"
+        ).exists()
+
+    def test_reject_then_undo_then_approve(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+        self._force_tty(monkeypatch)
+        self._patch_inputs(monkeypatch, ["r", "u", "a"])
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert approved.exists()
+        assert "reading_status: approved" in approved.read_text(encoding="utf-8")
+
+    def test_undo_restores_edited_file(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """[u] rolls back any in-session edits to the pending reading."""
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+        self._force_tty(monkeypatch)
+        self._patch_inputs(monkeypatch, ["e", "u", "a"])
+
+        pending_path = (
+            tmp_home / "pending" / "yt-abc12345678" / "reading" / "reading.md"
+        )
+
+        def fake_editor(_cmd: list[str], **_kwargs: object) -> object:
+            # Simulate the user destructively rewriting the file.
+            pending_path.write_text("REWRITTEN", encoding="utf-8")
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(
+            "auto_lorebook.commands.approve_reading.subprocess.run", fake_editor
+        )
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            original = pending_path.read_bytes()
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        # After [e][u][a]: wiki copy must reflect ORIGINAL content, not "REWRITTEN".
+        assert approved.exists()
+        assert "REWRITTEN" not in approved.read_text(encoding="utf-8")
+        assert "King Theron" in approved.read_text(encoding="utf-8")
+        # Sanity: the original we snapshotted before the run matches what
+        # generate-reading produced.
+        assert b"King Theron" in original
+
+    def test_edit_invokes_editor_then_reprompts(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+        monkeypatch.setenv("EDITOR", "my-fake-editor")
+        self._force_tty(monkeypatch)
+        self._patch_inputs(monkeypatch, ["e", "a"])
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: object) -> object:
+            calls.append(cmd)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(
+            "auto_lorebook.commands.approve_reading.subprocess.run", fake_run
+        )
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        assert len(calls) == 1
+        assert calls[0][0] == "my-fake-editor"
+        assert calls[0][1].endswith("reading.md")
 
 
 class TestRegenerateReading:

--- a/tests/test_reject_ingest_cmd.py
+++ b/tests/test_reject_ingest_cmd.py
@@ -214,7 +214,7 @@ def _approve_one(
     _wire_client(client)
     with patch("auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client):
         generate_reading_cmd.run(_args(source_id=SOURCE_ID))
-        approve_reading_cmd.run(_args(source_id=SOURCE_ID))
+        approve_reading_cmd.run(_args(source_id=SOURCE_ID, yes=True))
         review_cmd.run(_args(source_id=SOURCE_ID, auto_approve=True))
 
 

--- a/tests/test_replan_cmd.py
+++ b/tests/test_replan_cmd.py
@@ -218,7 +218,7 @@ class TestReplan:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id=SOURCE_ID))
-            approve_reading_cmd.run(_args(source_id=SOURCE_ID))
+            approve_reading_cmd.run(_args(source_id=SOURCE_ID, yes=True))
             review_cmd.run(_args(source_id=SOURCE_ID, auto_approve=True))
             # Now the entity stub exists and the proposals dir is empty.
             aldara_path = ingested_wiki / "locations" / "aldara.yaml"
@@ -252,7 +252,7 @@ class TestReplan:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id=SOURCE_ID))
-            approve_reading_cmd.run(_args(source_id=SOURCE_ID))
+            approve_reading_cmd.run(_args(source_id=SOURCE_ID, yes=True))
             # Drop a stale file into the proposals dir as if from an earlier
             # run that we want overwritten.
             proposals_dir = reading_pipeline.pending_proposals_dir(SOURCE_ID)
@@ -292,7 +292,7 @@ class TestReplan:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id=SOURCE_ID))
-            approve_reading_cmd.run(_args(source_id=SOURCE_ID))
+            approve_reading_cmd.run(_args(source_id=SOURCE_ID, yes=True))
             # Remove structure.yaml to break the prerequisite.
             reading_pipeline.pending_structure_path(SOURCE_ID).unlink()
             rc = replan_cmd.run(_args(source_id=SOURCE_ID))

--- a/tests/test_review_cmd.py
+++ b/tests/test_review_cmd.py
@@ -339,7 +339,10 @@ class TestAutoApprove:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            assert approve_reading_cmd.run(_args(source_id="yt-abc12345678")) == 0
+            assert (
+                approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=True))
+                == 0
+            )
             rc = review_cmd.run(_args(source_id="yt-abc12345678", auto_approve=True))
         assert rc == 0
         # Stub created
@@ -386,7 +389,7 @@ class TestEmptyDir:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            approve_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=True))
             # Drain via auto-approve, then run again — should be empty.
             review_cmd.run(_args(source_id="yt-abc12345678", auto_approve=True))
             capsys.readouterr()
@@ -447,7 +450,10 @@ class TestMultiTargetBundle:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            assert approve_reading_cmd.run(_args(source_id="yt-abc12345678")) == 0
+            assert (
+                approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=True))
+                == 0
+            )
             rc = review_cmd.run(_args(source_id="yt-abc12345678", auto_approve=True))
         assert rc == 0
 
@@ -490,7 +496,10 @@ class TestMultiTargetBundle:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            assert approve_reading_cmd.run(_args(source_id="yt-abc12345678")) == 0
+            assert (
+                approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=True))
+                == 0
+            )
 
         result = review_mod.run(
             cfg=cfg_mod.load_config(),
@@ -531,7 +540,10 @@ class TestMultiTargetBundle:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            assert approve_reading_cmd.run(_args(source_id="yt-abc12345678")) == 0
+            assert (
+                approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=True))
+                == 0
+            )
 
         result = review_mod.run(
             cfg=cfg_mod.load_config(),


### PR DESCRIPTION
## Summary

Transform `approve-reading` from a one-shot approval command into an interactive session that allows users to review, edit, reject, or undo changes to draft readings before committing them to the wiki.

## Key Changes

- **Interactive session loop** in `approve_reading.py`:
  - New `_interactive_session()` function implements a REPL-style prompt with five actions:
    - `[a]pprove` — approve and run the full pipeline (plan + extract)
    - `[e]dit` — open the draft in `$EDITOR` for inline modifications
    - `[r]eject` — queue the pending directory for deletion (deferred until quit)
    - `[u]ndo` — restore the draft to session-start state and clear any queued reject
    - `[q]uit` — commit a queued reject (with confirmation) or exit cleanly
  - Snapshots the original file content at session start to enable undo
  - Renders the first 40 lines of the draft plus metadata on each iteration

- **Non-interactive fallback**:
  - Added `--yes` flag to skip the interactive loop and auto-approve (required for non-TTY/scripted runs)
  - Checks `_is_interactive()` and errors if neither `--yes` nor TTY is available
  - Refactored original approval flow into `_approve_and_extract()` for reuse

- **Editor integration**:
  - Respects `$EDITOR` environment variable (defaults to `vi`)
  - Invokes editor via `subprocess.run()` and returns to prompt on save

- **Pending action tracking**:
  - Maintains state across loop iterations (none/reject)
  - Displays pending action in the render output
  - Confirmation prompt on quit if reject is queued

- **Test coverage**:
  - New `TestApproveReadingInteractive` class with 9 test cases covering:
    - Approve keystroke runs full pipeline
    - Non-TTY without `--yes` errors
    - Quit without action is no-op
    - Reject + quit with/without confirmation
    - Reject + undo + approve flow
    - Undo restores edited file to original
    - Edit invokes editor and reprompts
  - Updated existing tests to pass `yes=True` for non-interactive runs

- **Documentation updates**:
  - Updated help text and description in `add_parser()`
  - Added interactive key table to `docs/pipeline/reading.md`
  - Updated getting-started guide with interactive workflow
  - Updated architecture diagrams to reflect "approve / edit / reject reading"

## Implementation Details

- Uses `pathlib.Path` for file operations and `shutil.rmtree()` for cleanup
- Handles `EOFError` and `KeyboardInterrupt` gracefully (Ctrl-C exits 130)
- Dirty-file detection compares current bytes to original snapshot
- Unrecognized input re-prompts without action
- All test fixtures updated to use `yes=True` for backward compatibility with non-interactive test runs

https://claude.ai/code/session_01DPwSGEg3MnjiEFsUewtm2t