### PR TITLE
Add anchor tolerance with clamping for Stage 1b bullet validation

### DIFF
--- a/docs/pipeline/reading.md
+++ b/docs/pipeline/reading.md
@@ -167,6 +167,15 @@ edited anchor at save time. This preserves the hint's usefulness after
 routine timestamp corrections without requiring the human to think
 about windows.
 
+**Anchor tolerance.** When an LLM returns an anchor a few seconds
+outside a segment's bounds — common with plain-text (.txt) sources
+where Stage 1a invents second-based bounds — Stage 1b clamps the
+anchor to the nearest boundary rather than failing. Anchors within
+`DEFAULT_ANCHOR_TOLERANCE_SECONDS` (default 2.0s) of a boundary are
+silently clamped and a warning is logged; anchors further outside
+still raise `Stage1bError`. The `anchor_tolerance_seconds` kwarg on
+`run()` overrides the default when needed.
+
 ## Reading assembly
 
 The final `reading.md` interleaves segment headers (from 1a) with

--- a/src/auto_lorebook/stage1b.py
+++ b/src/auto_lorebook/stage1b.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 DEFAULT_HINT_WINDOW_SECONDS = 15.0
+DEFAULT_ANCHOR_TOLERANCE_SECONDS = 2.0
 DEFAULT_MAX_CONCURRENCY = 4
 
 _TIMESTAMP_LINE_RE = re.compile(r"^\[(?P<ts>[0-9:,.]+)\]\s?(?P<body>.*)$")
@@ -126,6 +127,7 @@ def run(
     client: OpenRouterClient,
     model: str,
     hint_window_seconds: float = DEFAULT_HINT_WINDOW_SECONDS,
+    anchor_tolerance_seconds: float = DEFAULT_ANCHOR_TOLERANCE_SECONDS,
     max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
     segment_ids: list[str] | None = None,
 ) -> ReadingBullets:
