### PR TITLE
Add agent skill documentation for issue tracking and domain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,20 @@ Read the docs when evaluating current state of implementation and roadmap.
 Always update docs after feature implemented.
 Update relevant doc after bugfix where necessary.
 
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues at `corvous/auto-lorebook` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical roles mapped 1:1 to defaults (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
 ## TDD Workflow
 
 Always follow red/green TDD:

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This repo is single-context:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-...md
+│   └── 0002-...md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -52,7 +52,13 @@ ENV_VAR_ALLOWLIST: frozenset[str] = frozenset({
 
 #: Markdown files under ``docs/`` intentionally outside the published
 #: ``mkdocs.yml`` nav (e.g. shared includes).
-DOC_ORPHAN_ALLOWLIST: frozenset[str] = frozenset()
+DOC_ORPHAN_ALLOWLIST: frozenset[str] = frozenset({
+    # Agent-skill contracts consumed by Claude Code skills, not the
+    # public mkdocs site. Referenced from AGENTS.md.
+    "agents/domain.md",
+    "agents/issue-tracker.md",
+    "agents/triage-labels.md",
+})
 
 #: Registered CLI subcommands intentionally absent from the user-facing
 #: CLI reference (e.g. debugging-only). Prefer documenting over


### PR DESCRIPTION
## Summary

This PR establishes foundational documentation for AI agent skills, defining how agents should interact with the repository's issue tracker, domain knowledge, and triage workflows.

## Key changes

- **`docs/agents/domain.md`**: Documents how agents should consume domain documentation, including reading `CONTEXT.md` and ADRs, using consistent glossary vocabulary, and flagging ADR conflicts rather than silently overriding them.

- **`docs/agents/issue-tracker.md`**: Specifies GitHub Issues as the canonical issue tracker with `gh` CLI conventions for creating, reading, listing, commenting on, and labeling issues.

- **`docs/agents/triage-labels.md`**: Maps five canonical triage roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) to their label implementations in this repository.

- **`AGENTS.md`**: Updated to reference the new skill documentation and provide a high-level overview of agent capabilities (issue tracker, triage labels, domain docs).

## Implementation details

These docs establish a contract between the agent system and the repository:
- Agents know where to find domain context and architectural decisions
- Agents use consistent vocabulary from `CONTEXT.md` when naming concepts
- Agents surface conflicts with existing decisions rather than silently overriding them
- Agents interact with GitHub Issues through a standardized CLI interface
- Triage labels follow a predictable, canonical naming scheme

This enables agents to operate autonomously while maintaining consistency with project conventions and decision history.

https://claude.ai/code/session_0199yxyULxdSLZL2ADgawNn2