### PR TITLE
Add seed-ingest command for QA testing of pipeline stages

### DIFF
--- a/docs/architecture/repository-layout.md
+++ b/docs/architecture/repository-layout.md
@@ -75,6 +75,13 @@ paused mid-review, and resumed.
   `created_by_ingest` and `approved_at` fields on the resulting
   facts.
 
+## QA fixtures
+
+Synthetic stage-input artifacts ship with the package under
+`src/auto_lorebook/_qa_fixtures/<name>/` and are loaded via
+`importlib.resources` by the `seed-ingest` command. See
+[QA seeding](../contributing.md#qa-seeding).
+
 ## Why the split
 
 Keeping pending state outside the wiki repo means:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -47,6 +47,38 @@ against a cheaper model than the project default.
 When you add or change a real-world integration boundary, add or
 update the matching live test in the same commit.
 
+## QA seeding
+
+`auto-lorebook seed-ingest --at=<stage>` mints a fresh disposable
+`qa-<hex>` source_id and lays down synthetic stage-input artifacts, so
+a single pipeline stage can be exercised in isolation without running
+the prior stages or hitting the LLM.
+
+```bash
+uv run auto-lorebook seed-ingest --at=plan
+# Seeded source qa-1a2b3c4d at stage 'plan' from fixture 'tiny-aldara'.
+# Next: auto-lorebook replan qa-1a2b3c4d
+```
+
+Stage ladder (each `--at` value seeds everything from prior levels too):
+
+| `--at`      | Next command                                              |
+|-------------|-----------------------------------------------------------|
+| `structure` | `generate-reading <sid>` — runs Stage 1a + 1b             |
+| `summarize` | `regenerate-reading <sid> --from=summarize` — runs 1b     |
+| `approve`   | `approve-reading <sid> --yes` — runs approve + plan + extract |
+| `plan`      | `replan <sid>` — runs Stage 2 + 3                         |
+
+Fixtures live in the package at `src/auto_lorebook/_qa_fixtures/`; the
+default is `tiny-aldara` (a 4-cue SRT with two segments). Add new
+fixtures by dropping a sibling directory containing the same set of
+artifacts.
+
+Clean up with `reject-ingest <sid>` (which knows how to remove pending
+artifacts and any contributions written into the wiki). The interactive
+review and reading-approval gates are out of scope for QA seeding —
+exercise them manually if you need to test those paths.
+
 ## After every code assignment
 
 Run these in order:

--- a/docs/pipeline/extractor.md
+++ b/docs/pipeline/extractor.md
@@ -4,6 +4,11 @@ For each planned claim, the extractor locates the verbatim span in the
 raw transcript and produces a proposal with full metadata. No
 paraphrasing — extraction only.
 
+> Test this stage in isolation with
+> `auto-lorebook seed-ingest --at=plan`, then `replan <sid>` (which
+> runs the planner then this extractor). See
+> [QA seeding](../contributing.md#qa-seeding).
+
 ## Purpose
 
 Narrow by design: locate and snip. Cleanup happens upstream (reading-

--- a/docs/pipeline/planner.md
+++ b/docs/pipeline/planner.md
@@ -5,6 +5,10 @@ resolving entity identity (existing vs. new) and flagging ambiguity.
 It is an intermediate stage with no approval gate and no filesystem
 side effects.
 
+> Test this stage in isolation with
+> `auto-lorebook seed-ingest --at=plan`, then `replan <sid>`. See
+> [QA seeding](../contributing.md#qa-seeding).
+
 ## Purpose
 
 - Route each claim bullet to one or more entities.

--- a/docs/pipeline/reading.md
+++ b/docs/pipeline/reading.md
@@ -5,6 +5,11 @@ segments the transcript and attributes speakers in a single pass. 1b
 (summarize) produces claim bullets per segment. The human reviews the
 combined output as a single reading — one review gate.
 
+> Test this stage in isolation with
+> `auto-lorebook seed-ingest --at=structure` (Stage 1a + 1b) or
+> `--at=summarize` (Stage 1b only). See
+> [QA seeding](../contributing.md#qa-seeding).
+
 ## Design drivers
 
 Two properties of the intended use dominate the design of this stage:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -125,6 +125,21 @@ auto-lorebook sources list          # flags sources with missing session_date
 auto-lorebook sources show <source_id>
 ```
 
+## QA
+
+```bash
+auto-lorebook seed-ingest --at={structure|summarize|approve|plan} \
+  [--fixture <name>] \
+  [--source-id <id>]
+```
+
+Mints a fresh `qa-<hex>` source_id and lays down a synthetic ingest up
+through the chosen stage, so the next pipeline stage can be exercised
+in isolation without re-running prior stages or hitting the LLM. The
+default fixture is `tiny-aldara`; additional fixtures live under
+`src/auto_lorebook/_qa_fixtures/`. Pair with `reject-ingest <id>` to
+clean up. See [QA seeding](../contributing.md#qa-seeding).
+
 ## Web UI
 
 ```bash

--- a/src/auto_lorebook/_qa_fixtures/tiny-aldara/bullets.yaml
+++ b/src/auto_lorebook/_qa_fixtures/tiny-aldara/bullets.yaml
@@ -1,0 +1,14 @@
+schema_version: 1
+source_id: __QA_SOURCE_ID__
+generated_at: '2026-01-01T00:00:00Z'
+segments:
+  seg-001:
+    - text: Intro bullet
+      anchor: '0:00:15'
+      locator_hint_start: '0:00:08'
+      locator_hint_end: '0:00:23'
+  seg-002:
+    - text: King Theron founded Aldara
+      anchor: '0:02:30'
+      locator_hint_start: '0:02:23'
+      locator_hint_end: '0:02:38'

--- a/src/auto_lorebook/_qa_fixtures/tiny-aldara/info.yaml
+++ b/src/auto_lorebook/_qa_fixtures/tiny-aldara/info.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+source_id: __QA_SOURCE_ID__
+source_type: srt
+source_url: null
+title: Tiny Aldara QA Fixture
+duration_seconds: 600
+caption_type: null
+fetched_at: '2026-01-01T00:00:00Z'
+session_date: null
+transcript_filename: transcript.en.srt
+context:
+  perspective: null
+  source_nature: null
+  setting: null
+  speakers: []
+  notes: null

--- a/src/auto_lorebook/_qa_fixtures/tiny-aldara/plan.yaml
+++ b/src/auto_lorebook/_qa_fixtures/tiny-aldara/plan.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+source_id: __QA_SOURCE_ID__
+planned_at: '2026-01-01T00:00:00Z'
+entity_resolutions:
+  - mention: Aldara
+    mention_locations:
+      - '[0:02:00-0:10:00] founding'
+    resolution: new
+    proposed_entity_name: Aldara
+    proposed_category: locations
+    rationale: Mentioned as a founded place.
+new_entities:
+  - name: Aldara
+    category: locations
+planned_claims:
+  - claim_group_id: cg-001
+    reading_section: '[0:02:00-0:10:00] Founding of Aldara'
+    reading_bullet_index: 0
+    locator: '0:02:30'
+    locator_hint: '0:02:23-0:02:38'
+    proposed_speaker: DM
+    proposed_status: authoritative
+    targets:
+      - entity: Aldara
+        entity_state: new
+        proposed_section: founding
+        proposed_category: locations
+        rationale: Founding fact.
+unresolved: []

--- a/src/auto_lorebook/_qa_fixtures/tiny-aldara/reading.md
+++ b/src/auto_lorebook/_qa_fixtures/tiny-aldara/reading.md
@@ -1,0 +1,26 @@
+---
+schema_version: 1
+source_id: __QA_SOURCE_ID__
+source_name: Tiny Aldara QA Fixture
+source_url: null
+source_type: srt
+session_date: null
+ingested_at: '2026-01-01T00:00:00Z'
+reading_status: approved
+default_speaker: DM
+name_corrections: {}
+---
+
+# Reading: Tiny Aldara QA Fixture
+
+## [0:00:00-0:02:00] Intro
+
+Speaker: DM
+
+- Intro bullet [0:00:15]
+
+## [0:02:00-0:10:00] Founding of Aldara
+
+Speaker: DM
+
+- King Theron founded Aldara [0:02:30]

--- a/src/auto_lorebook/_qa_fixtures/tiny-aldara/structure.yaml
+++ b/src/auto_lorebook/_qa_fixtures/tiny-aldara/structure.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+source_id: __QA_SOURCE_ID__
+generated_at: '2026-01-01T00:00:00Z'
+default_speaker: DM
+segments:
+  - id: seg-001
+    start: '0:00:00'
+    end: '0:02:00'
+    title: Intro
+    speaker: DM
+  - id: seg-002
+    start: '0:02:00'
+    end: '0:10:00'
+    title: Founding of Aldara
+    speaker: DM
+uncertainty_flags: []

--- a/src/auto_lorebook/_qa_fixtures/tiny-aldara/transcript.en.srt
+++ b/src/auto_lorebook/_qa_fixtures/tiny-aldara/transcript.en.srt
@@ -1,0 +1,15 @@
+1
+00:00:00,000 --> 00:00:30,000
+Welcome to the session.
+
+2
+00:00:30,000 --> 00:02:00,000
+Today we talk about Aldara.
+
+3
+00:02:00,000 --> 00:05:00,000
+King Theron founded Aldara in the Second Age.
+
+4
+00:05:00,000 --> 00:10:00,000
+The war followed. Many died.

--- a/src/auto_lorebook/cli.py
+++ b/src/auto_lorebook/cli.py
@@ -21,6 +21,7 @@ from auto_lorebook.commands import (
     reject_ingest_cmd,
     replan_cmd,
     review_cmd,
+    seed_ingest_cmd,
     version_cmd,
 )
 
@@ -110,6 +111,7 @@ def create_parser() -> argparse.ArgumentParser:
     review_cmd.add_parser(subparsers, common_parser)
     replan_cmd.add_parser(subparsers, common_parser)
     reject_ingest_cmd.add_parser(subparsers, common_parser)
+    seed_ingest_cmd.add_parser(subparsers, common_parser)
 
     return parser
 

--- a/src/auto_lorebook/commands/__init__.py
+++ b/src/auto_lorebook/commands/__init__.py
@@ -15,6 +15,7 @@ from auto_lorebook.commands import regenerate_reading as regenerate_reading_cmd
 from auto_lorebook.commands import reject_ingest as reject_ingest_cmd
 from auto_lorebook.commands import replan as replan_cmd
 from auto_lorebook.commands import review as review_cmd
+from auto_lorebook.commands import seed_ingest as seed_ingest_cmd
 from auto_lorebook.commands import version as version_cmd
 
 __all__ = [
@@ -28,5 +29,6 @@ __all__ = [
     "reject_ingest_cmd",
     "replan_cmd",
     "review_cmd",
+    "seed_ingest_cmd",
     "version_cmd",
 ]

--- a/src/auto_lorebook/commands/seed_ingest.py
+++ b/src/auto_lorebook/commands/seed_ingest.py
@@ -1,0 +1,214 @@
+"""auto-lorebook seed-ingest subcommand.
+
+Seeds a fresh disposable ``qa-*`` source with synthetic stage-input
+fixtures, so a stage can be exercised in isolation without running the
+prior stages or hitting the LLM. Pair with ``reject-ingest <sid>`` to
+clean up.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from importlib import resources
+from typing import TYPE_CHECKING
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook._io import atomic_write_text
+
+if TYPE_CHECKING:
+    import argparse
+    from importlib.resources.abc import Traversable
+    from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+# placeholder substituted with the seeded source_id at copy time. Must
+# not occur in any fixture file's natural content.
+_SOURCE_ID_PLACEHOLDER = "__QA_SOURCE_ID__"
+
+_FIXTURE_PACKAGE = "auto_lorebook._qa_fixtures"
+_DEFAULT_FIXTURE = "tiny-aldara"
+_SOURCE_ID_BYTES = 4  # 8 hex chars
+_MINT_RETRY = 16
+
+# stage → (next CLI hint, ordered list of files to seed cumulatively)
+_STAGES: dict[str, tuple[str, ...]] = {
+    "structure": ("info", "transcript"),
+    "summarize": ("info", "transcript", "structure"),
+    "approve": ("info", "transcript", "structure", "bullets", "draft_reading"),
+    "plan": (
+        "info",
+        "transcript",
+        "structure",
+        "bullets",
+        "draft_reading",
+        "approved_reading",
+    ),
+}
+
+_NEXT_CMD: dict[str, str] = {
+    "structure": "generate-reading {sid}",
+    "summarize": "regenerate-reading {sid} --from=summarize",
+    "approve": "approve-reading {sid} --yes",
+    "plan": "replan {sid}",
+}
+
+
+class SeedIngestError(RuntimeError):
+    """User-facing seed-ingest failure."""
+
+
+def add_parser(
+    subparsers: argparse._SubParsersAction,
+    common_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Register the seed-ingest subcommand."""
+    parser = subparsers.add_parser(
+        "seed-ingest",
+        parents=[common_parser],
+        help="Seed a disposable QA source from synthetic fixtures",
+        description=(
+            "Mints a fresh `qa-<hex>` source_id and lays down a canned "
+            "ingest up through the stage selected by --at, so the next "
+            "pipeline stage can be exercised in isolation. Use "
+            "`reject-ingest <sid>` to clean up."
+        ),
+    )
+    parser.add_argument(
+        "--at",
+        required=True,
+        choices=sorted(_STAGES),
+        help="Stage to seed inputs for; the printed next-step runs that stage.",
+    )
+    parser.add_argument(
+        "--fixture",
+        default=_DEFAULT_FIXTURE,
+        help=f"Fixture name under {_FIXTURE_PACKAGE} (default: {_DEFAULT_FIXTURE}).",
+    )
+    parser.add_argument(
+        "--source-id",
+        dest="source_id",
+        default=None,
+        help="Override the minted qa-* id. Must not collide.",
+    )
+    parser.set_defaults(func=run)
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the seed-ingest command."""
+    try:
+        cfg = cfg_mod.load_config()
+    except cfg_mod.ConfigError as e:
+        _logger.error("%s", e)
+        return 1
+
+    try:
+        sid = args.source_id or _mint_source_id(cfg)
+        _seed(cfg, sid, args.at, args.fixture)
+    except SeedIngestError as e:
+        _logger.error("%s", e)
+        return 1
+
+    next_cmd = _NEXT_CMD[args.at].format(sid=sid)
+    print(  # noqa: T201
+        f"Seeded source {sid} at stage {args.at!r} from fixture {args.fixture!r}."
+    )
+    print(f"Next: auto-lorebook {next_cmd}")  # noqa: T201
+    return 0
+
+
+def _mint_source_id(cfg: cfg_mod.Config) -> str:
+    for _ in range(_MINT_RETRY):
+        candidate = f"qa-{secrets.token_hex(_SOURCE_ID_BYTES)}"
+        if not _source_collides(cfg, candidate):
+            return candidate
+    msg = f"could not mint a unique source_id after {_MINT_RETRY} attempts"
+    raise SeedIngestError(msg)
+
+
+def _source_collides(cfg: cfg_mod.Config, sid: str) -> bool:
+    wiki_src = cfg.wiki_repo_path / "sources" / sid
+    pending = cfg_mod.config_dir() / "pending" / sid
+    return wiki_src.exists() or pending.exists()
+
+
+def _seed(cfg: cfg_mod.Config, sid: str, at: str, fixture_name: str) -> None:
+    if _source_collides(cfg, sid):
+        msg = (
+            f"source {sid!r} already exists under "
+            f"{cfg.wiki_repo_path / 'sources' / sid} or "
+            f"{cfg_mod.config_dir() / 'pending' / sid}"
+        )
+        raise SeedIngestError(msg)
+
+    fixture_root = _resolve_fixture(fixture_name)
+    wiki_src = cfg.wiki_repo_path / "sources" / sid
+    pending_reading = cfg_mod.config_dir() / "pending" / sid / "reading"
+
+    # wiki side first so a half-failed seed leaves only sources/<sid>
+    # behind, which `reject-ingest` will tolerate.
+    for key in _STAGES[at]:
+        src_name, dest, status = _emit_target(key, wiki_src, pending_reading)
+        _emit_file(fixture_root, src_name, dest, sid, status=status)
+
+
+def _emit_target(
+    key: str,
+    wiki_src: Path,
+    pending_reading: Path,
+) -> tuple[str, Path, str | None]:
+    if key == "info":
+        return "info.yaml", wiki_src / "info.yaml", None
+    if key == "transcript":
+        return "transcript.en.srt", wiki_src / "transcript.en.srt", None
+    if key == "structure":
+        return "structure.yaml", pending_reading / "structure.yaml", None
+    if key == "bullets":
+        return "bullets.yaml", pending_reading / "bullets.yaml", None
+    if key == "draft_reading":
+        return "reading.md", pending_reading / "reading.md", "draft"
+    if key == "approved_reading":
+        return "reading.md", wiki_src / "reading.md", "approved"
+    msg = f"internal: unknown seed key {key!r}"
+    raise SeedIngestError(msg)
+
+
+def _emit_file(
+    fixture_root: Traversable,
+    fixture_filename: str,
+    dest: Path,
+    sid: str,
+    *,
+    status: str | None,
+) -> None:
+    src = fixture_root / fixture_filename
+    if not src.is_file():
+        msg = f"fixture file missing: {fixture_filename} in {fixture_root}"
+        raise SeedIngestError(msg)
+    text = src.read_text(encoding="utf-8")
+    text = text.replace(_SOURCE_ID_PLACEHOLDER, sid)
+    if status is not None:
+        # fixture's reading.md ships approved; rewrite for pre-approval seeding.
+        text = text.replace(
+            "reading_status: approved",
+            f"reading_status: {status}",
+        )
+    atomic_write_text(dest, text)
+
+
+def _resolve_fixture(fixture_name: str) -> Traversable:
+    root = resources.files(_FIXTURE_PACKAGE) / fixture_name
+    if not root.is_dir():
+        msg = (
+            f"fixture {fixture_name!r} not found under {_FIXTURE_PACKAGE}; "
+            "available: " + ", ".join(sorted(_list_fixtures()))
+        )
+        raise SeedIngestError(msg)
+    return root
+
+
+def _list_fixtures() -> list[str]:
+    root = resources.files(_FIXTURE_PACKAGE)
+    return [child.name for child in root.iterdir() if child.is_dir()]

--- a/tests/test_seed_ingest_cmd.py
+++ b/tests/test_seed_ingest_cmd.py
@@ -1,0 +1,254 @@
+"""Tests for the `seed-ingest` QA subcommand."""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from auto_lorebook import (
+    info_yaml,
+    plan_yaml,
+    proposal_yaml,
+    reading,
+    stage1b,
+)
+from auto_lorebook import reading_pipeline as pipeline
+from auto_lorebook import (
+    structure as structure_mod,
+)
+from auto_lorebook.commands import seed_ingest_cmd
+from tests.test_reading_commands import _wire_client_responses
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    return home
+
+
+def _write_user_config(home: Path, wiki: Path) -> None:
+    (home / "config.yaml").write_text(
+        f"""schema_version: 1
+wiki_repo_path: {wiki}
+openrouter:
+  api_key_env: FAKE_OR_KEY
+models:
+  primary: anthropic/claude-sonnet-4-5
+""",
+        encoding="utf-8",
+    )
+
+
+def _args(**kwargs: object) -> argparse.Namespace:
+    return argparse.Namespace(**kwargs)
+
+
+def _seeded_sid_from(stdout: str) -> str:
+    # "Seeded source qa-XXXXXXXX at stage 'plan' from fixture 'tiny-aldara'."
+    first = stdout.splitlines()[0]
+    return first.split()[2]
+
+
+class TestSeedIngestPerStage:
+    """Each --at value seeds the right files and they load via their parsers."""
+
+    @pytest.mark.parametrize(
+        ("at", "expected_wiki", "expected_pending"),
+        [
+            (
+                "structure",
+                {"transcript.en.srt", "info.yaml"},
+                set(),
+            ),
+            (
+                "summarize",
+                {"transcript.en.srt", "info.yaml"},
+                {"structure.yaml"},
+            ),
+            (
+                "approve",
+                {"transcript.en.srt", "info.yaml"},
+                {"structure.yaml", "bullets.yaml", "reading.md"},
+            ),
+            (
+                "plan",
+                {"transcript.en.srt", "info.yaml", "reading.md"},
+                {"structure.yaml", "bullets.yaml", "reading.md"},
+            ),
+        ],
+    )
+    def test_files_land_at_expected_paths(
+        self,
+        tmp_home: Path,
+        tmp_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+        at: str,
+        expected_wiki: set[str],
+        expected_pending: set[str],
+    ) -> None:
+        _write_user_config(tmp_home, tmp_wiki)
+        rc = seed_ingest_cmd.run(_args(at=at, fixture="tiny-aldara", source_id=None))
+        assert rc == 0
+        sid = _seeded_sid_from(capsys.readouterr().out)
+        assert sid.startswith("qa-")
+
+        wiki_src = tmp_wiki / "sources" / sid
+        pending_reading = tmp_home / "pending" / sid / "reading"
+
+        assert {p.name for p in wiki_src.iterdir()} == expected_wiki
+        if expected_pending:
+            assert {p.name for p in pending_reading.iterdir()} == expected_pending
+        else:
+            assert not pending_reading.exists()
+
+    def test_substitutes_source_id_in_artifacts(
+        self,
+        tmp_home: Path,
+        tmp_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_user_config(tmp_home, tmp_wiki)
+        rc = seed_ingest_cmd.run(
+            _args(at="plan", fixture="tiny-aldara", source_id=None)
+        )
+        assert rc == 0
+        sid = _seeded_sid_from(capsys.readouterr().out)
+
+        info = info_yaml.read(tmp_wiki / "sources" / sid / "info.yaml")
+        assert info.source_id == sid
+
+        struct = structure_mod.read(
+            tmp_home / "pending" / sid / "reading" / "structure.yaml"
+        )
+        assert struct.source_id == sid
+
+        bullets = stage1b.read_bullets(
+            tmp_home / "pending" / sid / "reading" / "bullets.yaml"
+        )
+        assert bullets.source_id == sid
+
+        approved_path = tmp_wiki / "sources" / sid / "reading.md"
+        fm = reading.read_frontmatter(approved_path)
+        assert fm["source_id"] == sid
+        assert fm["reading_status"] == "approved"
+
+        # placeholder must not survive anywhere on disk
+        for path in (
+            tmp_wiki / "sources" / sid / "info.yaml",
+            tmp_home / "pending" / sid / "reading" / "structure.yaml",
+            tmp_home / "pending" / sid / "reading" / "bullets.yaml",
+            tmp_home / "pending" / sid / "reading" / "reading.md",
+            approved_path,
+        ):
+            assert "__QA_SOURCE_ID__" not in path.read_text(encoding="utf-8")
+
+    def test_approve_writes_draft_status(
+        self,
+        tmp_home: Path,
+        tmp_wiki: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_user_config(tmp_home, tmp_wiki)
+        rc = seed_ingest_cmd.run(
+            _args(at="approve", fixture="tiny-aldara", source_id=None)
+        )
+        assert rc == 0
+        sid = _seeded_sid_from(capsys.readouterr().out)
+
+        draft = tmp_home / "pending" / sid / "reading" / "reading.md"
+        fm = reading.read_frontmatter(draft)
+        assert fm["reading_status"] == "draft"
+
+    def test_explicit_source_id_used_verbatim(
+        self,
+        tmp_home: Path,
+        tmp_wiki: Path,
+    ) -> None:
+        _write_user_config(tmp_home, tmp_wiki)
+        rc = seed_ingest_cmd.run(
+            _args(at="structure", fixture="tiny-aldara", source_id="qa-pinned")
+        )
+        assert rc == 0
+        assert (tmp_wiki / "sources" / "qa-pinned" / "info.yaml").exists()
+
+
+class TestNextStageRunsOnSeededInputs:
+    """Stage outputs run on seeded inputs validate via their loaders."""
+
+    def test_plan_then_extract_produces_valid_proposals(
+        self,
+        tmp_home: Path,
+        tmp_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_user_config(tmp_home, tmp_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+        rc = seed_ingest_cmd.run(
+            _args(at="plan", fixture="tiny-aldara", source_id=None)
+        )
+        assert rc == 0
+        sid = _seeded_sid_from(capsys.readouterr().out)
+
+        from auto_lorebook import config as cfg_mod  # noqa: PLC0415
+
+        cfg = cfg_mod.load_config()
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            plan_result = pipeline.plan(cfg, sid)
+            extract_result = pipeline.extract(cfg, sid)
+
+        loaded_plan = plan_yaml.read(plan_result.plan_path)
+        assert loaded_plan.source_id == sid
+        assert loaded_plan.planned_claims
+
+        proposal_files = sorted(extract_result.proposals_dir.glob("*.yaml"))
+        assert proposal_files
+        for p in proposal_files:
+            proposal_yaml.read(p)
+
+
+class TestSeedIngestNoClobber:
+    def test_repeat_seed_with_same_id_errors(
+        self,
+        tmp_home: Path,
+        tmp_wiki: Path,
+    ) -> None:
+        _write_user_config(tmp_home, tmp_wiki)
+        first = seed_ingest_cmd.run(
+            _args(at="structure", fixture="tiny-aldara", source_id="qa-fixed")
+        )
+        assert first == 0
+        info_path = tmp_wiki / "sources" / "qa-fixed" / "info.yaml"
+        original_text = info_path.read_text(encoding="utf-8")
+
+        second = seed_ingest_cmd.run(
+            _args(at="structure", fixture="tiny-aldara", source_id="qa-fixed")
+        )
+        assert second == 1
+        # first seed left intact
+        assert info_path.read_text(encoding="utf-8") == original_text
+
+
+class TestUnknownFixture:
+    def test_missing_fixture_errors(
+        self,
+        tmp_home: Path,
+        tmp_wiki: Path,
+    ) -> None:
+        _write_user_config(tmp_home, tmp_wiki)
+        rc = seed_ingest_cmd.run(
+            _args(at="structure", fixture="does-not-exist", source_id=None)
+        )
+        assert rc == 1


### PR DESCRIPTION
## Summary

Adds a new `seed-ingest` subcommand that enables isolated testing of individual pipeline stages without running prior stages or hitting the LLM. The command mints disposable `qa-*` source IDs and seeds synthetic stage-input artifacts from fixtures.

## Key Changes

- **New `seed-ingest` command** (`src/auto_lorebook/commands/seed_ingest.py`):
  - Mints unique `qa-<hex>` source IDs with collision detection
  - Seeds artifacts cumulatively up to a specified stage (`--at={structure|summarize|approve|plan}`)
  - Substitutes placeholder source IDs in fixture files at copy time
  - Handles status rewrites for reading files (draft vs. approved)
  - Provides helpful next-step CLI hints for each stage

- **QA fixtures** (`src/auto_lorebook/_qa_fixtures/tiny-aldara/`):
  - Minimal 4-cue SRT transcript with two segments
  - Complete artifact set: `info.yaml`, `structure.yaml`, `bullets.yaml`, `reading.md`, `plan.yaml`
  - Uses `__QA_SOURCE_ID__` placeholder for substitution
  - Loaded via `importlib.resources` for package-relative access

- **Comprehensive test suite** (`tests/test_seed_ingest_cmd.py`):
  - Validates correct file placement at each stage
  - Verifies source ID substitution across all artifact types
  - Tests reading status transitions (draft/approved)
  - Confirms seeded inputs work with downstream pipeline stages
  - Validates collision detection and fixture resolution

- **Documentation updates**:
  - Contributing guide: QA seeding workflow and stage ladder
  - CLI reference: New `seed-ingest` command syntax
  - Architecture: QA fixtures location and loading mechanism
  - Pipeline docs: Testing hints for reading, planner, and extractor stages

- **CLI integration**:
  - Registered in `cli.py` and `commands/__init__.py`
  - Follows existing command patterns with proper error handling

## Implementation Details

- Fixtures are organized by name under `_qa_fixtures/` for easy extension
- Seeding is atomic per-file using existing `atomic_write_text` utility
- Wiki-side files are written before pending files to ensure clean partial failures
- Source ID collision check covers both wiki sources and pending directories
- Status field rewriting enables testing both draft and approved reading paths

https://claude.ai/code/session_01C1WJMjEx4AFcZfx1PwJmyW