### PR TITLE
Per-segment pending layout + reading sidecar + assembly module

### DIFF
--- a/docs/architecture/repository-layout.md
+++ b/docs/architecture/repository-layout.md
@@ -44,7 +44,12 @@ Entity identity lives entirely in entity YAMLs. An entity exists iff
     <ingest_id>/
       reading/                      # intermediate reading artifacts
         structure.yaml              # Stage 1a output (segments + attribution)
-        reading.md                  # Stage 1b output (draft)
+        bullets.yaml                # Stage 1b output (raw bullets)
+        reading.yaml                # sidecar (default_speaker, name_corrections, session_date)
+        segments/
+          seg-001.md                # per-segment frontmatter + rendered body
+          seg-002.md
+          …
       plan.yaml                     # planner output
       proposals/
         <proposal_id>.yaml          # one per proposed fact

--- a/docs/architecture/schema-versioning.md
+++ b/docs/architecture/schema-versioning.md
@@ -15,6 +15,8 @@ All YAML artifacts the tool writes:
 
 - `sources/<source_id>/info.yaml`
 - `pending/<ingest_id>/reading/structure.yaml`
+- `pending/<ingest_id>/reading/reading.yaml`
+- `pending/<ingest_id>/reading/segments/<segment_id>.md` (frontmatter)
 - `pending/<ingest_id>/plan.yaml`
 - `pending/<ingest_id>/proposals/<proposal_id>.yaml`
 - `<category>/<slug>.yaml` (entity YAMLs)

--- a/docs/getting-started/first-ingest.md
+++ b/docs/getting-started/first-ingest.md
@@ -48,9 +48,8 @@ LLM quality but don't block the pipeline. See
 ## 3. Review the reading
 
 After Stage 1a (structure) and Stage 1b (summarize) run, you get a
-draft at `pending/yt-abc123/reading/reading.md` — a segmented,
-attributed, claim-bulleted version of the transcript. Open the
-interactive review:
+draft: sidecar at `pending/yt-abc123/reading/reading.yaml` and one
+`segments/seg-NNN.md` per segment. Open the interactive review:
 
 ```bash
 auto-lorebook approve-reading yt-abc123
@@ -59,12 +58,8 @@ auto-lorebook approve-reading yt-abc123
 The session prints the draft and prompts:
 
 - `a` — approve (flips status, copies to wiki).
-- `e` — edit in `$EDITOR`. Fix:
-    - Segment boundaries or titles.
-    - Speaker attributions.
-    - Claim bullets that don't match what was said, are invented, or
-      are missing.
-    - `name_corrections` frontmatter map.
+- `e` — preview assembled draft in `$EDITOR` (read-only; edits are
+  discarded). Edit segment files directly for now.
 - `r` — queue the draft for deletion.
 - `u` — restore the draft to its session-start contents and clear any
   queued reject.

--- a/docs/pipeline/reading.md
+++ b/docs/pipeline/reading.md
@@ -129,9 +129,12 @@ explicitly none. This is the only substage that can invent content.
 **Input.** Segmented, speaker-attributed transcript from 1a and the
 full preamble (including `interpretation_defaults`).
 
-**Output.** `pending/<ingest_id>/reading/reading.md` — assembled from
-1a's segments plus 1b's per-segment bullets. This is the artifact the
-human reviews.
+**Output.** Per-segment files under
+`pending/<ingest_id>/reading/segments/seg-NNN.md` (one per segment,
+frontmatter + rendered bullets), plus a sidecar
+`pending/<ingest_id>/reading/reading.yaml` (default_speaker,
+name_corrections, session_date). The wiki-side `reading.md` is
+assembled from these at approval time, not written during generation.
 
 **Per-segment extraction.** 1b processes each segment independently
 (trivially parallelizable). Empty bullet lists are allowed and
@@ -178,8 +181,9 @@ still raise `Stage1bError`. The `anchor_tolerance_seconds` kwarg on
 
 ## Reading assembly
 
-The final `reading.md` interleaves segment headers (from 1a) with
-their bullet lists (from 1b):
+At approval, the wiki-side `reading.md` is assembled from all segment
+files plus the sidecar. The assembled document interleaves segment
+headers (from 1a) with their bullet lists (from 1b):
 
 ```markdown
 ---
@@ -233,10 +237,10 @@ render as clickable links.
 ## Name corrections
 
 When the human notices a mishearing (e.g., "Fair-on" should be
-"Theron"), they add it to the `name_corrections` map in frontmatter
-rather than find-replacing throughout the reading. The tool applies
-the substitutions during rendering and passes the map to downstream
-stages.
+"Theron"), they add it to the `name_corrections` map in
+`reading.yaml` rather than find-replacing throughout the reading. The
+tool applies the substitutions during rendering and passes the map to
+downstream stages. Corrections are preserved across regenerations.
 
 Corrections from approved readings can be promoted to the global
 `.transcription-corrections.yaml` so future sources benefit
@@ -292,10 +296,10 @@ auto-lorebook approve-reading <source_id>
 
 | Key | Action |
 |-----|--------|
-| `a` | Approve: flip status to `approved`, copy to wiki. |
-| `e` | Edit: open the draft in `$EDITOR` (defaults to `vi`); on save, return to the prompt. |
+| `a` | Approve: assemble segment files + sidecar into `reading.md`, copy to wiki. |
+| `e` | Preview: assemble draft into a temp file and open in `$EDITOR`. Edits are discarded on exit (preview-only; per-segment editing lands in a future slice). |
 | `r` | Reject: queue the pending reading dir for deletion. Deferred — nothing happens until you `q`. |