@@ -133,6 +135,8 @@ def run(
 
     :param segment_ids: if given, run only these segments (unknown ids
         raise). Default: run all segments.
+    :param anchor_tolerance_seconds: anchors this far outside segment bounds
+        are clamped; further raises Stage1bError.
     :raises Stage1bError: any segment's LLM response fails parsing /
         validation
     """
@@ -157,6 +161,7 @@ def run(
                 client,
                 model,
                 hint_window_seconds,
+                anchor_tolerance_seconds,
             ): seg.id
             for seg in targets
         }
@@ -177,6 +182,7 @@ def _run_one(
     client: OpenRouterClient,
     model: str,
     hint_window_seconds: float,
+    anchor_tolerance_seconds: float = DEFAULT_ANCHOR_TOLERANCE_SECONDS,
 ) -> list[Bullet]:
     messages = [
         {
@@ -204,7 +210,10 @@ def _run_one(
         msg = f"Stage 1b for {segment.id}: 'bullets' must be a list"
         raise Stage1bError(msg)
 
-    return [_parse_bullet(raw, segment, hint_window_seconds) for raw in raw_bullets]
+    return [
+        _parse_bullet(raw, segment, hint_window_seconds, anchor_tolerance_seconds)
+        for raw in raw_bullets
+    ]
 
 
 def _build_user(segment: Segment, segment_text: str) -> str:
@@ -220,6 +229,7 @@ def _parse_bullet(
     raw: dict[str, Any],
     segment: Segment,
     hint_window_seconds: float,
+    anchor_tolerance_seconds: float = DEFAULT_ANCHOR_TOLERANCE_SECONDS,
 ) -> Bullet:
     if not isinstance(raw, dict):
         msg = f"Stage 1b for {segment.id}: each bullet must be an object"
@@ -234,11 +244,31 @@ def _parse_bullet(
         msg = f"Stage 1b for {segment.id}: bad anchor timestamp: {e}"
         raise Stage1bError(msg) from e
     if not (segment.start <= anchor <= segment.end):
-        msg = (
-            f"Stage 1b for {segment.id}: bullet anchor {anchor}s outside "
-            f"segment ({segment.start}-{segment.end})"
-        )
-        raise Stage1bError(msg)
+        # check if within tolerance window; clamp if so, else raise
+        if segment.end < anchor <= segment.end + anchor_tolerance_seconds:
+            _logger.warning(
+                "stage1b: clamping anchor %ss to segment %s end %ss (was %ss past)",
+                anchor,
+                segment.id,
+                segment.end,
+                anchor - segment.end,
+            )
+            anchor = segment.end
+        elif segment.start - anchor_tolerance_seconds <= anchor < segment.start:
+            _logger.warning(
+                "stage1b: clamping anchor %ss to segment %s start %ss (was %ss before)",
+                anchor,
+                segment.id,
+                segment.start,
+                segment.start - anchor,
+            )
+            anchor = segment.start
+        else:
+            msg = (
+                f"Stage 1b for {segment.id}: bullet anchor {anchor}s outside "
+                f"segment ({segment.start}-{segment.end})"
+            )
+            raise Stage1bError(msg)
     hint_start = max(segment.start, anchor - hint_window_seconds)
     hint_end = min(segment.end, anchor + hint_window_seconds)
     return Bullet(

--- a/tests/test_stage1b.py
+++ b/tests/test_stage1b.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import threading
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
@@ -241,7 +242,7 @@ class TestRun:
             )
 
     def test_bullet_anchor_outside_segment_raises(self) -> None:
-        # anchor is in seg-001 range but returned for seg-002
+        # anchor is in seg-001 range but returned for seg-002; far outside tolerance
         client = MagicMock()
         client.complete.return_value = OpenRouterResponse(
             text=_bullets_payload([{"text": "x", "anchor": "0:00:10"}]),
@@ -274,6 +275,158 @@ class TestRun:
                 client=client,
                 model="m/one",
             )
+
+    def test_anchor_slightly_past_end_clamps_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # anchor 1.5s past segment.end (within default tolerance 2.0) — clamps, no raise
+        s = Structure(
+            source_id="yt-x",
+            generated_at="2026-04-20T00:00:00Z",
+            default_speaker="DM",
+            segments=[
+                Segment(id="seg-002", start=7.0, end=30.0, title="x", speaker="DM"),
+            ],
+        )
+        # 30 + 1.5 = 31.5s → "0:00:31" is the closest h:mm:ss representation
+        client = MagicMock()
+        client.complete.return_value = OpenRouterResponse(
+            text=_bullets_payload([{"text": "claim", "anchor": "0:00:31"}]),
+            model="m",
+            tokens_in=0,
+            tokens_out=0,
+        )
+        transcript = LoadedTranscript(text_for_llm="plain text", total_duration=60.0)
+        with caplog.at_level(logging.WARNING, logger="auto_lorebook.stage1b"):
+            result = run(
+                transcript=transcript,
+                structure=s,
+                preamble_text="",
+                client=client,
+                model="m/one",
+            )
+        bullets = result.segments["seg-002"]
+        assert len(bullets) == 1
+        assert bullets[0].anchor == pytest.approx(30.0)  # clamped to segment.end
+        assert any("clamp" in r.message.lower() for r in caplog.records)
+
+    def test_anchor_slightly_before_start_clamps_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # anchor 1.0s before segment.start — clamps to start, no raise
+        s = Structure(
+            source_id="yt-x",
+            generated_at="2026-04-20T00:00:00Z",
+            default_speaker="DM",
+            segments=[
+                Segment(id="seg-002", start=10.0, end=40.0, title="x", speaker="DM"),
+            ],
+        )
+        client = MagicMock()
+        client.complete.return_value = OpenRouterResponse(
+            text=_bullets_payload([{"text": "claim", "anchor": "0:00:09"}]),
+            model="m",
+            tokens_in=0,
+            tokens_out=0,
+        )
+        transcript = LoadedTranscript(text_for_llm="plain text", total_duration=60.0)
+        with caplog.at_level(logging.WARNING, logger="auto_lorebook.stage1b"):
+            result = run(
+                transcript=transcript,
+                structure=s,
+                preamble_text="",
+                client=client,
+                model="m/one",
+            )
+        bullets = result.segments["seg-002"]
+        assert len(bullets) == 1
+        assert bullets[0].anchor == pytest.approx(10.0)  # clamped to segment.start
+        assert any("clamp" in r.message.lower() for r in caplog.records)
+
+    def test_clamped_locator_hints_stay_in_segment(self) -> None:
+        # after clamping, hints stay within segment bounds
+        s = Structure(
+            source_id="yt-x",
+            generated_at="2026-04-20T00:00:00Z",
+            default_speaker="DM",
+            segments=[
+                Segment(id="seg-002", start=7.0, end=30.0, title="x", speaker="DM"),
+            ],
+        )
+        client = MagicMock()
+        client.complete.return_value = OpenRouterResponse(
+            text=_bullets_payload([{"text": "claim", "anchor": "0:00:31"}]),
+            model="m",
+            tokens_in=0,
+            tokens_out=0,
+        )
+        transcript = LoadedTranscript(text_for_llm="plain text", total_duration=60.0)
+        result = run(
+            transcript=transcript,
+            structure=s,
+            preamble_text="",
+            client=client,
+            model="m/one",
+        )
+        b = result.segments["seg-002"][0]
+        assert b.locator_hint_start >= 7.0
+        assert b.locator_hint_end <= 30.0
+
+    def test_anchor_beyond_tolerance_raises(self) -> None:
+        # anchor 4.0s past segment.end with default tolerance 2.0 — must raise
+        s = Structure(
+            source_id="yt-x",
+            generated_at="2026-04-20T00:00:00Z",
+            default_speaker="DM",
+            segments=[
+                Segment(id="seg-002", start=7.0, end=30.0, title="x", speaker="DM"),
+            ],
+        )
+        client = MagicMock()
+        client.complete.return_value = OpenRouterResponse(
+            text=_bullets_payload([{"text": "claim", "anchor": "0:00:34"}]),
+            model="m",
+            tokens_in=0,
+            tokens_out=0,
+        )
+        transcript = LoadedTranscript(text_for_llm="plain text", total_duration=60.0)
+        with pytest.raises(Stage1bError, match="anchor"):
+            run(
+                transcript=transcript,
+                structure=s,
+                preamble_text="",
+                client=client,
+                model="m/one",
+            )
+
+    def test_custom_anchor_tolerance_plumbs_through(self) -> None:
+        # custom tolerance of 5.0s allows an anchor 4.0s past segment.end
+        s = Structure(
+            source_id="yt-x",
+            generated_at="2026-04-20T00:00:00Z",
+            default_speaker="DM",
+            segments=[
+                Segment(id="seg-002", start=7.0, end=30.0, title="x", speaker="DM"),
+            ],
+        )
+        client = MagicMock()
+        client.complete.return_value = OpenRouterResponse(
+            text=_bullets_payload([{"text": "claim", "anchor": "0:00:34"}]),
+            model="m",
+            tokens_in=0,
+            tokens_out=0,
+        )
+        transcript = LoadedTranscript(text_for_llm="plain text", total_duration=60.0)
+        result = run(
+            transcript=transcript,
+            structure=s,
+            preamble_text="",
+            client=client,
+            model="m/one",
+            anchor_tolerance_seconds=5.0,
+        )
+        b = result.segments["seg-002"][0]
+        assert b.anchor == pytest.approx(30.0)  # clamped to end
 
 
 class TestBullet:


### PR DESCRIPTION
## Summary
Adds configurable anchor tolerance to Stage 1b bullet validation, allowing anchors slightly outside segment bounds to be clamped rather than raising errors. This is particularly useful for plain-text sources where Stage 1a generates approximate second-based segment boundaries.

## Key Changes
- Added `DEFAULT_ANCHOR_TOLERANCE_SECONDS` constant (2.0s) to define the default tolerance window
- Added `anchor_tolerance_seconds` parameter to `run()` and `_run_one()` functions to allow customization
- Modified `_parse_bullet()` to implement three-tier anchor validation:
  - Anchors within segment bounds: accepted as-is
  - Anchors within tolerance of boundaries: clamped to the boundary with a warning logged
  - Anchors beyond tolerance: raise `Stage1bError` as before
- Updated locator hint calculation to ensure hints stay within segment bounds after clamping
- Added comprehensive test coverage for clamping behavior, tolerance boundaries, and custom tolerance values

## Implementation Details
- Tolerance checks are asymmetric: anchors past segment.end or before segment.start are handled separately
- Warnings are logged at the WARNING level to the `auto_lorebook.stage1b` logger when clamping occurs
- Locator hints are recalculated after clamping to ensure they remain within segment bounds
- The tolerance parameter is plumbed through the parallel execution layer in `run()`
- Documentation updated to explain the anchor tolerance feature and its default behavior

https://claude.ai/code/session_01KXZtm2BvQswWx79eESQdV8