-| `u` | Undo: restore the draft to its session-start contents and clear any queued reject. |
+| `u` | Undo: restore all segment files and sidecar to session-start contents and clear any queued reject. |
 | `q` | Quit: if a reject is queued, confirm and delete `pending/<id>/reading/`; otherwise no-op. |
 
 `--yes` skips the loop and auto-approves; required for non-TTY runs

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -85,11 +85,19 @@ Every YAML file carries `schema_version` as its first key — see
   ingest lifetime.
 - **Details** — [Stage 1a](../pipeline/reading.md#stage-1a-structure).
 
-### `~/.auto-lorebook/pending/<ingest_id>/reading/reading.md`
+### `~/.auto-lorebook/pending/<ingest_id>/reading/reading.yaml`
 
-- **Stage** — Stage 1b output (draft).
-- **Purpose** — draft reading before human approval. Moves to the
-  wiki on `approve-reading`.
+- **Stage** — Stage 1b output; sidecar.
+- **Purpose** — session metadata: `default_speaker`, `name_corrections`,
+  `session_date`. Preserved across regenerations.
+- **Details** — [Stage 1b](../pipeline/reading.md#stage-1b-summarize).
+
+### `~/.auto-lorebook/pending/<ingest_id>/reading/segments/<segment_id>.md`
+
+- **Stage** — Stage 1b output; per-segment.
+- **Purpose** — YAML frontmatter (segment metadata, `segment_status`)
+  plus pre-rendered bullet body. Assembled into the wiki-side
+  `reading.md` at approval time.
 - **Details** — [reading assembly](../pipeline/reading.md#reading-assembly).
 
 ### `~/.auto-lorebook/pending/<ingest_id>/plan.yaml`
@@ -114,10 +122,14 @@ SHA-256 hashes of the inputs that produced it. See
 
 ## Hand-edit surfaces
 
-Only two files are intended as hand-edit surfaces:
+Only these files are intended as hand-edit surfaces:
 
-- `reading.md` — before approval. Edit segment headers, bullets,
-  speaker attributions, `name_corrections`, `session_date`.
+- `pending/<id>/reading/reading.yaml` — before approval. Edit
+  `name_corrections` and `session_date`.
+- `pending/<id>/reading/segments/seg-NNN.md` — before approval. Edit
+  bullet body text and timestamps. (Per-segment interactive editing
+  lands in a future slice; currently the assembled preview is
+  read-only.)
 - `<category>/<slug>.yaml` — after approval. Edit facts, aliases,
   sections, `superseded_by`.
 

--- a/src/auto_lorebook/_qa_fixtures/tiny-aldara/reading.yaml
+++ b/src/auto_lorebook/_qa_fixtures/tiny-aldara/reading.yaml
@@ -1,0 +1,4 @@
+schema_version: 1
+default_speaker: DM
+session_date: null
+name_corrections: {}

--- a/src/auto_lorebook/_qa_fixtures/tiny-aldara/segments/seg-001.md
+++ b/src/auto_lorebook/_qa_fixtures/tiny-aldara/segments/seg-001.md
@@ -1,0 +1,12 @@
+---
+schema_version: 1
+segment_id: seg-001
+segment_status: draft
+start: 0:00:00
+end: 0:02:00
+title: Intro
+speaker: DM
+notes: null
+overrides: []
+---
+- Intro bullet [0:00:15]

--- a/src/auto_lorebook/_qa_fixtures/tiny-aldara/segments/seg-002.md
+++ b/src/auto_lorebook/_qa_fixtures/tiny-aldara/segments/seg-002.md
@@ -1,0 +1,12 @@
+---
+schema_version: 1
+segment_id: seg-002
+segment_status: draft
+start: 0:02:00
+end: 0:10:00
+title: Founding of Aldara
+speaker: DM
+notes: null
+overrides: []
+---
+- King Theron founded Aldara [0:02:30]

--- a/src/auto_lorebook/commands/approve_reading.py
+++ b/src/auto_lorebook/commands/approve_reading.py
@@ -14,7 +14,6 @@ from auto_lorebook.interactive import _is_interactive
 
 if TYPE_CHECKING:
     import argparse
-    from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
@@ -32,10 +31,11 @@ def add_parser(
         parents=[common_parser],
         help="Interactively approve, edit, or reject the draft reading",
         description=(
-            "Opens an interactive session over the draft reading.md under "
+            "Opens an interactive session over the draft reading under "
             "~/.auto-lorebook/pending/<source_id>/reading/. Keys: "
-            "[a]pprove (flip to approved + copy to wiki), "
-            "[e]dit (open in $EDITOR), [r]eject (queue pending dir for delete), "
+            "[a]pprove (assemble + copy to wiki), "
+            "[e]dit (preview assembled draft in $EDITOR — preview only), "
+            "[r]eject (queue pending dir for delete), "
             "[u]ndo (restore to session start, clear reject), "
             "[q]uit (commit a queued reject after confirmation, else no-op). "
             "Pass --yes to skip the loop and auto-approve."
@@ -70,7 +70,7 @@ def run(args: argparse.Namespace) -> int:
 
 
 def _approve_only(cfg: cfg_mod.Config, source_id: str) -> int:
-    """Approve reading: flip status + copy to wiki."""
+    """Approve reading: assemble + copy to wiki."""
     try:
         approved = pipeline.approve(cfg, source_id)
     except pipeline.ReadingPipelineError as e:
@@ -83,18 +83,19 @@ def _approve_only(cfg: cfg_mod.Config, source_id: str) -> int:
 
 
 def _interactive_session(cfg: cfg_mod.Config, source_id: str) -> int:
-    pending_path = pipeline.pending_reading_path(source_id)
-    if not pending_path.exists():
+    sidecar_path = pipeline.pending_sidecar_path(source_id)
+    if not sidecar_path.exists():
         _logger.error(
             "No draft reading for %r. Run `generate-reading` first.", source_id
         )
         return 1
 
-    original_bytes = pending_path.read_bytes()
+    # snapshot all segment files + sidecar at session start for [u]ndo
+    snapshot = _take_snapshot(source_id)
     pending_action = "none"
 
     while True:
-        _render(pending_path, pending_action, original_bytes)
+        _render(cfg, source_id, pending_action)
         try:
             choice = input(_PROMPT).strip().lower()
         except EOFError:
@@ -112,18 +113,21 @@ def _interactive_session(cfg: cfg_mod.Config, source_id: str) -> int:
             pending_action = "reject"
             continue
         if choice == "u":
-            pending_path.write_bytes(original_bytes)
+            _restore_snapshot(snapshot)
             pending_action = "none"
             continue
         if choice == "e":
-            editor = os.environ.get("EDITOR", "vi")
-            subprocess.run([editor, str(pending_path)], check=False)  # noqa: S603
+            _preview_edit(cfg, source_id)
             continue
         # unrecognized → re-prompt
 
 
-def _render(pending_path: Path, pending_action: str, original_bytes: bytes) -> None:
-    text = pending_path.read_text(encoding="utf-8")
+def _render(cfg: cfg_mod.Config, source_id: str, pending_action: str) -> None:
+    try:
+        text = pipeline.assemble_draft(cfg, source_id)
+    except pipeline.ReadingPipelineError as e:
+        print(f"\n[error assembling draft: {e}]")  # noqa: T201
+        text = ""
     lines = text.splitlines()
     head = "\n".join(lines[:_RENDER_LINES])
     suffix = (
@@ -131,10 +135,53 @@ def _render(pending_path: Path, pending_action: str, original_bytes: bytes) -> N
         if len(lines) > _RENDER_LINES
         else ""
     )
-    dirty = " [edited]" if pending_path.read_bytes() != original_bytes else ""
-    print(f"\n--- {pending_path}{dirty} ---")  # noqa: T201
+    pdir = pipeline.pending_dir(source_id)
+    print(f"\n--- {pdir} ---")  # noqa: T201
     print(head + suffix)  # noqa: T201
     print(f"--- pending action: {pending_action} ---")  # noqa: T201
+
+
+def _preview_edit(cfg: cfg_mod.Config, source_id: str) -> None:
+    """Open assembled draft in $EDITOR for preview; discard edits on exit."""
+    try:
+        text = pipeline.assemble_draft(cfg, source_id)
+    except pipeline.ReadingPipelineError as e:
+        _logger.error("Could not assemble draft: %s", e)
+        return
+    draft_path = pipeline.pending_dir(source_id) / ".draft-edit.md"
+    draft_path.write_text(text, encoding="utf-8")
+    editor = os.environ.get("EDITOR", "vi")
+    subprocess.run([editor, str(draft_path)], check=False)  # noqa: S603
+    import contextlib  # noqa: PLC0415
+
+    with contextlib.suppress(OSError):
+        draft_path.unlink(missing_ok=True)
+    print(  # noqa: T201
+        "Per-segment editing lands in slice #31. "
+        "This view is preview-only — your edits were not saved."
+    )
+
+
+def _take_snapshot(source_id: str) -> dict[str, bytes]:
+    """Snapshot all segment files + sidecar; keyed by file path string."""
+    snapshot: dict[str, bytes] = {}
+    sidecar = pipeline.pending_sidecar_path(source_id)
+    if sidecar.exists():
+        snapshot[str(sidecar)] = sidecar.read_bytes()
+    segs_dir = pipeline.pending_segments_dir(source_id)
+    if segs_dir.exists():
+        for p in segs_dir.glob("*.md"):
+            snapshot[str(p)] = p.read_bytes()
+    return snapshot
+
+
+def _restore_snapshot(snapshot: dict[str, bytes]) -> None:
+    from pathlib import Path  # noqa: PLC0415
+
+    for path_str, data in snapshot.items():
+        p = Path(path_str)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(data)
 
 
 def _commit_quit(source_id: str, pending_action: str) -> int:

--- a/src/auto_lorebook/commands/generate_reading.py
+++ b/src/auto_lorebook/commands/generate_reading.py
@@ -51,7 +51,8 @@ def run(args: argparse.Namespace) -> int:
         _logger.error("%s", e)
         return 1
 
-    print(f"Draft reading: {result.pending_reading_path}")  # noqa: T201
+    print(f"Draft reading sidecar: {result.sidecar_path}")  # noqa: T201
+    print(f"  segments:    {result.segments_dir}")  # noqa: T201
     print(f"  structure:   {result.structure_path}")  # noqa: T201
     print(f"  bullets:     {result.bullets_path}")  # noqa: T201
     if result.gap_warnings:

--- a/src/auto_lorebook/commands/regenerate_reading.py
+++ b/src/auto_lorebook/commands/regenerate_reading.py
@@ -72,7 +72,8 @@ def run(args: argparse.Namespace) -> int:
         _logger.error("%s", e)
         return 1
 
-    print(f"Draft reading: {result.pending_reading_path}")  # noqa: T201
+    print(f"Draft reading sidecar: {result.sidecar_path}")  # noqa: T201
+    print(f"  segments:    {result.segments_dir}")  # noqa: T201
     if result.gap_warnings:
         print()  # noqa: T201
         print(f"{len(result.gap_warnings)} possible coverage gap(s):")  # noqa: T201

--- a/src/auto_lorebook/commands/seed_ingest.py
+++ b/src/auto_lorebook/commands/seed_ingest.py
@@ -36,13 +36,14 @@ _MINT_RETRY = 16
 _STAGES: dict[str, tuple[str, ...]] = {
     "structure": ("info", "transcript"),
     "summarize": ("info", "transcript", "structure"),
-    "approve": ("info", "transcript", "structure", "bullets", "draft_reading"),
+    "approve": ("info", "transcript", "structure", "bullets", "sidecar", "segments"),
     "plan": (
         "info",
         "transcript",
         "structure",
         "bullets",
-        "draft_reading",
+        "sidecar",
+        "segments",
         "approved_reading",
     ),
 }
@@ -150,8 +151,11 @@ def _seed(cfg: cfg_mod.Config, sid: str, at: str, fixture_name: str) -> None:
     # wiki side first so a half-failed seed leaves only sources/<sid>
     # behind, which `reject-ingest` will tolerate.
     for key in _STAGES[at]:
-        src_name, dest, status = _emit_target(key, wiki_src, pending_reading)
-        _emit_file(fixture_root, src_name, dest, sid, status=status)
+        if key == "segments":
+            _emit_segments_dir(fixture_root, pending_reading / "segments", sid)
+        else:
+            src_name, dest, status = _emit_target(key, wiki_src, pending_reading)
+            _emit_file(fixture_root, src_name, dest, sid, status=status)
 
 
 def _emit_target(
@@ -167,8 +171,8 @@ def _emit_target(
         return "structure.yaml", pending_reading / "structure.yaml", None
     if key == "bullets":
         return "bullets.yaml", pending_reading / "bullets.yaml", None
-    if key == "draft_reading":
-        return "reading.md", pending_reading / "reading.md", "draft"
+    if key == "sidecar":
+        return "reading.yaml", pending_reading / "reading.yaml", None
     if key == "approved_reading":
         return "reading.md", wiki_src / "reading.md", "approved"
     msg = f"internal: unknown seed key {key!r}"
@@ -196,6 +200,25 @@ def _emit_file(
             f"reading_status: {status}",
         )
     atomic_write_text(dest, text)
+
+
+def _emit_segments_dir(
+    fixture_root: Traversable,
+    dest_dir: Path,
+    sid: str,
+) -> None:
+    """Copy all *.md files from fixture segments/ to dest_dir."""
+    src_dir = fixture_root / "segments"
+    if not src_dir.is_dir():
+        msg = f"fixture segments/ directory missing in {fixture_root}"
+        raise SeedIngestError(msg)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for child in src_dir.iterdir():
+        if not child.name.endswith(".md"):
+            continue
+        text = child.read_text(encoding="utf-8")
+        text = text.replace(_SOURCE_ID_PLACEHOLDER, sid)
+        atomic_write_text(dest_dir / child.name, text)
 
 
 def _resolve_fixture(fixture_name: str) -> Traversable:

--- a/src/auto_lorebook/reading.py
+++ b/src/auto_lorebook/reading.py
@@ -1,30 +1,21 @@
-"""Reading.md assembly, writer, and frontmatter helpers.
+"""reading.md frontmatter helpers and wiki-side write path.
 
-Interleaves Stage 1a segment headers with Stage 1b bullets, renders
-inline uncertainty flags, applies `name_corrections` during rendering,
-and produces clickable `h:mm:ss` links (for YouTube sources) via
-URL post-processing.
+Provides `linkify_timestamp`, `apply_name_corrections`, `read_frontmatter`,
+`with_status`, `set_status`, and `write` — used by commands/review.py and
+the wiki-side write path. Assembly is now in reading_assembly.py.
 """
 
 from __future__ import annotations
 
-import logging
 import re
 from typing import TYPE_CHECKING, Any
 
 import yaml
 
 from auto_lorebook._io import atomic_write_text
-from auto_lorebook.timestamps import format_timestamp
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from auto_lorebook.info_yaml import Info
-    from auto_lorebook.stage1b import Bullet, ReadingBullets
-    from auto_lorebook.structure import Segment, Structure, UncertaintyFlag
-
-_logger = logging.getLogger(__name__)
 
 VALID_STATUSES = frozenset({"draft", "approved"})
 
@@ -49,41 +40,6 @@ def apply_name_corrections(text: str, name_corrections: dict[str, str]) -> str:
     for wrong, right in name_corrections.items():
         out = out.replace(wrong, right)
     return out
-
-
-def assemble(
-    *,
-    info: Info,
-    structure: Structure,
-    bullets: ReadingBullets,
-    name_corrections: dict[str, str] | None = None,
-) -> str:
-    """Render reading.md as a string.
-
-    :param name_corrections: mapping applied to rendered text and
-        written into the frontmatter map. Callers pass pre-existing
-        corrections from the previous reading.md when regenerating.
-    """
-    corrections = dict(name_corrections or {})
-    parts: list[str] = [_render_frontmatter(info, structure, corrections)]
-    parts.append(f"# Reading: {info.title or info.source_id}")
-
-    by_segment = bullets.segments
-    flags_by_segment = _flags_by_segment(structure)
-
-    for seg in structure.segments:
-        parts.append(_render_segment(seg, info.source_url, corrections))
-        parts.extend(
-            _render_uncertainty_flag(flag) for flag in flags_by_segment.get(seg.id, [])
-        )
-        seg_bullets = by_segment.get(seg.id, [])
-        if not seg_bullets:
-            parts.append("_No claims extracted from this segment._")
-        else:
-            parts.extend(
-                _render_bullet(b, info.source_url, corrections) for b in seg_bullets
-            )
-    return "\n\n".join(parts) + "\n"
 
 
 def write(path: Path, text: str) -> None:
@@ -147,75 +103,3 @@ def with_status(path: Path, status: str) -> str:
 def set_status(path: Path, status: str) -> None:
     """Rewrite the `reading_status` field in place."""
     atomic_write_text(path, with_status(path, status))
-
-
-def _render_frontmatter(
-    info: Info,
-    structure: Structure,
-    name_corrections: dict[str, str],
-) -> str:
-    fm: dict[str, Any] = {
-        "schema_version": 1,
-        "source_id": info.source_id,
-        "source_name": info.title,
-        "source_url": info.source_url,
-        "source_type": info.source_type,
-        "session_date": info.session_date,
-        "ingested_at": info.fetched_at,
-        "reading_status": "draft",
-        "default_speaker": structure.default_speaker,
-        "name_corrections": dict(name_corrections),
-    }
-    body = yaml.safe_dump(
-        fm,
-        allow_unicode=True,
-        sort_keys=False,
-        default_flow_style=False,
-    ).rstrip("\n")
-    return f"---\n{body}\n---"
-
-
-def _render_segment(
-    seg: Segment,
-    source_url: str | None,
-    name_corrections: dict[str, str],
-) -> str:
-    start_ts = format_timestamp(seg.start)
-    end_ts = format_timestamp(seg.end)
-    header_text = apply_name_corrections(seg.title, name_corrections)
-    link = linkify_timestamp(source_url, seg.start)
-    if link:
-        header = f"## [[{start_ts}-{end_ts}]]({link}) {header_text}"
-    else:
-        header = f"## [{start_ts}-{end_ts}] {header_text}"
-    speaker_line = f"Speaker: {seg.speaker}"
-    return f"{header}\n\n{speaker_line}"
-
-
-def _render_bullet(
-    b: Bullet,
-    source_url: str | None,
-    name_corrections: dict[str, str],
-) -> str:
-    text = apply_name_corrections(b.text, name_corrections)
-    anchor_ts = format_timestamp(b.anchor)
-    link = linkify_timestamp(source_url, b.anchor)
-    if link:
-        return f"- {text} [[{anchor_ts}]]({link})"
-    return f"- {text} [{anchor_ts}]"
-
-
-def _render_uncertainty_flag(flag: UncertaintyFlag) -> str:
-    ts = format_timestamp(flag.locator)
-    note = f"; {flag.note}" if flag.note else ""
-    return f"- [{ts}] uncertain {flag.kind}: {flag.span}{note}"
-
-
-def _flags_by_segment(structure: Structure) -> dict[str, list[UncertaintyFlag]]:
-    out: dict[str, list[UncertaintyFlag]] = {}
-    for flag in structure.uncertainty_flags:
-        for seg in structure.segments:
-            if seg.start <= flag.locator <= seg.end:
-                out.setdefault(seg.id, []).append(flag)
-                break
-    return out

--- a/src/auto_lorebook/reading_assembly.py
+++ b/src/auto_lorebook/reading_assembly.py
@@ -1,0 +1,93 @@
+"""Assemble wiki-side reading.md from segments + sidecar + info.
+
+Pure function — no filesystem I/O. Imports rendering helpers from
+reading.py to avoid duplication.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from auto_lorebook.reading import apply_name_corrections, linkify_timestamp
+from auto_lorebook.timestamps import format_timestamp
+
+if TYPE_CHECKING:
+    from auto_lorebook.info_yaml import Info
+    from auto_lorebook.reading_sidecar import Sidecar
+    from auto_lorebook.segment_file import SegmentFile
+
+
+def assemble(
+    *,
+    segments: list[SegmentFile],
+    sidecar: Sidecar,
+    info: Info,
+) -> str:
+    """Render wiki-side reading.md; always emits reading_status: approved."""
+    corrections = dict(sidecar.name_corrections)
+    parts: list[str] = [_render_frontmatter(info, sidecar)]
+    parts.append(f"# Reading: {info.title or info.source_id}")
+
+    for sf in segments:
+        fm = sf.frontmatter
+        parts.append(
+            _render_segment_header(
+                fm.start, fm.end, fm.title, fm.speaker, info.source_url, corrections
+            )
+        )
+        # body is pre-rendered; strip trailing newline for join, re-add via body itself
+        body = sf.body.rstrip("\n")
+        if body:
+            parts.append(body)
+        else:
+            parts.append("_No claims extracted from this segment._")
+
+    return "\n\n".join(parts) + "\n"
+
+
+def _render_frontmatter(info: Info, sidecar: Sidecar) -> str:
+    fm: dict[str, Any] = {
+        "schema_version": 1,
+        "source_id": info.source_id,
+        "source_name": info.title,
+        "source_url": info.source_url,
+        "source_type": info.source_type,
+        "session_date": (
+            sidecar.session_date
+            if sidecar.session_date is not None
+            else info.session_date
+        ),
+        "ingested_at": info.fetched_at,
+        "reading_status": "approved",
+        "default_speaker": sidecar.default_speaker,
+        "name_corrections": dict(sidecar.name_corrections),
+    }
+    body = yaml.safe_dump(
+        fm,
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    ).rstrip("\n")
+    return f"---\n{body}\n---"
+
+
+def _render_segment_header(
+    start: float,
+    end: float,
+    title: str,
+    speaker: str,
+    source_url: str | None,
+    name_corrections: dict[str, str],
+) -> str:
+    start_ts = format_timestamp(start)
+    end_ts = format_timestamp(end)
+    header_text = apply_name_corrections(title, name_corrections)
+    link = linkify_timestamp(source_url, start)
+    if link:
+        header = f"## [[{start_ts}-{end_ts}]]({link}) {header_text}"
+    else:
+        header = f"## [{start_ts}-{end_ts}] {header_text}"
+    speaker_line = f"Speaker: {speaker}"
+    return f"{header}\n\n{speaker_line}"

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -1,8 +1,8 @@
 """High-level orchestration of the Stage 1 reading pipeline.
 
-Exposes `generate`, `approve`, and `regenerate` entry points used by
-the three reading subcommands. The command modules handle argparse;
-this module handles the wiring between stages.
+Exposes `generate`, `approve`, `regenerate`, and `assemble_draft` entry
+points used by the three reading subcommands. The command modules handle
+argparse; this module handles the wiring between stages.
 """
 
 from __future__ import annotations
@@ -26,6 +26,9 @@ from auto_lorebook import plan_yaml as plan_yaml_mod
 from auto_lorebook import preamble as preamble_mod
 from auto_lorebook import proposal_yaml as proposal_yaml_mod
 from auto_lorebook import reading as reading_mod
+from auto_lorebook import reading_assembly as reading_assembly_mod
+from auto_lorebook import reading_sidecar as sidecar_mod
+from auto_lorebook import segment_file as segment_file_mod
 from auto_lorebook import stage1a as stage1a_mod
 from auto_lorebook import stage1b as stage1b_mod
 from auto_lorebook import stage2 as stage2_mod
@@ -42,6 +45,8 @@ if TYPE_CHECKING:
     from auto_lorebook.info_yaml import Info
     from auto_lorebook.plan_yaml import Plan
     from auto_lorebook.proposal_yaml import Proposal
+    from auto_lorebook.reading_sidecar import Sidecar
+    from auto_lorebook.segment_file import SegmentFile
 
 _logger = logging.getLogger(__name__)
 
@@ -54,7 +59,8 @@ class ReadingPipelineError(RuntimeError):
 class GenerateResult:
     """Paths and warnings produced by a generate/regenerate run."""
 
-    pending_reading_path: Path
+    sidecar_path: Path
+    segments_dir: Path
     structure_path: Path
     bullets_path: Path
     gap_warnings: list[GapWarning]
@@ -78,7 +84,7 @@ class ExtractResult:
 
 
 def generate(cfg: cfg_mod.Config, source_id: str) -> GenerateResult:
-    """Run Stage 1a + 1b from scratch and write the draft reading.md."""
+    """Run Stage 1a + 1b from scratch and write draft segment files."""
     return _run_full(cfg, source_id)
 
 
@@ -102,18 +108,54 @@ def regenerate(
 
 
 def approve(cfg: cfg_mod.Config, source_id: str) -> Path:
-    """Flip the draft to approved and copy it into the wiki."""
-    pending_path = pending_reading_path(source_id)
-    try:
-        approved_text = reading_mod.with_status(pending_path, "approved")
-    except FileNotFoundError as e:
+    """Assemble approved reading from segment files and copy to wiki."""
+    sidecar_path = pending_sidecar_path(source_id)
+    if not sidecar_path.exists():
         msg = f"No draft reading for {source_id!r}. Run `generate-reading` first."
-        raise ReadingPipelineError(msg) from e
-    reading_mod.write(pending_path, approved_text)
-    dest = cfg.wiki_repo_path / "sources" / source_id / "reading.md"
+        raise ReadingPipelineError(msg)
+
+    wiki_repo = cfg.wiki_repo_path
+    info_path = wiki_repo / "sources" / source_id / "info.yaml"
+    try:
+        info = info_yaml_mod.read(info_path)
+    except info_yaml_mod.InfoError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    try:
+        sc = sidecar_mod.read(sidecar_path)
+    except sidecar_mod.ReadingSidecarError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    segments = _load_segments(source_id)
+    text = reading_assembly_mod.assemble(segments=segments, sidecar=sc, info=info)
+
+    dest = wiki_repo / "sources" / source_id / "reading.md"
     dest.parent.mkdir(parents=True, exist_ok=True)
-    reading_mod.write(dest, approved_text)
+    reading_mod.write(dest, text)
     return dest
+
+
+def assemble_draft(cfg: cfg_mod.Config, source_id: str) -> str:
+    """Assemble the current segment files into a draft preview string."""
+    sidecar_path = pending_sidecar_path(source_id)
+    if not sidecar_path.exists():
+        msg = f"No draft reading for {source_id!r}. Run `generate-reading` first."
+        raise ReadingPipelineError(msg)
+
+    wiki_repo = cfg.wiki_repo_path
+    info_path = wiki_repo / "sources" / source_id / "info.yaml"
+    try:
+        info = info_yaml_mod.read(info_path)
+    except info_yaml_mod.InfoError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    try:
+        sc = sidecar_mod.read(sidecar_path)
+    except sidecar_mod.ReadingSidecarError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    segments = _load_segments(source_id)
+    return reading_assembly_mod.assemble(segments=segments, sidecar=sc, info=info)
 
 
 def pending_dir(source_id: str) -> Path:
@@ -121,8 +163,16 @@ def pending_dir(source_id: str) -> Path:
     return cfg_mod.config_dir() / "pending" / source_id / "reading"
 
 
-def pending_reading_path(source_id: str) -> Path:
-    return pending_dir(source_id) / "reading.md"
+def pending_sidecar_path(source_id: str) -> Path:
+    return pending_dir(source_id) / "reading.yaml"
+
+
+def pending_segments_dir(source_id: str) -> Path:
+    return pending_dir(source_id) / "segments"
+
+
+def pending_segment_path(source_id: str, segment_id: str) -> Path:
+    return pending_segments_dir(source_id) / f"{segment_id}.md"
 
 
 def pending_structure_path(source_id: str) -> Path:
@@ -379,17 +429,48 @@ def _run_full(cfg: cfg_mod.Config, source_id: str) -> GenerateResult:
         bullets.segments.setdefault(seg.id, [])
     stage1b_mod.write_bullets(bullets, pending_bullets_path(source_id))
 
-    name_corrections = _load_existing_name_corrections(source_id)
-    text = reading_mod.assemble(
-        info=info,
-        structure=structure,
-        bullets=bullets,
+    # build sidecar from structure defaults
+    existing_sc = _load_existing_sidecar(source_id)
+    name_corrections = existing_sc.name_corrections if existing_sc else {}
+    session_date = existing_sc.session_date if existing_sc else None
+    sc = sidecar_mod.Sidecar(
+        default_speaker=structure.default_speaker,
         name_corrections=name_corrections,
+        session_date=session_date,
     )
-    reading_mod.write(pending_reading_path(source_id), text)
+    sidecar_path = pending_sidecar_path(source_id)
+    sidecar_mod.write(sc, sidecar_path)
+
+    # write per-segment files
+    segs_dir = pending_segments_dir(source_id)
+    segs_dir.mkdir(parents=True, exist_ok=True)
+    flags_by_seg = _flags_by_segment(structure)
+    for seg in structure.segments:
+        body = _build_segment_body(
+            seg,
+            bullets.segments.get(seg.id, []),
+            flags_by_seg.get(seg.id, []),
+            info.source_url,
+            name_corrections,
+        )
+        sf = segment_file_mod.SegmentFile(
+            frontmatter=segment_file_mod.SegmentFrontmatter(
+                segment_id=seg.id,
+                segment_status="draft",
+                start=seg.start,
+                end=seg.end,
+                title=seg.title,
+                speaker=seg.speaker,
+                notes=seg.notes,
+                overrides=list(seg.overrides),
+            ),
+            body=body,
+        )
+        segment_file_mod.write(sf, pending_segment_path(source_id, seg.id))
 
     return GenerateResult(
-        pending_reading_path=pending_reading_path(source_id),
+        sidecar_path=sidecar_path,
+        segments_dir=segs_dir,
         structure_path=pending_structure_path(source_id),
         bullets_path=pending_bullets_path(source_id),
         gap_warnings=warnings,
@@ -433,17 +514,55 @@ def _run_summarize_only(
     new_bullets.segments = merged
     stage1b_mod.write_bullets(new_bullets, pending_bullets_path(source_id))
 
-    name_corrections = _load_existing_name_corrections(source_id)
-    text = reading_mod.assemble(
-        info=info,
-        structure=structure,
-        bullets=new_bullets,
+    # always rewrite sidecar (preserving corrections + session_date)
+    existing_sc = _load_existing_sidecar(source_id)
+    name_corrections = existing_sc.name_corrections if existing_sc else {}
+    session_date = existing_sc.session_date if existing_sc else None
+    sc = sidecar_mod.Sidecar(
+        default_speaker=structure.default_speaker,
         name_corrections=name_corrections,
+        session_date=session_date,
     )
-    reading_mod.write(pending_reading_path(source_id), text)
+    sidecar_path = pending_sidecar_path(source_id)
+    sidecar_mod.write(sc, sidecar_path)
+
+    # rewrite only targeted segment files (or all when segment_ids is None)
+    segs_dir = pending_segments_dir(source_id)
+    segs_dir.mkdir(parents=True, exist_ok=True)
+    flags_by_seg = _flags_by_segment(structure)
+    target_ids = (
+        set(segment_ids)
+        if segment_ids is not None
+        else {seg.id for seg in structure.segments}
+    )
+    for seg in structure.segments:
+        if seg.id not in target_ids:
+            continue
+        body = _build_segment_body(
+            seg,
+            new_bullets.segments.get(seg.id, []),
+            flags_by_seg.get(seg.id, []),
+            info.source_url,
+            name_corrections,
+        )
+        sf = segment_file_mod.SegmentFile(
+            frontmatter=segment_file_mod.SegmentFrontmatter(
+                segment_id=seg.id,
+                segment_status="draft",
+                start=seg.start,
+                end=seg.end,
+                title=seg.title,
+                speaker=seg.speaker,
+                notes=seg.notes,
+                overrides=list(seg.overrides),
+            ),
+            body=body,
+        )
+        segment_file_mod.write(sf, pending_segment_path(source_id, seg.id))
 
     return GenerateResult(
-        pending_reading_path=pending_reading_path(source_id),
+        sidecar_path=sidecar_path,
+        segments_dir=segs_dir,
         structure_path=pending_structure_path(source_id),
         bullets_path=pending_bullets_path(source_id),
         gap_warnings=gap_check_mod.check(structure),
@@ -516,15 +635,61 @@ def _load_existing_bullets(source_id: str) -> stage1b_mod.ReadingBullets:
     return stage1b_mod.read_bullets(path)
 
 
-def _load_existing_name_corrections(source_id: str) -> dict[str, str]:
-    path = pending_reading_path(source_id)
+def _load_existing_sidecar(source_id: str) -> Sidecar | None:
+    path = pending_sidecar_path(source_id)
     if not path.exists():
-        return {}
+        return None
     try:
-        fm = reading_mod.read_frontmatter(path)
-    except reading_mod.ReadingError:
-        return {}
-    raw = fm.get("name_corrections") or {}
-    if not isinstance(raw, dict):
-        return {}
-    return {str(k): str(v) for k, v in raw.items()}
+        return sidecar_mod.read(path)
+    except sidecar_mod.ReadingSidecarError:
+        return None
+
+
+def _load_segments(source_id: str) -> list[SegmentFile]:
+    """Load all seg-NNN.md files sorted by filename."""
+    segs_dir = pending_segments_dir(source_id)
+    if not segs_dir.exists():
+        return []
+    paths = sorted(segs_dir.glob("*.md"))
+    return [segment_file_mod.read(p) for p in paths]
+
+
+def _flags_by_segment(
+    structure: structure_mod.Structure,
+) -> dict[str, list[structure_mod.UncertaintyFlag]]:
+    out: dict[str, list[structure_mod.UncertaintyFlag]] = {}
+    for flag in structure.uncertainty_flags:
+        for seg in structure.segments:
+            if seg.start <= flag.locator <= seg.end:
+                out.setdefault(seg.id, []).append(flag)
+                break
+    return out
+
+
+def _build_segment_body(
+    _seg: structure_mod.Segment,
+    bullets: list[stage1b_mod.Bullet],
+    flags: list[structure_mod.UncertaintyFlag],
+    source_url: str | None,
+    name_corrections: dict[str, str],
+) -> str:
+    """Render segment body: uncertainty flags + bullets (or empty marker)."""
+    from auto_lorebook.timestamps import format_timestamp  # noqa: PLC0415
+
+    parts: list[str] = []
+    for flag in flags:
+        ts = format_timestamp(flag.locator)
+        note = f"; {flag.note}" if flag.note else ""
+        parts.append(f"- [{ts}] uncertain {flag.kind}: {flag.span}{note}")
+    if not bullets:
+        parts.append("_No claims extracted from this segment._")
+    else:
+        for b in bullets:
+            text = reading_mod.apply_name_corrections(b.text, name_corrections)
+            anchor_ts = format_timestamp(b.anchor)
+            link = reading_mod.linkify_timestamp(source_url, b.anchor)
+            if link:
+                parts.append(f"- {text} [[{anchor_ts}]]({link})")
+            else:
+                parts.append(f"- {text} [{anchor_ts}]")
+    return "\n\n".join(parts) + "\n"

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -446,7 +446,7 @@ def _run_full(cfg: cfg_mod.Config, source_id: str) -> GenerateResult:
     segs_dir.mkdir(parents=True, exist_ok=True)
     flags_by_seg = _flags_by_segment(structure)
     for seg in structure.segments:
-        body = _build_segment_body(
+        body = build_segment_body(
             seg,
             bullets.segments.get(seg.id, []),
             flags_by_seg.get(seg.id, []),
@@ -538,7 +538,7 @@ def _run_summarize_only(
     for seg in structure.segments:
         if seg.id not in target_ids:
             continue
-        body = _build_segment_body(
+        body = build_segment_body(
             seg,
             new_bullets.segments.get(seg.id, []),
             flags_by_seg.get(seg.id, []),
@@ -666,7 +666,7 @@ def _flags_by_segment(
     return out
 
 
-def _build_segment_body(
+def build_segment_body(
     _seg: structure_mod.Segment,
     bullets: list[stage1b_mod.Bullet],
     flags: list[structure_mod.UncertaintyFlag],

--- a/src/auto_lorebook/reading_sidecar.py
+++ b/src/auto_lorebook/reading_sidecar.py
@@ -1,0 +1,98 @@
+"""pending/<id>/reading/reading.yaml: sidecar for the reading session.
+
+Stores session metadata (default_speaker, session_date, name_corrections)
+separately from per-segment content.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from auto_lorebook._io import atomic_write_text
+from auto_lorebook.schema import SchemaVersionError, read_schema_version
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_MAX_SCHEMA = 1
+
+
+class ReadingSidecarError(ValueError):
+    """Raised when reading.yaml is missing or malformed."""
+
+
+@dataclass
+class Sidecar:
+    """In-memory representation of reading.yaml."""
+
+    default_speaker: str
+    name_corrections: dict[str, str] = field(default_factory=dict)
+    session_date: str | None = None
+
+
+def _to_dict(sc: Sidecar) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "default_speaker": sc.default_speaker,
+        "session_date": sc.session_date,
+        "name_corrections": dict(sc.name_corrections),
+    }
+
+
+def write(sc: Sidecar, path: Path) -> None:
+    """Atomically write reading.yaml."""
+    body = yaml.safe_dump(
+        _to_dict(sc),
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    )
+    atomic_write_text(path, body)
+
+
+def read(path: Path) -> Sidecar:
+    """Read reading.yaml into a Sidecar.
+
+    :raises ReadingSidecarError: missing file, missing/future schema_version,
+        or malformed YAML.
+    """
+    if not path.exists():
+        msg = f"{path}: not found"
+        raise ReadingSidecarError(msg)
+    text = path.read_text(encoding="utf-8")
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        msg = f"{path}: YAML parse error: {e}"
+        raise ReadingSidecarError(msg) from e
+    if not isinstance(data, dict):
+        msg = f"{path}: expected YAML mapping"
+        raise ReadingSidecarError(msg)
+    try:
+        read_schema_version(data, str(path), max_supported=_MAX_SCHEMA)
+    except SchemaVersionError as e:
+        raise ReadingSidecarError(str(e)) from e
+
+    default_speaker = data.get("default_speaker", "")
+    if not isinstance(default_speaker, str):
+        msg = f"{path}: default_speaker must be a string"
+        raise ReadingSidecarError(msg)
+
+    session_date = data.get("session_date")
+    if session_date is not None and not isinstance(session_date, str):
+        session_date = str(session_date)
+
+    raw_corrections = data.get("name_corrections") or {}
+    if not isinstance(raw_corrections, dict):
+        msg = f"{path}: name_corrections must be a mapping"
+        raise ReadingSidecarError(msg)
+    name_corrections = {str(k): str(v) for k, v in raw_corrections.items()}
+
+    return Sidecar(
+        default_speaker=default_speaker,
+        name_corrections=name_corrections,
+        session_date=session_date,
+    )

--- a/src/auto_lorebook/segment_file.py
+++ b/src/auto_lorebook/segment_file.py
@@ -1,0 +1,187 @@
+"""pending/<id>/reading/segments/seg-NNN.md: per-segment frontmatter + body.
+
+Frontmatter carries segment metadata; body carries rendered bullets and
+uncertainty flags.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from auto_lorebook._io import atomic_write_text
+from auto_lorebook.schema import SchemaVersionError, read_schema_version
+from auto_lorebook.structure import Override
+from auto_lorebook.timestamps import format_timestamp, parse_timestamp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_MAX_SCHEMA = 1
+_FRONTMATTER_RE = re.compile(r"^---\n(?P<fm>.*?)\n---\n(?P<rest>.*)$", re.DOTALL)
+
+VALID_STATUSES = frozenset({"draft", "approved"})
+
+
+class SegmentFileError(ValueError):
+    """Raised for missing files, missing frontmatter, or invalid status."""
+
+
+@dataclass(frozen=True)
+class SegmentFrontmatter:
+    """Parsed frontmatter for a single segment file."""
+
+    segment_id: str
+    segment_status: str
+    start: float
+    end: float
+    title: str
+    speaker: str
+    notes: str | None = None
+    overrides: list[Override] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SegmentFile:
+    """In-memory representation of a seg-NNN.md file."""
+
+    frontmatter: SegmentFrontmatter
+    body: str
+
+
+def _override_to_dict(o: Override) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "start": format_timestamp(o.start),
+        "end": format_timestamp(o.end),
+        "speaker": o.speaker,
+    }
+    if o.voiced_by is not None:
+        out["voiced_by"] = o.voiced_by
+    if o.note is not None:
+        out["note"] = o.note
+    return out
+
+
+def _fm_to_dict(fm: SegmentFrontmatter) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "schema_version": 1,
+        "segment_id": fm.segment_id,
+        "segment_status": fm.segment_status,
+        "start": format_timestamp(fm.start),
+        "end": format_timestamp(fm.end),
+        "title": fm.title,
+        "speaker": fm.speaker,
+        "notes": fm.notes,
+        "overrides": [_override_to_dict(o) for o in fm.overrides],
+    }
+    return out
+
+
+def write(sf: SegmentFile, path: Path) -> None:
+    """Atomically write a seg-NNN.md file."""
+    fm_text = yaml.safe_dump(
+        _fm_to_dict(sf.frontmatter),
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    ).rstrip("\n")
+    text = f"---\n{fm_text}\n---\n{sf.body}"
+    atomic_write_text(path, text)
+
+
+def read(path: Path) -> SegmentFile:
+    """Read a seg-NNN.md file.
+
+    :raises SegmentFileError: missing file, missing frontmatter, bad status,
+        or invalid schema_version.
+    """
+    if not path.exists():
+        msg = f"{path}: not found"
+        raise SegmentFileError(msg)
+    text = path.read_text(encoding="utf-8")
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        msg = f"{path}: no '---' frontmatter block"
+        raise SegmentFileError(msg)
+    try:
+        data = yaml.safe_load(m.group("fm"))
+    except yaml.YAMLError as e:
+        msg = f"{path}: frontmatter YAML parse error: {e}"
+        raise SegmentFileError(msg) from e
+    if not isinstance(data, dict):
+        msg = f"{path}: frontmatter is not a mapping"
+        raise SegmentFileError(msg)
+    try:
+        read_schema_version(data, str(path), max_supported=_MAX_SCHEMA)
+    except SchemaVersionError as e:
+        raise SegmentFileError(str(e)) from e
+
+    status = data.get("segment_status", "draft")
+    if status not in VALID_STATUSES:
+        msg = (
+            f"{path}: invalid segment_status {status!r}; "
+            f"expected one of {sorted(VALID_STATUSES)}"
+        )
+        raise SegmentFileError(msg)
+
+    overrides = [
+        Override(
+            start=parse_timestamp(raw_o["start"]),
+            end=parse_timestamp(raw_o["end"]),
+            speaker=raw_o["speaker"],
+            voiced_by=raw_o.get("voiced_by"),
+            note=raw_o.get("note"),
+        )
+        for raw_o in data.get("overrides") or []
+    ]
+
+    fm = SegmentFrontmatter(
+        segment_id=data["segment_id"],
+        segment_status=status,
+        start=parse_timestamp(data["start"]),
+        end=parse_timestamp(data["end"]),
+        title=data["title"],
+        speaker=data["speaker"],
+        notes=data.get("notes"),
+        overrides=overrides,
+    )
+    return SegmentFile(frontmatter=fm, body=m.group("rest"))
+
+
+def with_status(path: Path, status: str) -> str:
+    """Return segment file text with segment_status set to status.
+
+    :raises SegmentFileError: invalid status or missing/malformed frontmatter.
+    """
+    if status not in VALID_STATUSES:
+        msg = (
+            f"invalid segment_status {status!r}; "
+            f"expected one of {sorted(VALID_STATUSES)}"
+        )
+        raise SegmentFileError(msg)
+    sf = read(path)
+    new_fm = SegmentFrontmatter(
+        segment_id=sf.frontmatter.segment_id,
+        segment_status=status,
+        start=sf.frontmatter.start,
+        end=sf.frontmatter.end,
+        title=sf.frontmatter.title,
+        speaker=sf.frontmatter.speaker,
+        notes=sf.frontmatter.notes,
+        overrides=sf.frontmatter.overrides,
+    )
+    fm_text = yaml.safe_dump(
+        _fm_to_dict(new_fm),
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    ).rstrip("\n")
+    return f"---\n{fm_text}\n---\n{sf.body}"
+
+
+def set_status(path: Path, status: str) -> None:
+    """Rewrite segment_status in place."""
+    atomic_write_text(path, with_status(path, status))

--- a/tests/_reading_fixtures.py
+++ b/tests/_reading_fixtures.py
@@ -1,0 +1,142 @@
+"""Shared builder helpers for reading tests.
+
+Underscore prefix prevents pytest collection.
+"""
+
+from __future__ import annotations
+
+from auto_lorebook.info_yaml import Info, SourceContext
+from auto_lorebook.reading_sidecar import Sidecar
+from auto_lorebook.segment_file import SegmentFile, SegmentFrontmatter
+from auto_lorebook.stage1b import Bullet, ReadingBullets
+from auto_lorebook.structure import Segment, Structure, UncertaintyFlag
+
+
+def _info(
+    *,
+    source_url: str | None = "https://youtube.com/watch?v=abc12345678",
+    title: str | None = "Session 3",
+) -> Info:
+    return Info(
+        source_id="yt-abc12345678",
+        source_type="youtube",
+        fetched_at="2026-04-20T14:35:12Z",
+        source_url=source_url,
+        title=title,
+        duration_seconds=600,
+        transcript_filename="transcript.en.srt",
+        context=SourceContext(),
+    )
+
+
+def _structure() -> Structure:
+    return Structure(
+        source_id="yt-abc12345678",
+        generated_at="2026-04-20T14:32:00Z",
+        default_speaker="DM",
+        segments=[
+            Segment(
+                id="seg-001", start=0.0, end=120.0, title="Introduction", speaker="DM"
+            ),
+            Segment(
+                id="seg-002",
+                start=120.0,
+                end=270.0,
+                title="Rules discussion: grappling",
+                speaker="mixed",
+                notes="off-topic",
+            ),
+            Segment(
+                id="seg-003",
+                start=270.0,
+                end=600.0,
+                title="Founding of Aldara",
+                speaker="DM",
+            ),
+        ],
+        uncertainty_flags=[
+            UncertaintyFlag(
+                locator=347.0, span="a place name", kind="name", note="unclear"
+            )
+        ],
+    )
+
+
+def _bullets() -> ReadingBullets:
+    return ReadingBullets(
+        source_id="yt-abc12345678",
+        generated_at="2026-04-20T14:34:00Z",
+        segments={
+            "seg-001": [],
+            "seg-002": [],
+            "seg-003": [
+                Bullet(
+                    text="King Theron founded Aldara in the Second Age",
+                    anchor=272.0,
+                    locator_hint_start=257.0,
+                    locator_hint_end=287.0,
+                ),
+                Bullet(
+                    text="The founding displaced an earlier elven presence",
+                    anchor=314.0,
+                    locator_hint_start=299.0,
+                    locator_hint_end=329.0,
+                ),
+            ],
+        },
+    )
+
+
+def _sidecar(name_corrections: dict[str, str] | None = None) -> Sidecar:
+    return Sidecar(
+        default_speaker="DM",
+        name_corrections=name_corrections or {},
+        session_date=None,
+    )
+
+
+def _segment_files() -> list[SegmentFile]:
+    """Three segment files matching _structure() + _bullets()."""
+    seg001 = SegmentFile(
+        frontmatter=SegmentFrontmatter(
+            segment_id="seg-001",
+            segment_status="draft",
+            start=0.0,
+            end=120.0,
+            title="Introduction",
+            speaker="DM",
+        ),
+        body="_No claims extracted from this segment.\n",
+    )
+    seg002 = SegmentFile(
+        frontmatter=SegmentFrontmatter(
+            segment_id="seg-002",
+            segment_status="draft",
+            start=120.0,
+            end=270.0,
+            title="Rules discussion: grappling",
+            speaker="mixed",
+            notes="off-topic",
+        ),
+        body="_No claims extracted from this segment.\n",
+    )
+    seg003 = SegmentFile(
+        frontmatter=SegmentFrontmatter(
+            segment_id="seg-003",
+            segment_status="draft",
+            start=270.0,
+            end=600.0,
+            title="Founding of Aldara",
+            speaker="DM",
+        ),
+        body=(
+            "- [0:05:47] uncertain name: a place name; unclear\n"
+            "\n"
+            "- King Theron founded Aldara in the Second Age"
+            " [[0:04:32]](https://youtube.com/watch?v=abc12345678&t=272)\n"
+            "\n"
+            "- The founding displaced an earlier elven presence"
+            " [[0:05:14]](https://youtube.com/watch?v=abc12345678&t=314)\n"
+        ),
+    )
+    return [seg001, seg002, seg003]

--- a/tests/_reading_fixtures.py
+++ b/tests/_reading_fixtures.py
@@ -106,7 +106,7 @@ def _segment_files() -> list[SegmentFile]:
             title="Introduction",
             speaker="DM",
         ),
-        body="_No claims extracted from this segment.\n",
+        body="_No claims extracted from this segment._\n",
     )
     seg002 = SegmentFile(
         frontmatter=SegmentFrontmatter(
@@ -118,7 +118,7 @@ def _segment_files() -> list[SegmentFile]:
             speaker="mixed",
             notes="off-topic",
         ),
-        body="_No claims extracted from this segment.\n",
+        body="_No claims extracted from this segment._\n",
     )
     seg003 = SegmentFile(
         frontmatter=SegmentFrontmatter(

--- a/tests/test_reading.py
+++ b/tests/test_reading.py
@@ -1,4 +1,7 @@
-"""Tests for reading.py — reading.md assembly + frontmatter helpers."""
+"""Tests for reading.py — frontmatter helpers (linkify, apply, read, set_status, write).
+
+Assembly tests live in test_reading_assembly.py.
+"""
 
 from __future__ import annotations
 
@@ -6,103 +9,29 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from auto_lorebook.info_yaml import Info, SourceContext
 from auto_lorebook.reading import (
     ReadingError,
     apply_name_corrections,
-    assemble,
     linkify_timestamp,
     read_frontmatter,
     set_status,
     write,
 )
-from auto_lorebook.stage1b import Bullet, ReadingBullets
-from auto_lorebook.structure import Segment, Structure, UncertaintyFlag
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def _info(
-    *,
-    source_url: str | None = "https://youtube.com/watch?v=abc12345678",
-    title: str | None = "Session 3",
-) -> Info:
-    return Info(
-        source_id="yt-abc12345678",
-        source_type="youtube",
-        fetched_at="2026-04-20T14:35:12Z",
-        source_url=source_url,
-        title=title,
-        duration_seconds=600,
-        transcript_filename="transcript.en.srt",
-        context=SourceContext(),
-    )
+_SAMPLE_READING_MD = """\
+---
+schema_version: 1
+source_id: yt-abc12345678
+reading_status: draft
+---
+# Reading: Session 3
 
-
-def _structure() -> Structure:
-    return Structure(
-        source_id="yt-abc12345678",
-        generated_at="2026-04-20T14:32:00Z",
-        default_speaker="DM",
-        segments=[
-            Segment(
-                id="seg-001",
-                start=0.0,
-                end=120.0,
-                title="Introduction",
-                speaker="DM",
-            ),
-            Segment(
-                id="seg-002",
-                start=120.0,
-                end=270.0,
-                title="Rules discussion: grappling",
-                speaker="mixed",
-                notes="off-topic",
-            ),
-            Segment(
-                id="seg-003",
-                start=270.0,
-                end=600.0,
-                title="Founding of Aldara",
-                speaker="DM",
-            ),
-        ],
-        uncertainty_flags=[
-            UncertaintyFlag(
-                locator=347.0,
-                span="a place name",
-                kind="name",
-                note="unclear",
-            )
-        ],
-    )
-
-
-def _bullets() -> ReadingBullets:
-    return ReadingBullets(
-        source_id="yt-abc12345678",
-        generated_at="2026-04-20T14:34:00Z",
-        segments={
-            "seg-001": [],  # empty is permitted
-            "seg-002": [],
-            "seg-003": [
-                Bullet(
-                    text="King Theron founded Aldara in the Second Age",
-                    anchor=272.0,
-                    locator_hint_start=257.0,
-                    locator_hint_end=287.0,
-                ),
-                Bullet(
-                    text="The founding displaced an earlier elven presence",
-                    anchor=314.0,
-                    locator_hint_start=299.0,
-                    locator_hint_end=329.0,
-                ),
-            ],
-        },
-    )
+Some content.
+"""
 
 
 class TestLinkifyTimestamp:
@@ -139,71 +68,10 @@ class TestApplyNameCorrections:
         assert got == "Alice says Bob"
 
 
-class TestAssemble:
-    def test_frontmatter_contains_expected_keys(self) -> None:
-        md = assemble(info=_info(), structure=_structure(), bullets=_bullets())
-        assert md.startswith("---\n")
-        assert "schema_version: 1" in md
-        assert "source_id: yt-abc12345678" in md
-        assert "reading_status: draft" in md
-        assert "default_speaker: DM" in md
-
-    def test_segment_headers_linkified(self) -> None:
-        md = assemble(info=_info(), structure=_structure(), bullets=_bullets())
-        # seg-003 starts at 270s
-        assert (
-            "[[0:04:30-0:10:00]]"
-            "(https://youtube.com/watch?v=abc12345678&t=270)"
-            " Founding of Aldara"
-        ) in md
-
-    def test_speaker_line_emitted(self) -> None:
-        md = assemble(info=_info(), structure=_structure(), bullets=_bullets())
-        assert "Speaker: DM" in md
-        assert "Speaker: mixed" in md
-
-    def test_empty_segment_gets_explicit_marker(self) -> None:
-        md = assemble(info=_info(), structure=_structure(), bullets=_bullets())
-        assert "_No claims extracted from this segment._" in md
-
-    def test_bullets_rendered_with_clickable_anchor(self) -> None:
-        md = assemble(info=_info(), structure=_structure(), bullets=_bullets())
-        assert (
-            "- King Theron founded Aldara in the Second Age "
-            "[[0:04:32]](https://youtube.com/watch?v=abc12345678&t=272)"
-        ) in md
-
-    def test_uncertainty_flags_rendered(self) -> None:
-        md = assemble(info=_info(), structure=_structure(), bullets=_bullets())
-        assert "[0:05:47]" in md
-        assert "a place name" in md
-
-    def test_no_source_url_omits_links(self) -> None:
-        info = _info(source_url=None)
-        md = assemble(info=info, structure=_structure(), bullets=_bullets())
-        # header still appears, just without URL
-        assert "## [0:00:00-0:02:00] Introduction" in md
-
-    def test_existing_frontmatter_name_corrections_applied(self) -> None:
-        # if the human added corrections to the frontmatter map on a
-        # previous pass, assemble() applies them to rendered text.
-        md = assemble(
-            info=_info(),
-            structure=_structure(),
-            bullets=_bullets(),
-            name_corrections={"Aldara": "Aldaria"},
-        )
-        assert "Aldaria" in md
-        assert (
-            "King Theron founded Aldara in the Second Age" not in md or "Aldaria" in md
-        )
-
-
 class TestWriteReadFrontmatter:
     def test_write_and_read_round_trip(self, tmp_path: Path) -> None:
         path = tmp_path / "reading.md"
-        text = assemble(info=_info(), structure=_structure(), bullets=_bullets())
-        write(path, text)
+        write(path, _SAMPLE_READING_MD)
         fm = read_frontmatter(path)
         assert fm["source_id"] == "yt-abc12345678"
         assert fm["reading_status"] == "draft"
@@ -220,15 +88,13 @@ class TestWriteReadFrontmatter:
 
     def test_set_status_flip_to_approved(self, tmp_path: Path) -> None:
         path = tmp_path / "reading.md"
-        text = assemble(info=_info(), structure=_structure(), bullets=_bullets())
-        write(path, text)
+        write(path, _SAMPLE_READING_MD)
         set_status(path, "approved")
         fm = read_frontmatter(path)
         assert fm["reading_status"] == "approved"
 
     def test_set_status_rejects_bad_value(self, tmp_path: Path) -> None:
         path = tmp_path / "reading.md"
-        text = assemble(info=_info(), structure=_structure(), bullets=_bullets())
-        write(path, text)
+        write(path, _SAMPLE_READING_MD)
         with pytest.raises(ReadingError):
             set_status(path, "published")

--- a/tests/test_reading_assembly.py
+++ b/tests/test_reading_assembly.py
@@ -3,8 +3,15 @@
 from __future__ import annotations
 
 from auto_lorebook.reading_assembly import assemble
+from auto_lorebook.reading_pipeline import build_segment_body
 from auto_lorebook.segment_file import SegmentFile, SegmentFrontmatter
-from tests._reading_fixtures import _info, _segment_files, _sidecar
+from tests._reading_fixtures import (
+    _bullets,
+    _info,
+    _segment_files,
+    _sidecar,
+    _structure,
+)
 
 # Golden bytes: assembled output that the new assemble() must produce.
 # Derived from the legacy reading.assemble() output, with reading_status: approved
@@ -29,7 +36,7 @@ _GOLDEN = (
     "\n"
     "Speaker: DM\n"
     "\n"
-    "_No claims extracted from this segment.\n"
+    "_No claims extracted from this segment._\n"
     "\n"
     "## [[0:02:00-0:04:30]]"
     "(https://youtube.com/watch?v=abc12345678&t=120)"
@@ -37,7 +44,7 @@ _GOLDEN = (
     "\n"
     "Speaker: mixed\n"
     "\n"
-    "_No claims extracted from this segment.\n"
+    "_No claims extracted from this segment._\n"
     "\n"
     "## [[0:04:30-0:10:00]]"
     "(https://youtube.com/watch?v=abc12345678&t=270)"
@@ -78,7 +85,7 @@ class TestNoSourceUrl:
                 title="Introduction",
                 speaker="DM",
             ),
-            body="_No claims extracted from this segment.\n",
+            body="_No claims extracted from this segment._\n",
         )
         result = assemble(
             segments=[seg], sidecar=_sidecar(), info=_info(source_url=None)
@@ -151,3 +158,34 @@ class TestPureNoFilesystem:
     def test_returns_string_not_path(self) -> None:
         result = assemble(segments=_segment_files(), sidecar=_sidecar(), info=_info())
         assert isinstance(result, str)
+
+
+class TestFixtureMatchesPipeline:
+    """Anchors _segment_files() bodies to actual pipeline output.
+
+    Without this, the golden test could pass on a fixture that drifts from
+    what generate-reading actually writes — making the byte-identity check
+    a tautology rather than a true legacy capture.
+    """
+
+    def test_bodies_match_build_segment_body(self) -> None:
+        structure = _structure()
+        bullets = _bullets()
+        info = _info()
+        expected = _segment_files()
+        for seg, expected_sf in zip(structure.segments, expected, strict=True):
+            flags = [
+                f
+                for f in structure.uncertainty_flags
+                if seg.start <= f.locator < seg.end
+            ]
+            body = build_segment_body(
+                _seg=seg,
+                bullets=bullets.segments[seg.id],
+                flags=flags,
+                source_url=info.source_url,
+                name_corrections={},
+            )
+            assert body == expected_sf.body, (
+                f"fixture body for {seg.id} drifted from pipeline build_segment_body"
+            )

--- a/tests/test_reading_assembly.py
+++ b/tests/test_reading_assembly.py
@@ -1,0 +1,153 @@
+"""Tests for reading_assembly.py — wiki-side reading.md assembly."""
+
+from __future__ import annotations
+
+from auto_lorebook.reading_assembly import assemble
+from auto_lorebook.segment_file import SegmentFile, SegmentFrontmatter
+from tests._reading_fixtures import _info, _segment_files, _sidecar
+
+# Golden bytes: assembled output that the new assemble() must produce.
+# Derived from the legacy reading.assemble() output, with reading_status: approved
+# (legacy produced draft; wiki-side always approved).
+_GOLDEN = (
+    "---\n"
+    "schema_version: 1\n"
+    "source_id: yt-abc12345678\n"
+    "source_name: Session 3\n"
+    "source_url: https://youtube.com/watch?v=abc12345678\n"
+    "source_type: youtube\n"
+    "session_date: null\n"
+    "ingested_at: '2026-04-20T14:35:12Z'\n"
+    "reading_status: approved\n"
+    "default_speaker: DM\n"
+    "name_corrections: {}\n"
+    "---\n"
+    "\n"
+    "# Reading: Session 3\n"
+    "\n"
+    "## [[0:00:00-0:02:00]](https://youtube.com/watch?v=abc12345678&t=0) Introduction\n"
+    "\n"
+    "Speaker: DM\n"
+    "\n"
+    "_No claims extracted from this segment.\n"
+    "\n"
+    "## [[0:02:00-0:04:30]]"
+    "(https://youtube.com/watch?v=abc12345678&t=120)"
+    " Rules discussion: grappling\n"
+    "\n"
+    "Speaker: mixed\n"
+    "\n"
+    "_No claims extracted from this segment.\n"
+    "\n"
+    "## [[0:04:30-0:10:00]]"
+    "(https://youtube.com/watch?v=abc12345678&t=270)"
+    " Founding of Aldara\n"
+    "\n"
+    "Speaker: DM\n"
+    "\n"
+    "- [0:05:47] uncertain name: a place name; unclear\n"
+    "\n"
+    "- King Theron founded Aldara in the Second Age"
+    " [[0:04:32]](https://youtube.com/watch?v=abc12345678&t=272)\n"
+    "\n"
+    "- The founding displaced an earlier elven presence"
+    " [[0:05:14]](https://youtube.com/watch?v=abc12345678&t=314)\n"
+)
+
+
+class TestGoldenByteMatch:
+    def test_matches_legacy_output(self) -> None:
+        result = assemble(segments=_segment_files(), sidecar=_sidecar(), info=_info())
+        assert result == _GOLDEN
+
+    def test_always_approved_status(self) -> None:
+        result = assemble(segments=_segment_files(), sidecar=_sidecar(), info=_info())
+        assert "reading_status: approved" in result
+        assert "reading_status: draft" not in result
+
+
+class TestNoSourceUrl:
+    def test_no_url_segment_headers_plain(self) -> None:
+        # segment headers rendered without URL links when source_url is None
+        seg = SegmentFile(
+            frontmatter=SegmentFrontmatter(
+                segment_id="seg-001",
+                segment_status="draft",
+                start=0.0,
+                end=120.0,
+                title="Introduction",
+                speaker="DM",
+            ),
+            body="_No claims extracted from this segment.\n",
+        )
+        result = assemble(
+            segments=[seg], sidecar=_sidecar(), info=_info(source_url=None)
+        )
+        assert "## [0:00:00-0:02:00] Introduction" in result
+        assert "[[0:00:00" not in result
+
+
+class TestNameCorrections:
+    def test_corrections_applied_to_segment_headers(self) -> None:
+        result = assemble(
+            segments=_segment_files(),
+            sidecar=_sidecar(name_corrections={"Aldara": "Aldaria"}),
+            info=_info(),
+        )
+        assert "Aldaria" in result
+
+    def test_corrections_in_frontmatter(self) -> None:
+        result = assemble(
+            segments=_segment_files(),
+            sidecar=_sidecar(name_corrections={"Aldara": "Aldaria"}),
+            info=_info(),
+        )
+        assert "Aldara: Aldaria" in result
+
+
+class TestEmptySegmentMarker:
+    def test_empty_body_gets_marker(self) -> None:
+        seg = SegmentFile(
+            frontmatter=SegmentFrontmatter(
+                segment_id="seg-001",
+                segment_status="draft",
+                start=0.0,
+                end=60.0,
+                title="Intro",
+                speaker="DM",
+            ),
+            body="",
+        )
+        result = assemble(segments=[seg], sidecar=_sidecar(), info=_info())
+        assert "_No claims extracted from this segment._" in result
+
+
+class TestSegmentStatusIgnored:
+    def test_approved_segment_still_assembled(self) -> None:
+        segs = _segment_files()
+        # flip one to approved — should not affect output
+        sf = segs[0]
+        approved_sf = SegmentFile(
+            frontmatter=SegmentFrontmatter(
+                segment_id=sf.frontmatter.segment_id,
+                segment_status="approved",
+                start=sf.frontmatter.start,
+                end=sf.frontmatter.end,
+                title=sf.frontmatter.title,
+                speaker=sf.frontmatter.speaker,
+            ),
+            body=sf.body,
+        )
+        result = assemble(
+            segments=[approved_sf, segs[1], segs[2]],
+            sidecar=_sidecar(),
+            info=_info(),
+        )
+        assert "Introduction" in result
+        assert "reading_status: approved" in result
+
+
+class TestPureNoFilesystem:
+    def test_returns_string_not_path(self) -> None:
+        result = assemble(segments=_segment_files(), sidecar=_sidecar(), info=_info())
+        assert isinstance(result, str)

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -249,10 +249,22 @@ class TestGenerateReading:
         pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
         assert (pending / "structure.yaml").exists()
         assert (pending / "bullets.yaml").exists()
-        assert (pending / "reading.md").exists()
-        md = (pending / "reading.md").read_text(encoding="utf-8")
-        assert "reading_status: draft" in md
-        assert "King Theron founded Aldara" in md
+        assert (pending / "reading.yaml").exists()
+        assert (pending / "segments" / "seg-001.md").exists()
+        assert (pending / "segments" / "seg-002.md").exists()
+        # no old-style reading.md under pending
+        assert not (pending / "reading.md").exists()
+
+        # reading.yaml has correct schema
+        import yaml as _yaml  # noqa: PLC0415
+
+        sidecar_data = _yaml.safe_load((pending / "reading.yaml").read_text())
+        assert sidecar_data["schema_version"] == 1
+        assert sidecar_data["default_speaker"] == "DM"
+
+        # seg-002.md contains the Theron claim
+        seg002 = (pending / "segments" / "seg-002.md").read_text(encoding="utf-8")
+        assert "King Theron founded Aldara" in seg002
 
     def test_missing_api_key_errors(
         self,
@@ -409,9 +421,10 @@ class TestApproveReadingInteractive:
         approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
         assert not approved.exists()
         assert not (tmp_home / "pending" / "yt-abc12345678" / "plan.yaml").exists()
-        assert (
-            tmp_home / "pending" / "yt-abc12345678" / "reading" / "reading.md"
-        ).exists()
+        # sidecar and segments exist; no old reading.md
+        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        assert (pending / "reading.yaml").exists()
+        assert not (pending / "reading.md").exists()
 
     def test_reject_then_quit_with_confirm_deletes_pending(
         self,
@@ -457,9 +470,9 @@ class TestApproveReadingInteractive:
             rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
 
         assert rc == 0
-        assert (
-            tmp_home / "pending" / "yt-abc12345678" / "reading" / "reading.md"
-        ).exists()
+        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        assert (pending / "reading.yaml").exists()
+        assert not (pending / "reading.md").exists()
 
     def test_reject_then_undo_then_approve(
         self,
@@ -485,30 +498,44 @@ class TestApproveReadingInteractive:
         assert approved.exists()
         assert "reading_status: approved" in approved.read_text(encoding="utf-8")
 
-    def test_undo_restores_edited_file(
+    def test_undo_restores_segment_files(
         self,
         tmp_home: Path,
         ingested_wiki: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """[u] rolls back any in-session edits to the pending reading."""
+        """[u] rolls back in-session mutations to segment files."""
         _write_user_config(tmp_home, ingested_wiki)
         monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
         self._force_tty(monkeypatch)
-        self._patch_inputs(monkeypatch, ["e", "u", "a"])
 
-        pending_path = (
-            tmp_home / "pending" / "yt-abc12345678" / "reading" / "reading.md"
+        seg001_path = (
+            tmp_home
+            / "pending"
+            / "yt-abc12345678"
+            / "reading"
+            / "segments"
+            / "seg-001.md"
         )
 
-        def fake_editor(_cmd: list[str], **_kwargs: object) -> object:
-            # Simulate the user destructively rewriting the file.
-            pending_path.write_text("REWRITTEN", encoding="utf-8")
-            return MagicMock(returncode=0)
-
-        monkeypatch.setattr(
-            "auto_lorebook.commands.approve_reading.subprocess.run", fake_editor
+        corrupted = (
+            b"---\nschema_version: 1\nsegment_id: seg-001\n"
+            b"segment_status: approved\nstart: '0:00:00'\nend: '0:02:00'\n"
+            b"title: CORRUPTED\nspeaker: DM\nnotes: null\noverrides: []\n"
+            b"---\nCORRUPTED BODY\n"
         )
+        call_count = {"n": 0}
+
+        def fake_input(_prompt: str = "") -> str:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # first prompt: corrupt seg-001 then say 'u'
+                seg001_path.write_bytes(corrupted)
+                return "u"
+            # after undo, approve
+            return "a"
+
+        monkeypatch.setattr("builtins.input", fake_input)
 
         client = MagicMock()
         _wire_client_responses(client)
@@ -516,24 +543,21 @@ class TestApproveReadingInteractive:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            original = pending_path.read_bytes()
             rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
 
         assert rc == 0
         approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
-        # After [e][u][a]: wiki copy must reflect ORIGINAL content, not "REWRITTEN".
         assert approved.exists()
-        assert "REWRITTEN" not in approved.read_text(encoding="utf-8")
-        assert "King Theron" in approved.read_text(encoding="utf-8")
-        # Sanity: the original we snapshotted before the run matches what
-        # generate-reading produced.
-        assert b"King Theron" in original
+        # After [u][a]: wiki copy reflects restored content, not corrupted title
+        assert "CORRUPTED" not in approved.read_text(encoding="utf-8")
+        assert "Intro" in approved.read_text(encoding="utf-8")
 
-    def test_edit_invokes_editor_then_reprompts(
+    def test_edit_invokes_editor_preview_only(
         self,
         tmp_home: Path,
         ingested_wiki: Path,
         monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
         _write_user_config(tmp_home, ingested_wiki)
         monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
@@ -562,7 +586,16 @@ class TestApproveReadingInteractive:
         assert rc == 0
         assert len(calls) == 1
         assert calls[0][0] == "my-fake-editor"
-        assert calls[0][1].endswith("reading.md")
+        assert calls[0][1].endswith(".draft-edit.md")
+
+        out = capsys.readouterr().out
+        assert "preview-only" in out
+        assert "edits were not saved" in out
+
+        # segment files must be unchanged (edits discarded)
+        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        assert (pending / "segments" / "seg-001.md").exists()
+        assert (pending / "segments" / "seg-002.md").exists()
 
 
 class TestRegenerateReading:
@@ -610,6 +643,41 @@ class TestRegenerateReading:
         added = client.complete.call_count - first_complete_count
         # one call for seg-002
         assert added == 1
+
+    def test_summarize_only_preserves_reading_yaml(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--from=summarize preserves reading.yaml (sidecar)."""
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+            sidecar_before = (pending / "reading.yaml").read_bytes()
+
+            regenerate_reading_cmd.run(
+                _args(
+                    source_id="yt-abc12345678",
+                    from_stage="summarize",
+                    segments="seg-002",
+                )
+            )
+
+        # sidecar always rewritten but should be structurally identical
+        import yaml as _yaml  # noqa: PLC0415
+
+        sidecar_after = _yaml.safe_load((pending / "reading.yaml").read_text())
+        sidecar_orig = _yaml.safe_load(sidecar_before)
+        assert sidecar_after["default_speaker"] == sidecar_orig["default_speaker"]
+        assert sidecar_after["name_corrections"] == sidecar_orig["name_corrections"]
 
 
 class TestPlan:

--- a/tests/test_reading_sidecar.py
+++ b/tests/test_reading_sidecar.py
@@ -1,0 +1,103 @@
+"""Tests for reading_sidecar.py — reading.yaml I/O."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from auto_lorebook.reading_sidecar import ReadingSidecarError, Sidecar, read, write
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _full_sidecar() -> Sidecar:
+    return Sidecar(
+        default_speaker="DM",
+        name_corrections={"Fair-on": "Theron", "Aldera": "Aldara"},
+        session_date="2026-01-15",
+    )
+
+
+class TestRoundTripFull:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        sc = _full_sidecar()
+        p = tmp_path / "reading.yaml"
+        write(sc, p)
+        loaded = read(p)
+        assert loaded.default_speaker == sc.default_speaker
+        assert loaded.name_corrections == sc.name_corrections
+        assert loaded.session_date == sc.session_date
+
+    def test_schema_version_first(self, tmp_path: Path) -> None:
+        p = tmp_path / "reading.yaml"
+        write(_full_sidecar(), p)
+        first_line = p.read_text(encoding="utf-8").splitlines()[0]
+        assert first_line == "schema_version: 1"
+
+    def test_key_order(self, tmp_path: Path) -> None:
+        p = tmp_path / "reading.yaml"
+        write(_full_sidecar(), p)
+        parsed = yaml.safe_load(p.read_text(encoding="utf-8"))
+        keys = list(parsed.keys())
+        assert keys == [
+            "schema_version",
+            "default_speaker",
+            "session_date",
+            "name_corrections",
+        ]
+
+    def test_byte_identical_round_trip(self, tmp_path: Path) -> None:
+        p = tmp_path / "reading.yaml"
+        write(_full_sidecar(), p)
+        first_bytes = p.read_bytes()
+        loaded = read(p)
+        write(loaded, p)
+        assert p.read_bytes() == first_bytes
+
+
+class TestEmptyCorrections:
+    def test_empty_corrections(self, tmp_path: Path) -> None:
+        sc = Sidecar(default_speaker="GM", name_corrections={}, session_date=None)
+        p = tmp_path / "reading.yaml"
+        write(sc, p)
+        loaded = read(p)
+        assert loaded.name_corrections == {}
+        assert loaded.session_date is None
+
+
+class TestNullSessionDate:
+    def test_null_session_date(self, tmp_path: Path) -> None:
+        sc = Sidecar(default_speaker="GM")
+        p = tmp_path / "reading.yaml"
+        write(sc, p)
+        loaded = read(p)
+        assert loaded.session_date is None
+
+
+class TestMissingFileRaises:
+    def test_missing_file(self, tmp_path: Path) -> None:
+        with pytest.raises(ReadingSidecarError, match="not found"):
+            read(tmp_path / "nope.yaml")
+
+
+class TestMissingSchemaVersionRaises:
+    def test_missing_schema_version(self, tmp_path: Path) -> None:
+        p = tmp_path / "reading.yaml"
+        p.write_text("default_speaker: DM\nname_corrections: {}\n", encoding="utf-8")
+        with pytest.raises(ReadingSidecarError, match="schema_version"):
+            read(p)
+
+
+class TestFutureSchemaRaises:
+    def test_future_schema(self, tmp_path: Path) -> None:
+        p = tmp_path / "reading.yaml"
+        p.write_text(
+            "schema_version: 99\ndefault_speaker: DM\n"
+            "session_date: null\nname_corrections: {}\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ReadingSidecarError, match="schema_version"):
+            read(p)

--- a/tests/test_seed_ingest_cmd.py
+++ b/tests/test_seed_ingest_cmd.py
@@ -16,6 +16,8 @@ from auto_lorebook import (
     stage1b,
 )
 from auto_lorebook import reading_pipeline as pipeline
+from auto_lorebook import reading_sidecar as reading_sidecar_mod
+from auto_lorebook import segment_file as segment_file_mod
 from auto_lorebook import (
     structure as structure_mod,
 )
@@ -76,12 +78,12 @@ class TestSeedIngestPerStage:
             (
                 "approve",
                 {"transcript.en.srt", "info.yaml"},
-                {"structure.yaml", "bullets.yaml", "reading.md"},
+                {"structure.yaml", "bullets.yaml", "reading.yaml", "segments"},
             ),
             (
                 "plan",
                 {"transcript.en.srt", "info.yaml", "reading.md"},
-                {"structure.yaml", "bullets.yaml", "reading.md"},
+                {"structure.yaml", "bullets.yaml", "reading.yaml", "segments"},
             ),
         ],
     )
@@ -108,6 +110,10 @@ class TestSeedIngestPerStage:
             assert {p.name for p in pending_reading.iterdir()} == expected_pending
         else:
             assert not pending_reading.exists()
+
+        # no old-style pending reading.md
+        if pending_reading.exists():
+            assert not (pending_reading / "reading.md").exists()
 
     def test_substitutes_source_id_in_artifacts(
         self,
@@ -140,12 +146,19 @@ class TestSeedIngestPerStage:
         assert fm["source_id"] == sid
         assert fm["reading_status"] == "approved"
 
+        sidecar = reading_sidecar_mod.read(
+            tmp_home / "pending" / sid / "reading" / "reading.yaml"
+        )
+        assert sidecar.default_speaker == "DM"
+
         # placeholder must not survive anywhere on disk
         for path in (
             tmp_wiki / "sources" / sid / "info.yaml",
             tmp_home / "pending" / sid / "reading" / "structure.yaml",
             tmp_home / "pending" / sid / "reading" / "bullets.yaml",
-            tmp_home / "pending" / sid / "reading" / "reading.md",
+            tmp_home / "pending" / sid / "reading" / "reading.yaml",
+            tmp_home / "pending" / sid / "reading" / "segments" / "seg-001.md",
+            tmp_home / "pending" / sid / "reading" / "segments" / "seg-002.md",
             approved_path,
         ):
             assert "__QA_SOURCE_ID__" not in path.read_text(encoding="utf-8")
@@ -163,9 +176,14 @@ class TestSeedIngestPerStage:
         assert rc == 0
         sid = _seeded_sid_from(capsys.readouterr().out)
 
-        draft = tmp_home / "pending" / sid / "reading" / "reading.md"
-        fm = reading.read_frontmatter(draft)
-        assert fm["reading_status"] == "draft"
+        seg001 = segment_file_mod.read(
+            tmp_home / "pending" / sid / "reading" / "segments" / "seg-001.md"
+        )
+        assert seg001.frontmatter.segment_status == "draft"
+        seg002 = segment_file_mod.read(
+            tmp_home / "pending" / sid / "reading" / "segments" / "seg-002.md"
+        )
+        assert seg002.frontmatter.segment_status == "draft"
 
     def test_explicit_source_id_used_verbatim(
         self,

--- a/tests/test_segment_file.py
+++ b/tests/test_segment_file.py
@@ -1,0 +1,184 @@
+"""Tests for segment_file.py — per-segment frontmatter + body I/O."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from auto_lorebook.segment_file import (
+    SegmentFile,
+    SegmentFileError,
+    SegmentFrontmatter,
+    read,
+    set_status,
+    with_status,
+    write,
+)
+from auto_lorebook.structure import Override
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _fm(
+    *,
+    segment_id: str = "seg-001",
+    segment_status: str = "draft",
+    start: float = 0.0,
+    end: float = 120.0,
+    title: str = "Introduction",
+    speaker: str = "DM",
+    notes: str | None = None,
+    overrides: list[Override] | None = None,
+) -> SegmentFrontmatter:
+    return SegmentFrontmatter(
+        segment_id=segment_id,
+        segment_status=segment_status,
+        start=start,
+        end=end,
+        title=title,
+        speaker=speaker,
+        notes=notes,
+        overrides=overrides or [],
+    )
+
+
+def _sf(body: str = "- Intro bullet [0:00:15]\n") -> SegmentFile:
+    return SegmentFile(frontmatter=_fm(), body=body)
+
+
+class TestRoundTripFull:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        sf = _sf()
+        p = tmp_path / "seg-001.md"
+        write(sf, p)
+        loaded = read(p)
+        assert loaded.frontmatter.segment_id == sf.frontmatter.segment_id
+        assert loaded.frontmatter.segment_status == sf.frontmatter.segment_status
+        assert loaded.frontmatter.start == sf.frontmatter.start
+        assert loaded.frontmatter.end == sf.frontmatter.end
+        assert loaded.frontmatter.title == sf.frontmatter.title
+        assert loaded.frontmatter.speaker == sf.frontmatter.speaker
+        assert loaded.body == sf.body
+
+    def test_schema_version_first(self, tmp_path: Path) -> None:
+        p = tmp_path / "seg-001.md"
+        write(_sf(), p)
+        first_line = p.read_text(encoding="utf-8").splitlines()[0]
+        assert first_line == "---"
+        lines = p.read_text(encoding="utf-8").splitlines()
+        # first line after opening --- must be schema_version
+        assert lines[1] == "schema_version: 1"
+
+    def test_frontmatter_key_order(self, tmp_path: Path) -> None:
+        p = tmp_path / "seg-001.md"
+        write(_sf(), p)
+        # extract frontmatter block
+        text = p.read_text(encoding="utf-8")
+        fm_text = text.split("---\n")[1]
+        parsed = yaml.safe_load(fm_text)
+        keys = list(parsed.keys())
+        # expected order: schema_version, segment_id, segment_status,
+        # start, end, title, speaker, notes, overrides
+        assert keys[0] == "schema_version"
+        assert keys[1] == "segment_id"
+        assert keys[2] == "segment_status"
+
+    def test_byte_identical_round_trip(self, tmp_path: Path) -> None:
+        sf = SegmentFile(
+            frontmatter=_fm(
+                notes="off-topic",
+                overrides=[Override(start=60.0, end=90.0, speaker="Player")],
+            ),
+            body="- Some claim [0:01:30]\n",
+        )
+        p = tmp_path / "seg-001.md"
+        write(sf, p)
+        first_bytes = p.read_bytes()
+        loaded = read(p)
+        write(loaded, p)
+        assert p.read_bytes() == first_bytes
+
+
+class TestDefaultStatusDraft:
+    def test_default_status_is_draft(self, tmp_path: Path) -> None:
+        p = tmp_path / "seg-001.md"
+        write(_sf(), p)
+        loaded = read(p)
+        assert loaded.frontmatter.segment_status == "draft"
+
+
+class TestSetStatus:
+    def test_set_status_flips_to_approved(self, tmp_path: Path) -> None:
+        p = tmp_path / "seg-001.md"
+        write(_sf(), p)
+        set_status(p, "approved")
+        loaded = read(p)
+        assert loaded.frontmatter.segment_status == "approved"
+
+    def test_set_status_rejects_unknown(self, tmp_path: Path) -> None:
+        p = tmp_path / "seg-001.md"
+        write(_sf(), p)
+        with pytest.raises(SegmentFileError, match=r"invalid.*status"):
+            set_status(p, "published")
+
+    def test_with_status_returns_new_text(self, tmp_path: Path) -> None:
+        p = tmp_path / "seg-001.md"
+        write(_sf(), p)
+        new_text = with_status(p, "approved")
+        assert "segment_status: approved" in new_text
+        # Original file unchanged
+        loaded = read(p)
+        assert loaded.frontmatter.segment_status == "draft"
+
+
+class TestBadStatusOnRead:
+    def test_bad_status_rejected(self, tmp_path: Path) -> None:
+        p = tmp_path / "seg-001.md"
+        write(_sf(), p)
+        text = p.read_text(encoding="utf-8")
+        text = text.replace("segment_status: draft", "segment_status: bogus")
+        p.write_text(text, encoding="utf-8")
+        with pytest.raises(SegmentFileError, match="segment_status"):
+            read(p)
+
+
+class TestOverridesPreserved:
+    def test_overrides_round_trip(self, tmp_path: Path) -> None:
+        overrides = [
+            Override(
+                start=30.0, end=60.0, speaker="Alice", voiced_by=None, note="aside"
+            ),
+            Override(start=90.0, end=100.0, speaker="Bob"),
+        ]
+        sf = SegmentFile(
+            frontmatter=_fm(overrides=overrides),
+            body="- A claim [0:00:45]\n",
+        )
+        p = tmp_path / "seg-001.md"
+        write(sf, p)
+        loaded = read(p)
+        assert len(loaded.frontmatter.overrides) == 2
+        assert loaded.frontmatter.overrides[0].speaker == "Alice"
+        assert loaded.frontmatter.overrides[0].note == "aside"
+        assert loaded.frontmatter.overrides[1].speaker == "Bob"
+
+
+class TestMissingFrontmatterRaises:
+    def test_no_frontmatter_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "seg-001.md"
+        p.write_text("just a body with no frontmatter\n", encoding="utf-8")
+        with pytest.raises(SegmentFileError, match="frontmatter"):
+            read(p)
+
+
+class TestBodyPreservedVerbatim:
+    def test_body_preserved(self, tmp_path: Path) -> None:
+        body = "- Claim one [0:00:15]\n- Claim two [0:01:00]\n\n_Extra line._\n"
+        sf = SegmentFile(frontmatter=_fm(), body=body)
+        p = tmp_path / "seg-001.md"
+        write(sf, p)
+        loaded = read(p)
+        assert loaded.body == body


### PR DESCRIPTION
### What this fixes

Splits the pending-side reading layout from a single `pending/<sid>/reading/reading.md` into:

- `pending/<sid>/reading/reading.yaml` — sidecar carrying `default_speaker`, `name_corrections`, `session_date` (plus `schema_version: 1`).
- `pending/<sid>/reading/segments/seg-NNN.md` — one file per segment with YAML frontmatter (`schema_version`, `segment_id`, `segment_status`, `start`, `end`, `title`, `speaker`, `notes`, `overrides`) and a body holding the segment's uncertainty flags + bullets (or the `_No claims extracted from this segment._` marker).

Three new deep modules land:

- `src/auto_lorebook/segment_file.py` — typed dataclasses `SegmentFrontmatter` / `SegmentFile`; `read` / `write` / `set_status` with `---`-fenced YAML frontmatter and verbatim body roundtrip.
- `src/auto_lorebook/reading_sidecar.py` — `Sidecar` dataclass; `read` / `write` with schema-version validation.
- `src/auto_lorebook/reading_assembly.py` — pure `assemble(*, segments, sidecar, info) -> str` (no `Path` / `_io` imports). Always emits `reading_status: approved` for the wiki-side artefact. The wiki `reading.md` is now produced at gate-crossing rather than copied from a pending file.

`reading_pipeline._run_full` / `_run_summarize_only` now write per-segment files + sidecar instead of the monolithic pending `reading.md`. `approve()` reads them back and calls `reading_assembly.assemble` to produce the wiki-side `reading.md`. `_load_existing_sidecar` preserves `name_corrections` across `regenerate-reading --from=summarize` runs (analogue of today's frontmatter-based preservation). `pending_reading_path` was deleted; new helpers `pending_sidecar_path`, `pending_segments_dir`, `pending_segment_path`, `assemble_draft` replace it.

The atomic `[a]/[e]/[r]/[u]/[q]` UX is preserved this slice (hierarchical UX is #31). `[e]` is preview-only and prints a discard warning — bidirectional segment editing arrives in #31. `[u]` undo snapshots both the sidecar and every `seg-NNN.md` at session start.

The legacy `reading.assemble` was removed; `reading.linkify_timestamp` / `apply_name_corrections` / `read_frontmatter` / `set_status` / `with_status` / `write` are kept for non-test callers.

The seed-ingest QA fixture (`_qa_fixtures/tiny-aldara`) was migrated to the new layout. Docs updated in the same commit set: `docs/architecture/repository-layout.md`, `docs/architecture/schema-versioning.md`, `docs/pipeline/reading.md`, `docs/reference/file-formats.md`, `docs/getting-started/first-ingest.md`.

### QA steps for the human

None — fully covered by the integration smoke (seed → approve → regenerate → interactive `[a]` and `[e]` paths, plus a wiki-side byte-for-byte equivalence check between `approve-reading --yes` output and a direct `reading_assembly.assemble(...)` call).

If you want a manual sanity check anyway: `uv run auto-lorebook seed-ingest tiny-aldara --at=approve` then `uv run auto-lorebook approve-reading <sid> --yes` and inspect the wiki `sources/<sid>/reading.md`.

### Automated coverage

`uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, `uv run pytest` (523 passed / 4 skipped), `uv run mkdocs build --strict` — all clean.

Closes #29

---
_Generated by [Claude Code](https://claude.ai/code/session_019uB5KZrsSXV4Ad844gJq11)_