### PR TITLE
Reading Review engine — state machine + Reviewer protocol (--yes only)

### DIFF
--- a/docs/architecture/repository-layout.md
+++ b/docs/architecture/repository-layout.md
@@ -64,10 +64,11 @@ paused mid-review, and resumed.
   `reading.md` land under `<wiki-repo>/sources/<source_id>/`.
   Intermediate reading artifacts (`structure.yaml`, draft
   `reading.md`) live under `pending/`.
-- **Reading approval.** `reading_status` in the draft frontmatter
-  flips to `approved` and the approved `reading.md` is committed to
-  the wiki alongside the raw transcript. `structure.yaml` is retained
-  as an audit artifact for the lifetime of the ingest.
+- **Reading approval.** The wiki-side `reading.md` is written by the
+  reading-review engine when every segment is decided (`accepted` or
+  `skipped`). The presence of the file is the gate — there is no
+  top-level frontmatter flag. `structure.yaml` is retained as an audit
+  artifact for the lifetime of the ingest.
 - **Planning + extraction.** Produces `pending/<ingest_id>/plan.yaml`
   and one YAML per proposed fact under
   `pending/<ingest_id>/proposals/`.

--- a/docs/pipeline/reading.md
+++ b/docs/pipeline/reading.md
@@ -194,7 +194,6 @@ source_url: https://youtube.com/watch?v=abc123
 source_type: youtube
 session_date: null              # human fills in during review
 ingested_at: 2026-04-20T14:35:12Z
-reading_status: draft           # draft | approved
 default_speaker: DM
 name_corrections:
   # empty initially; human adds transcription fixes here
@@ -261,36 +260,46 @@ context), then replaces with the correct content.
 
 ## Reading review
 
-The review is over the combined, assembled reading — the human sees
-the full `reading.md` and corrects whatever's wrong in it. Two scans:
+The reading-review engine operates over per-segment files under
+`pending/<ingest_id>/reading/segments/`. Each segment carries one of
+four statuses:
 
-**Scan 1: segment titles as a table of contents.** Skim titles
-top-to-bottom, looking for gaps, mislabeled segments, or the
-mechanical gap-check warning. A two-hour session produces maybe 40–80
-segment titles; skimming takes a minute or two.
+| Status | Meaning |
+|--------|---------|
+| `draft` | Fresh — not yet decided. |
+| `accepted` | Reviewer approved; included in the assembled reading. |
+| `skipped` | Reviewer skipped; body replaced with the "no claims" marker in the assembled reading. |
+| `regenerating` | Flagged for re-summarisation (slice #5); blocks the gate. |
 
-**Scan 2: bullets within segments.** For claim-bearing segments, read
-the bullets and confirm they correspond to reality. Empty bullet lists
-get a quick sanity check — a "Founding of Aldara" segment with no
-bullets is a red flag.
+**Deferred-commit semantics.** The engine accumulates pending marks
+during the walk — nothing is written to disk until the reviewer
+commits. On commit, changed segment files are written atomically, then
+the gate predicate is evaluated.
 
-Corrections fall into buckets aligned with the substages:
+**Gate predicate.** Every segment is `accepted` or `skipped`. When the
+gate fires, `reading_assembly.assemble` renders the wiki-side
+`reading.md` and writes it to
+`<wiki-repo>/sources/<source_id>/reading.md`. The presence of this
+file is the approval artefact — there is no `reading_status`
+frontmatter flag.
 
-- Segment boundaries, titles, or coverage gaps → edit section headers
-  or regenerate 1a (1a-class fix).
-- Wrong speaker attribution → edit `Speaker:` lines (1a-class fix,
-  attribution subset).
-- Claim doesn't match what was said, or is invented, or is missing →
-  edit, delete, add the bullet, or regenerate 1b for that segment
-  (1b-class fix).
-
-Transitioning `reading_status: draft` → `reading_status: approved` is
-the gate. The tool refuses to run downstream stages on a draft
-reading.
+**Decision verbs (current slice):** `accept`, `skip-bullets`,
+`regenerate-again` (no-op; marks as `regenerating`, gate blocks),
+`undo` (clears the pending mark for one segment), `commit` (the quit
+path that writes and evaluates the gate).
 
 ```bash
-auto-lorebook approve-reading <source_id>
+auto-lorebook approve-reading <source_id> --yes
 ```
+
+`--yes` drives an `AutoAcceptReviewer` that marks every still-`draft`
+segment `accepted` and commits unconditionally. The gate always fires
+for fixtures where every segment is decidable.
+
+The interactive per-segment hierarchical UX (keys `[a]/[s]/[r]/[u]/[q]`
+per segment) is deferred to slice #4. In the current slice, the
+interactive `[a]` key at the session level still assembles and copies
+to the wiki in one step (unchanged from slice #29).
 
 `approve-reading` opens an interactive session over the draft:
 

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -41,11 +41,12 @@ Every YAML file carries `schema_version` as its first key — see
 
 ### `sources/<source_id>/reading.md`
 
-- **Owner** — tool (draft in pending, approved copy committed to wiki).
-- **Purpose** — segmented, attributed, bulleted reading of the
-  transcript. Frontmatter carries `reading_status`,
-  `name_corrections`, and input hashes.
-- **Details** — [Stage 1: reading](../pipeline/reading.md#reading-assembly).
+- **Owner** — tool (written to wiki when the reading-review engine commits
+  with every segment decided).
+- **Purpose** — segmented, attributed, bulleted reading of the transcript.
+  Frontmatter carries `name_corrections`, `default_speaker`,
+  `session_date`, `source_*`. File presence is the approval gate.
+- **Details** — [Stage 1: reading](../pipeline/reading.md#reading-review).
 
 ### `<category>/<slug>.yaml`
 

--- a/src/auto_lorebook/_qa_fixtures/tiny-aldara/reading.md
+++ b/src/auto_lorebook/_qa_fixtures/tiny-aldara/reading.md
@@ -6,7 +6,6 @@ source_url: null
 source_type: srt
 session_date: null
 ingested_at: '2026-01-01T00:00:00Z'
-reading_status: approved
 default_speaker: DM
 name_corrections: {}
 ---

--- a/src/auto_lorebook/commands/approve_reading.py
+++ b/src/auto_lorebook/commands/approve_reading.py
@@ -11,13 +11,45 @@ from typing import TYPE_CHECKING
 from auto_lorebook import config as cfg_mod
 from auto_lorebook import reading_pipeline as pipeline
 from auto_lorebook.interactive import _is_interactive
+from auto_lorebook.reading_review import (
+    AcceptDecision,
+    CommitDecision,
+    SegmentView,
+    UndoDecision,
+)
 
 if TYPE_CHECKING:
     import argparse
 
+    from auto_lorebook.reading_review import SegmentDecision
+
 _logger = logging.getLogger(__name__)
 
 _PROMPT = "[a]pprove / [e]dit / [r]eject / [u]ndo / [q]uit > "
+
+
+class AutoAcceptReviewer:
+    """Marks every still-draft segment accepted, then commits unconditionally.
+
+    Used by `--yes` (non-interactive) path and `reading_pipeline.approve`.
+    Interactive hierarchical UX lands in slice #4.
+    """
+
+    by_label = "auto-accept"
+
+    def decide_segment(self, view: SegmentView) -> SegmentDecision:
+        # Already terminal on disk — don't overwrite with a pending mark.
+        if view.current_status in {"accepted", "skipped", "regenerating"}:
+            return UndoDecision()
+        return AcceptDecision()
+
+    def decide_quit(
+        self,
+        pending: tuple[SegmentView, ...],  # noqa: ARG002
+    ) -> CommitDecision:
+        return CommitDecision()
+
+
 _RENDER_LINES = 40
 
 

--- a/src/auto_lorebook/commands/seed_ingest.py
+++ b/src/auto_lorebook/commands/seed_ingest.py
@@ -154,27 +154,27 @@ def _seed(cfg: cfg_mod.Config, sid: str, at: str, fixture_name: str) -> None:
         if key == "segments":
             _emit_segments_dir(fixture_root, pending_reading / "segments", sid)
         else:
-            src_name, dest, status = _emit_target(key, wiki_src, pending_reading)
-            _emit_file(fixture_root, src_name, dest, sid, status=status)
+            src_name, dest = _emit_target(key, wiki_src, pending_reading)
+            _emit_file(fixture_root, src_name, dest, sid)
 
 
 def _emit_target(
     key: str,
     wiki_src: Path,
     pending_reading: Path,
-) -> tuple[str, Path, str | None]:
+) -> tuple[str, Path]:
     if key == "info":
-        return "info.yaml", wiki_src / "info.yaml", None
+        return "info.yaml", wiki_src / "info.yaml"
     if key == "transcript":
-        return "transcript.en.srt", wiki_src / "transcript.en.srt", None
+        return "transcript.en.srt", wiki_src / "transcript.en.srt"
     if key == "structure":
-        return "structure.yaml", pending_reading / "structure.yaml", None
+        return "structure.yaml", pending_reading / "structure.yaml"
     if key == "bullets":
-        return "bullets.yaml", pending_reading / "bullets.yaml", None
+        return "bullets.yaml", pending_reading / "bullets.yaml"
     if key == "sidecar":
-        return "reading.yaml", pending_reading / "reading.yaml", None
+        return "reading.yaml", pending_reading / "reading.yaml"
     if key == "approved_reading":
-        return "reading.md", wiki_src / "reading.md", "approved"
+        return "reading.md", wiki_src / "reading.md"
     msg = f"internal: unknown seed key {key!r}"
     raise SeedIngestError(msg)
 
@@ -184,8 +184,6 @@ def _emit_file(
     fixture_filename: str,
     dest: Path,
     sid: str,
-    *,
-    status: str | None,
 ) -> None:
     src = fixture_root / fixture_filename
     if not src.is_file():
@@ -193,12 +191,6 @@ def _emit_file(
         raise SeedIngestError(msg)
     text = src.read_text(encoding="utf-8")
     text = text.replace(_SOURCE_ID_PLACEHOLDER, sid)
-    if status is not None:
-        # fixture's reading.md ships approved; rewrite for pre-approval seeding.
-        text = text.replace(
-            "reading_status: approved",
-            f"reading_status: {status}",
-        )
     atomic_write_text(dest, text)
 
 

--- a/src/auto_lorebook/reading.py
+++ b/src/auto_lorebook/reading.py
@@ -1,8 +1,7 @@
 """reading.md frontmatter helpers and wiki-side write path.
 
 Provides `linkify_timestamp`, `apply_name_corrections`, `read_frontmatter`,
-`with_status`, `set_status`, and `write` — used by commands/review.py and
-the wiki-side write path. Assembly is now in reading_assembly.py.
+and `write`. Assembly lives in reading_assembly.py.
 """
 
 from __future__ import annotations
@@ -17,13 +16,11 @@ from auto_lorebook._io import atomic_write_text
 if TYPE_CHECKING:
     from pathlib import Path
 
-VALID_STATUSES = frozenset({"draft", "approved"})
-
 _FRONTMATTER_RE = re.compile(r"^---\n(?P<body>.*?)\n---\n(?P<rest>.*)$", re.DOTALL)
 
 
 class ReadingError(ValueError):
-    """Raised for missing files, missing frontmatter, or invalid status."""
+    """Raised for missing files, missing frontmatter, or invalid YAML."""
 
 
 def linkify_timestamp(source_url: str | None, seconds: float) -> str | None:
@@ -70,36 +67,3 @@ def read_frontmatter(path: Path) -> dict[str, Any]:
         msg = f"{path}: frontmatter is not a mapping"
         raise ReadingError(msg)
     return parsed
-
-
-def with_status(path: Path, status: str) -> str:
-    """Return the reading.md text with `reading_status` set to `status`.
-
-    :raises FileNotFoundError: path doesn't exist
-    :raises ReadingError: invalid status, missing/malformed frontmatter
-    """
-    if status not in VALID_STATUSES:
-        msg = (
-            f"invalid reading_status {status!r}; "
-            f"expected one of {sorted(VALID_STATUSES)}"
-        )
-        raise ReadingError(msg)
-    text = path.read_text(encoding="utf-8")
-    m = _FRONTMATTER_RE.match(text)
-    if not m:
-        msg = f"{path}: no frontmatter block"
-        raise ReadingError(msg)
-    parsed = yaml.safe_load(m.group("body")) or {}
-    if not isinstance(parsed, dict):
-        msg = f"{path}: frontmatter is not a mapping"
-        raise ReadingError(msg)
-    parsed["reading_status"] = status
-    new_fm = yaml.safe_dump(
-        parsed, allow_unicode=True, sort_keys=False, default_flow_style=False
-    ).rstrip("\n")
-    return f"---\n{new_fm}\n---\n{m.group('rest')}"
-
-
-def set_status(path: Path, status: str) -> None:
-    """Rewrite the `reading_status` field in place."""
-    atomic_write_text(path, with_status(path, status))

--- a/src/auto_lorebook/reading_assembly.py
+++ b/src/auto_lorebook/reading_assembly.py
@@ -25,7 +25,7 @@ def assemble(
     sidecar: Sidecar,
     info: Info,
 ) -> str:
-    """Render wiki-side reading.md; always emits reading_status: approved."""
+    """Render wiki-side reading.md; derived approval — file presence is the gate."""
     corrections = dict(sidecar.name_corrections)
     parts: list[str] = [_render_frontmatter(info, sidecar)]
     parts.append(f"# Reading: {info.title or info.source_id}")
@@ -60,7 +60,6 @@ def _render_frontmatter(info: Info, sidecar: Sidecar) -> str:
             else info.session_date
         ),
         "ingested_at": info.fetched_at,
-        "reading_status": "approved",
         "default_speaker": sidecar.default_speaker,
         "name_corrections": dict(sidecar.name_corrections),
     }

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -108,31 +108,33 @@ def regenerate(
 
 
 def approve(cfg: cfg_mod.Config, source_id: str) -> Path:
-    """Assemble approved reading from segment files and copy to wiki."""
-    sidecar_path = pending_sidecar_path(source_id)
-    if not sidecar_path.exists():
-        msg = f"No draft reading for {source_id!r}. Run `generate-reading` first."
+    """Auto-accept all draft segments via the reading-review engine.
+
+    :raises ReadingPipelineError: sidecar missing, engine error, or gate did
+        not fire (all segments must be decidable).
+    """
+    from auto_lorebook import reading_review as reading_review_mod  # noqa: PLC0415
+    from auto_lorebook.commands.approve_reading import (  # noqa: PLC0415
+        AutoAcceptReviewer,
+    )
+
+    try:
+        result = reading_review_mod.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=AutoAcceptReviewer(),
+        )
+    except reading_review_mod.ReadingReviewError as e:
+        raise ReadingPipelineError(str(e)) from e
+
+    if not result.gate_fired or result.wiki_reading_path is None:
+        msg = (
+            f"Reading review for {source_id!r} did not fire the gate; "
+            "not all segments could be decided."
+        )
         raise ReadingPipelineError(msg)
 
-    wiki_repo = cfg.wiki_repo_path
-    info_path = wiki_repo / "sources" / source_id / "info.yaml"
-    try:
-        info = info_yaml_mod.read(info_path)
-    except info_yaml_mod.InfoError as e:
-        raise ReadingPipelineError(str(e)) from e
-
-    try:
-        sc = sidecar_mod.read(sidecar_path)
-    except sidecar_mod.ReadingSidecarError as e:
-        raise ReadingPipelineError(str(e)) from e
-
-    segments = _load_segments(source_id)
-    text = reading_assembly_mod.assemble(segments=segments, sidecar=sc, info=info)
-
-    dest = wiki_repo / "sources" / source_id / "reading.md"
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    reading_mod.write(dest, text)
-    return dest
+    return result.wiki_reading_path
 
 
 def assemble_draft(cfg: cfg_mod.Config, source_id: str) -> str:
@@ -211,16 +213,8 @@ def plan(cfg: cfg_mod.Config, source_id: str) -> PlanResult:
             f"Run `approve-reading {source_id}` first."
         )
         raise ReadingPipelineError(msg)
-    try:
-        fm = reading_mod.read_frontmatter(approved_path)
-    except reading_mod.ReadingError as e:
-        raise ReadingPipelineError(str(e)) from e
-    if fm.get("reading_status") != "approved":
-        msg = (
-            f"Reading at {approved_path} is not approved "
-            f"(reading_status={fm.get('reading_status')!r})."
-        )
-        raise ReadingPipelineError(msg)
+    # File presence is the approval gate — written only when the reading-review
+    # engine commits with every segment decided (accepted or skipped).
 
     structure_path = pending_structure_path(source_id)
     bullets_path = pending_bullets_path(source_id)

--- a/src/auto_lorebook/reading_review.py
+++ b/src/auto_lorebook/reading_review.py
@@ -1,0 +1,278 @@
+"""Reading review engine: walk per-segment files, accumulate pending marks, commit.
+
+Pure-logic module. No `input()` / `print()` calls. Display + prompt I/O lives
+in `commands/approve_reading.py` and is injected via the `Reviewer` protocol.
+Tests script a `Reviewer` to drive the engine deterministically.
+
+Per-segment terminal states: `draft` (fresh), `accepted`, `skipped`,
+`regenerating`. A segment is "decided" if status is `accepted` or `skipped`.
+
+Decisions are deferred — the engine accumulates pending marks during the walk
+and commits in one transaction at `decide_quit` time. Gate predicate: every
+segment is decided. On gate fire, `reading_assembly.assemble` is invoked and
+the wiki-side `reading.md` is written.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import info_yaml as info_yaml_mod
+from auto_lorebook import reading as reading_mod
+from auto_lorebook import reading_assembly as reading_assembly_mod
+from auto_lorebook import reading_pipeline as pipeline_mod
+from auto_lorebook import reading_sidecar as sidecar_mod
+from auto_lorebook import segment_file as segment_file_mod
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from auto_lorebook.segment_file import SegmentFile
+
+_logger = logging.getLogger(__name__)
+
+_EMPTY_BODY = "_No claims extracted from this segment._\n"
+
+# ------------- error --------------------------------------------------------
+
+
+class ReadingReviewError(RuntimeError):
+    """Unrecoverable engine failure."""
+
+
+# ------------- decisions ----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AcceptDecision:
+    """Mark segment accepted."""
+
+
+@dataclass(frozen=True)
+class SkipBulletsDecision:
+    """Mark segment skipped; body will be rewritten to empty-bullets marker."""
+
+
+@dataclass(frozen=True)
+class RegenerateAgainDecision:
+    """Mark segment regenerating (no-op in this slice; gate blocks)."""
+
+
+@dataclass(frozen=True)
+class UndoDecision:
+    """Clear the pending mark for this segment."""
+
+
+@dataclass(frozen=True)
+class CommitDecision:
+    """Commit pending marks and quit."""
+
+
+SegmentDecision = (
+    AcceptDecision | SkipBulletsDecision | RegenerateAgainDecision | UndoDecision
+)
+
+# ------------- views / result -----------------------------------------------
+
+
+@dataclass(frozen=True)
+class SegmentView:
+    """Display data passed to the reviewer per segment."""
+
+    segment_index: int
+    segment_total: int
+    segment_id: str
+    title: str
+    start: float
+    end: float
+    speaker: str
+    current_status: str
+    pending_mark: str | None  # status queued this walk; None if untouched
+    bullets_preview: str
+    source_url: str | None
+    source_title: str | None
+
+
+@dataclass
+class ReadingReviewResult:
+    """Counts per terminal status after a run."""
+
+    accepted: int = 0
+    skipped: int = 0
+    regenerating: int = 0
+    unchanged: int = 0
+    gate_fired: bool = False
+    wiki_reading_path: Path | None = None
+
+
+# ------------- reviewer protocol --------------------------------------------
+
+
+class Reviewer(Protocol):
+    """Decision-maker injected into `run`. Tests script this directly."""
+
+    @property
+    def by_label(self) -> str:
+        """Recorded for parity with review.Reviewer; reserved for future slices."""
+        ...
+
+    def decide_segment(self, view: SegmentView) -> SegmentDecision:
+        """Return a decision for one segment during the walk."""
+        ...
+
+    def decide_quit(self, pending: tuple[SegmentView, ...]) -> CommitDecision | None:
+        """Return CommitDecision to commit, None to abort."""
+        ...
+
+
+# ------------- engine -------------------------------------------------------
+
+
+def run(
+    *,
+    cfg: cfg_mod.Config,
+    source_id: str,
+    reviewer: Reviewer,
+) -> ReadingReviewResult:
+    """Walk segments, collect pending marks, commit on reviewer signal.
+
+    Returns a `ReadingReviewResult` describing what happened. When the gate
+    fires (every segment decided), writes the wiki-side `reading.md`.
+    """
+    wiki_repo = cfg.wiki_repo_path
+    info_path = wiki_repo / "sources" / source_id / "info.yaml"
+    try:
+        info = info_yaml_mod.read(info_path)
+    except info_yaml_mod.InfoError as e:
+        raise ReadingReviewError(str(e)) from e
+
+    sidecar_path = pipeline_mod.pending_sidecar_path(source_id)
+    if not sidecar_path.exists():
+        msg = f"No draft reading for {source_id!r}; run `generate-reading` first."
+        raise ReadingReviewError(msg)
+    try:
+        sc = sidecar_mod.read(sidecar_path)
+    except sidecar_mod.ReadingSidecarError as e:
+        raise ReadingReviewError(str(e)) from e
+
+    segments = pipeline_mod._load_segments(source_id)  # noqa: SLF001
+    if not segments:
+        msg = f"No segment files found for {source_id!r}."
+        raise ReadingReviewError(msg)
+
+    total = len(segments)
+    # pending_marks: segment_id → "accepted" | "skipped" | "regenerating"
+    pending_marks: dict[str, str] = {}
+
+    # Walk: one pass; reviewer may return UndoDecision to retract a mark.
+    for idx, sf in enumerate(segments, start=1):
+        fm = sf.frontmatter
+        view = _build_view(sf, idx, total, pending_marks, info)
+        decision = reviewer.decide_segment(view)
+        if isinstance(decision, AcceptDecision):
+            pending_marks[fm.segment_id] = "accepted"
+        elif isinstance(decision, SkipBulletsDecision):
+            pending_marks[fm.segment_id] = "skipped"
+        elif isinstance(decision, RegenerateAgainDecision):
+            pending_marks[fm.segment_id] = "regenerating"
+        elif isinstance(decision, UndoDecision):
+            pending_marks.pop(fm.segment_id, None)
+
+    # Build views of segments with a pending mark for decide_quit.
+    pending_views = tuple(
+        _build_view(sf, idx, total, pending_marks, info)
+        for idx, sf in enumerate(segments, start=1)
+        if sf.frontmatter.segment_id in pending_marks
+    )
+
+    commit = reviewer.decide_quit(pending_views)
+    if commit is None:
+        # abort — write nothing
+        return ReadingReviewResult()
+
+    # Commit transaction: write changed segments, then maybe fire gate.
+    result = ReadingReviewResult()
+    committed_segments: list[SegmentFile] = []
+    for sf in segments:
+        sid = sf.frontmatter.segment_id
+        mark = pending_marks.get(sid)
+        if mark is None:
+            # unchanged
+            result.unchanged += 1
+            committed_segments.append(sf)
+        else:
+            seg_path = pipeline_mod.pending_segment_path(source_id, sid)
+            if mark == "accepted":
+                segment_file_mod.set_status(seg_path, "accepted")
+                new_sf = segment_file_mod.read(seg_path)
+                result.accepted += 1
+            elif mark == "skipped":
+                # Rewrite body to empty-bullets marker so assembly emits it.
+                new_fm = segment_file_mod.SegmentFrontmatter(
+                    segment_id=sf.frontmatter.segment_id,
+                    segment_status="skipped",
+                    start=sf.frontmatter.start,
+                    end=sf.frontmatter.end,
+                    title=sf.frontmatter.title,
+                    speaker=sf.frontmatter.speaker,
+                    notes=sf.frontmatter.notes,
+                    overrides=list(sf.frontmatter.overrides),
+                )
+                new_sf = segment_file_mod.SegmentFile(
+                    frontmatter=new_fm, body=_EMPTY_BODY
+                )
+                segment_file_mod.write(new_sf, seg_path)
+                result.skipped += 1
+            else:  # regenerating
+                segment_file_mod.set_status(seg_path, "regenerating")
+                new_sf = segment_file_mod.read(seg_path)
+                result.regenerating += 1
+            committed_segments.append(new_sf)
+
+    # Gate: all segments decided?
+    effective_statuses = {
+        sf.frontmatter.segment_id: sf.frontmatter.segment_status
+        for sf in committed_segments
+    }
+    gate = all(s in {"accepted", "skipped"} for s in effective_statuses.values())
+    result.gate_fired = gate
+
+    if gate:
+        text = reading_assembly_mod.assemble(
+            segments=committed_segments, sidecar=sc, info=info
+        )
+        dest = wiki_repo / "sources" / source_id / "reading.md"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        reading_mod.write(dest, text)
+        result.wiki_reading_path = dest
+        _logger.info("reading_review: gate fired; wrote %s", dest)
+
+    return result
+
+
+def _build_view(
+    sf: SegmentFile,
+    idx: int,
+    total: int,
+    pending_marks: dict[str, str],
+    info: info_yaml_mod.Info,
+) -> SegmentView:
+    """Build a SegmentView for the given segment."""
+    fm = sf.frontmatter
+    return SegmentView(
+        segment_index=idx,
+        segment_total=total,
+        segment_id=fm.segment_id,
+        title=fm.title,
+        start=fm.start,
+        end=fm.end,
+        speaker=fm.speaker,
+        current_status=fm.segment_status,
+        pending_mark=pending_marks.get(fm.segment_id),
+        bullets_preview=sf.body[:200],
+        source_url=info.source_url,
+        source_title=info.title,
+    )

--- a/src/auto_lorebook/segment_file.py
+++ b/src/auto_lorebook/segment_file.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 _MAX_SCHEMA = 1
 _FRONTMATTER_RE = re.compile(r"^---\n(?P<fm>.*?)\n---\n(?P<rest>.*)$", re.DOTALL)
 
-VALID_STATUSES = frozenset({"draft", "approved"})
+VALID_STATUSES = frozenset({"draft", "accepted", "skipped", "regenerating"})
 
 
 class SegmentFileError(ValueError):

--- a/tests/test_reading.py
+++ b/tests/test_reading.py
@@ -1,4 +1,4 @@
-"""Tests for reading.py — frontmatter helpers (linkify, apply, read, set_status, write).
+"""Tests for reading.py — frontmatter helpers (linkify, apply, read, write).
 
 Assembly tests live in test_reading_assembly.py.
 """
@@ -14,7 +14,6 @@ from auto_lorebook.reading import (
     apply_name_corrections,
     linkify_timestamp,
     read_frontmatter,
-    set_status,
     write,
 )
 
@@ -26,7 +25,6 @@ _SAMPLE_READING_MD = """\
 ---
 schema_version: 1
 source_id: yt-abc12345678
-reading_status: draft
 ---
 # Reading: Session 3
 
@@ -74,7 +72,6 @@ class TestWriteReadFrontmatter:
         write(path, _SAMPLE_READING_MD)
         fm = read_frontmatter(path)
         assert fm["source_id"] == "yt-abc12345678"
-        assert fm["reading_status"] == "draft"
 
     def test_read_frontmatter_missing_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ReadingError):
@@ -85,16 +82,3 @@ class TestWriteReadFrontmatter:
         path.write_text("no frontmatter here", encoding="utf-8")
         with pytest.raises(ReadingError):
             read_frontmatter(path)
-
-    def test_set_status_flip_to_approved(self, tmp_path: Path) -> None:
-        path = tmp_path / "reading.md"
-        write(path, _SAMPLE_READING_MD)
-        set_status(path, "approved")
-        fm = read_frontmatter(path)
-        assert fm["reading_status"] == "approved"
-
-    def test_set_status_rejects_bad_value(self, tmp_path: Path) -> None:
-        path = tmp_path / "reading.md"
-        write(path, _SAMPLE_READING_MD)
-        with pytest.raises(ReadingError):
-            set_status(path, "published")

--- a/tests/test_reading_assembly.py
+++ b/tests/test_reading_assembly.py
@@ -14,8 +14,7 @@ from tests._reading_fixtures import (
 )
 
 # Golden bytes: assembled output that the new assemble() must produce.
-# Derived from the legacy reading.assemble() output, with reading_status: approved
-# (legacy produced draft; wiki-side always approved).
+# No reading_status key — file presence is the approval gate.
 _GOLDEN = (
     "---\n"
     "schema_version: 1\n"
@@ -25,7 +24,6 @@ _GOLDEN = (
     "source_type: youtube\n"
     "session_date: null\n"
     "ingested_at: '2026-04-20T14:35:12Z'\n"
-    "reading_status: approved\n"
     "default_speaker: DM\n"
     "name_corrections: {}\n"
     "---\n"
@@ -67,10 +65,9 @@ class TestGoldenByteMatch:
         result = assemble(segments=_segment_files(), sidecar=_sidecar(), info=_info())
         assert result == _GOLDEN
 
-    def test_always_approved_status(self) -> None:
+    def test_no_reading_status_key(self) -> None:
         result = assemble(segments=_segment_files(), sidecar=_sidecar(), info=_info())
-        assert "reading_status: approved" in result
-        assert "reading_status: draft" not in result
+        assert "reading_status" not in result
 
 
 class TestNoSourceUrl:
@@ -130,14 +127,14 @@ class TestEmptySegmentMarker:
 
 
 class TestSegmentStatusIgnored:
-    def test_approved_segment_still_assembled(self) -> None:
+    def test_accepted_segment_still_assembled(self) -> None:
         segs = _segment_files()
-        # flip one to approved — should not affect output
+        # flip one to accepted — should not affect output
         sf = segs[0]
-        approved_sf = SegmentFile(
+        accepted_sf = SegmentFile(
             frontmatter=SegmentFrontmatter(
                 segment_id=sf.frontmatter.segment_id,
-                segment_status="approved",
+                segment_status="accepted",
                 start=sf.frontmatter.start,
                 end=sf.frontmatter.end,
                 title=sf.frontmatter.title,
@@ -146,12 +143,12 @@ class TestSegmentStatusIgnored:
             body=sf.body,
         )
         result = assemble(
-            segments=[approved_sf, segs[1], segs[2]],
+            segments=[accepted_sf, segs[1], segs[2]],
             sidecar=_sidecar(),
             info=_info(),
         )
         assert "Introduction" in result
-        assert "reading_status: approved" in result
+        assert "reading_status" not in result
 
 
 class TestPureNoFilesystem:

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -304,7 +304,8 @@ class TestApproveReading:
         assert rc == 0
         approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
         assert approved.exists()
-        assert "reading_status: approved" in approved.read_text(encoding="utf-8")
+        assert "# Reading: Session 3" in approved.read_text(encoding="utf-8")
+        assert "reading_status" not in approved.read_text(encoding="utf-8")
         # approve-reading must NOT cascade into plan/extract
         assert not (tmp_home / "pending" / "yt-abc12345678" / "plan.yaml").exists()
         assert not (tmp_home / "pending" / "yt-abc12345678" / "proposals").exists()
@@ -367,7 +368,8 @@ class TestApproveReadingInteractive:
         assert len(prompts) >= 1
         approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
         assert approved.exists()
-        assert "reading_status: approved" in approved.read_text(encoding="utf-8")
+        assert "# Reading: Session 3" in approved.read_text(encoding="utf-8")
+        assert "reading_status" not in approved.read_text(encoding="utf-8")
         # approve-reading no longer cascades into plan/extract
         assert not (tmp_home / "pending" / "yt-abc12345678" / "plan.yaml").exists()
 
@@ -496,7 +498,8 @@ class TestApproveReadingInteractive:
         assert rc == 0
         approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
         assert approved.exists()
-        assert "reading_status: approved" in approved.read_text(encoding="utf-8")
+        assert "# Reading: Session 3" in approved.read_text(encoding="utf-8")
+        assert "reading_status" not in approved.read_text(encoding="utf-8")
 
     def test_undo_restores_segment_files(
         self,
@@ -520,7 +523,7 @@ class TestApproveReadingInteractive:
 
         corrupted = (
             b"---\nschema_version: 1\nsegment_id: seg-001\n"
-            b"segment_status: approved\nstart: '0:00:00'\nend: '0:02:00'\n"
+            b"segment_status: accepted\nstart: '0:00:00'\nend: '0:02:00'\n"
             b"title: CORRUPTED\nspeaker: DM\nnotes: null\noverrides: []\n"
             b"---\nCORRUPTED BODY\n"
         )

--- a/tests/test_reading_review.py
+++ b/tests/test_reading_review.py
@@ -1,0 +1,402 @@
+"""Tests for reading_review.py — reading review engine + Reviewer protocol."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook import reading_pipeline as pipeline
+from auto_lorebook import segment_file as segment_file_mod
+from auto_lorebook.commands.approve_reading import AutoAcceptReviewer
+from auto_lorebook.reading_review import (
+    AcceptDecision,
+    CommitDecision,
+    RegenerateAgainDecision,
+    SegmentView,
+    SkipBulletsDecision,
+    UndoDecision,
+    run,
+)
+from tests._reading_fixtures import _info, _segment_files, _sidecar
+from tests.test_reading_commands import _SRT, _wire_client_responses
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+_SOURCE_ID = "yt-abc12345678"
+_EMPTY_MARKER = "_No claims extracted from this segment._"
+
+# ---------------------------------------------------------------------------
+# Setup helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_info(wiki: Path) -> None:
+    src = wiki / "sources" / _SOURCE_ID
+    src.mkdir(parents=True, exist_ok=True)
+    info = _info()
+    (src / "info.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "source_id": info.source_id,
+                "source_type": info.source_type,
+                "source_url": info.source_url,
+                "title": info.title,
+                "duration_seconds": info.duration_seconds,
+                "fetched_at": info.fetched_at,
+                "session_date": None,
+                "transcript_filename": info.transcript_filename,
+                "caption_type": "manual",
+                "context": {
+                    "perspective": None,
+                    "source_nature": None,
+                    "setting": None,
+                    "speakers": [],
+                    "notes": None,
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_pending() -> None:
+    """Write sidecar + three segment files under pending."""
+    sc = _sidecar()
+    sidecar_path = pipeline.pending_sidecar_path(_SOURCE_ID)
+    sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+    sidecar_path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "default_speaker": sc.default_speaker,
+                "name_corrections": sc.name_corrections,
+                "session_date": sc.session_date,
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    segs_dir = pipeline.pending_segments_dir(_SOURCE_ID)
+    segs_dir.mkdir(parents=True, exist_ok=True)
+    for sf in _segment_files():
+        segment_file_mod.write(sf, segs_dir / f"{sf.frontmatter.segment_id}.md")
+
+
+@pytest.fixture
+def env(
+    tmp_path: Path,
+    tmp_wiki: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[cfg_mod.Config, Path]:
+    """Write info.yaml and pending segment files; return (cfg, wiki)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    cfg = cfg_mod.Config(wiki_repo_path=tmp_wiki)
+    _write_info(tmp_wiki)
+    _write_pending()
+    return cfg, tmp_wiki
+
+
+# ---------------------------------------------------------------------------
+# Scripted reviewer
+# ---------------------------------------------------------------------------
+
+_DEFAULT_COMMIT = CommitDecision()
+
+_DecisionList = list[
+    AcceptDecision | SkipBulletsDecision | RegenerateAgainDecision | UndoDecision
+]
+
+
+class ScriptedReviewer:
+    """Feeds a pre-defined list of decisions; commit is configurable."""
+
+    by_label = "scripted"
+
+    def __init__(
+        self,
+        decisions: _DecisionList,
+        *,
+        abort: bool = False,
+    ) -> None:
+        self._decisions = list(decisions)
+        self._commit: CommitDecision | None = None if abort else _DEFAULT_COMMIT
+        self._idx = 0
+
+    def decide_segment(
+        self,
+        view: SegmentView,  # noqa: ARG002
+    ) -> AcceptDecision | SkipBulletsDecision | RegenerateAgainDecision | UndoDecision:
+        decision = self._decisions[self._idx]
+        self._idx += 1
+        return decision
+
+    def decide_quit(
+        self,
+        pending: tuple[SegmentView, ...],  # noqa: ARG002
+    ) -> CommitDecision | None:
+        return self._commit
+
+
+def _scripted(
+    decisions: _DecisionList,
+    *,
+    abort: bool = False,
+) -> ScriptedReviewer:
+    """Build a ScriptedReviewer; pass abort=True to make decide_quit return None."""
+    return ScriptedReviewer(decisions, abort=abort)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptAll:
+    def test_fires_gate_and_writes_wiki_reading(
+        self, env: tuple[cfg_mod.Config, Path]
+    ) -> None:
+        cfg, _ = env
+        reviewer = _scripted([AcceptDecision(), AcceptDecision(), AcceptDecision()])
+        result = run(cfg=cfg, source_id=_SOURCE_ID, reviewer=reviewer)
+
+        assert result.gate_fired is True
+        assert result.wiki_reading_path is not None
+        assert result.wiki_reading_path.exists()
+        assert result.accepted == 3
+        assert result.skipped == 0
+        assert result.regenerating == 0
+        # segment files on disk show accepted
+        segs_dir = pipeline.pending_segments_dir(_SOURCE_ID)
+        for sf_path in sorted(segs_dir.glob("*.md")):
+            sf = segment_file_mod.read(sf_path)
+            assert sf.frontmatter.segment_status == "accepted"
+        # wiki reading.md has expected content
+        text = result.wiki_reading_path.read_text(encoding="utf-8")
+        assert "# Reading: Session 3" in text
+        assert "reading_status" not in text
+
+
+class TestSkipBullets:
+    def test_empty_marker_rendered_in_assembly(
+        self, env: tuple[cfg_mod.Config, Path]
+    ) -> None:
+        cfg, _ = env
+        reviewer = _scripted([
+            AcceptDecision(),
+            SkipBulletsDecision(),
+            AcceptDecision(),
+        ])
+        result = run(cfg=cfg, source_id=_SOURCE_ID, reviewer=reviewer)
+
+        assert result.gate_fired is True
+        assert result.skipped == 1
+        assert result.accepted == 2
+
+        # seg-002 on disk: body is the empty-bullets marker
+        seg002_path = pipeline.pending_segment_path(_SOURCE_ID, "seg-002")
+        sf002 = segment_file_mod.read(seg002_path)
+        assert sf002.frontmatter.segment_status == "skipped"
+        assert _EMPTY_MARKER in sf002.body
+
+        # assembled wiki reading contains the marker for seg-002
+        assert result.wiki_reading_path is not None
+        text = result.wiki_reading_path.read_text(encoding="utf-8")
+        assert _EMPTY_MARKER in text
+
+
+class TestRegeneratingBlocksGate:
+    def test_gate_does_not_fire(self, env: tuple[cfg_mod.Config, Path]) -> None:
+        cfg, _ = env
+        reviewer = _scripted([
+            AcceptDecision(),
+            RegenerateAgainDecision(),
+            AcceptDecision(),
+        ])
+        result = run(cfg=cfg, source_id=_SOURCE_ID, reviewer=reviewer)
+
+        assert result.gate_fired is False
+        assert result.wiki_reading_path is None
+        assert result.regenerating == 1
+
+        seg002_path = pipeline.pending_segment_path(_SOURCE_ID, "seg-002")
+        sf002 = segment_file_mod.read(seg002_path)
+        assert sf002.frontmatter.segment_status == "regenerating"
+
+        seg001_path = pipeline.pending_segment_path(_SOURCE_ID, "seg-001")
+        sf001 = segment_file_mod.read(seg001_path)
+        assert sf001.frontmatter.segment_status == "accepted"
+
+
+class TestUndoSegmentScoped:
+    def test_undo_clears_one_segment_only(
+        self, env: tuple[cfg_mod.Config, Path]
+    ) -> None:
+        cfg, _ = env
+        # UndoDecision for seg-002's slot — its pending mark is cleared
+        reviewer = _scripted([AcceptDecision(), UndoDecision(), AcceptDecision()])
+        result = run(cfg=cfg, source_id=_SOURCE_ID, reviewer=reviewer)
+
+        # seg-002 stays draft (no pending mark → unchanged → disk not touched)
+        seg002_path = pipeline.pending_segment_path(_SOURCE_ID, "seg-002")
+        sf002 = segment_file_mod.read(seg002_path)
+        assert sf002.frontmatter.segment_status == "draft"
+
+        # gate does not fire — seg-002 still draft
+        assert result.gate_fired is False
+        assert result.accepted == 2
+        assert result.unchanged == 1
+
+        for sid in ("seg-001", "seg-003"):
+            sf = segment_file_mod.read(pipeline.pending_segment_path(_SOURCE_ID, sid))
+            assert sf.frontmatter.segment_status == "accepted"
+
+
+class TestEngineWritesNothingUntilCommit:
+    def test_disk_unchanged_during_walk(self, env: tuple[cfg_mod.Config, Path]) -> None:
+        cfg, _ = env
+        segs_dir = pipeline.pending_segments_dir(_SOURCE_ID)
+
+        snapshots_before = {p: p.read_bytes() for p in sorted(segs_dir.glob("*.md"))}
+        snapshots_mid: dict[Path, bytes] = {}
+        captured = False
+
+        class SnapshotReviewer:
+            by_label = "snapshot"
+
+            def decide_segment(
+                self,
+                view: SegmentView,  # noqa: ARG002
+            ) -> AcceptDecision:
+                return AcceptDecision()
+
+            def decide_quit(
+                self,
+                pending: tuple[SegmentView, ...],  # noqa: ARG002
+            ) -> CommitDecision:
+                nonlocal snapshots_mid, captured
+                snapshots_mid = {
+                    p: p.read_bytes() for p in sorted(segs_dir.glob("*.md"))
+                }
+                captured = True
+                return CommitDecision()
+
+        run(cfg=cfg, source_id=_SOURCE_ID, reviewer=SnapshotReviewer())
+        assert captured
+        assert snapshots_mid == snapshots_before
+
+
+class TestAbortOnNoneCommit:
+    def test_no_files_written_when_quit_returns_none(
+        self, env: tuple[cfg_mod.Config, Path]
+    ) -> None:
+        cfg, tmp_wiki = env
+        reviewer = _scripted(
+            [AcceptDecision(), AcceptDecision(), AcceptDecision()], abort=True
+        )
+        result = run(cfg=cfg, source_id=_SOURCE_ID, reviewer=reviewer)
+
+        assert result.gate_fired is False
+        assert result.wiki_reading_path is None
+        assert not (tmp_wiki / "sources" / _SOURCE_ID / "reading.md").exists()
+        segs_dir = pipeline.pending_segments_dir(_SOURCE_ID)
+        for sf_path in sorted(segs_dir.glob("*.md")):
+            sf = segment_file_mod.read(sf_path)
+            assert sf.frontmatter.segment_status == "draft"
+
+
+class TestYesShortcut:
+    def test_auto_accept_reviewer_fires_gate(
+        self, env: tuple[cfg_mod.Config, Path]
+    ) -> None:
+        cfg, _ = env
+        result = run(cfg=cfg, source_id=_SOURCE_ID, reviewer=AutoAcceptReviewer())
+
+        assert result.gate_fired is True
+        assert result.wiki_reading_path is not None
+        assert result.wiki_reading_path.exists()
+        text = result.wiki_reading_path.read_text(encoding="utf-8")
+        assert "# Reading: Session 3" in text
+        assert "reading_status" not in text
+
+    def test_pipeline_approve_uses_auto_accept(
+        self,
+        tmp_path: Path,
+        tmp_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """reading_pipeline.approve → AutoAcceptReviewer chain e2e."""
+        from auto_lorebook.commands import (  # noqa: PLC0415
+            approve_reading as approve_reading_cmd,
+        )
+        from auto_lorebook.commands import (  # noqa: PLC0415
+            generate_reading as generate_reading_cmd,
+        )
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+        (home / "config.yaml").write_text(
+            f"schema_version: 1\nwiki_repo_path: {tmp_wiki}\n"
+            "openrouter:\n  api_key_env: FAKE_OR_KEY\n"
+            "models:\n  primary: anthropic/claude-sonnet-4-5\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        src_dir = tmp_wiki / "sources" / _SOURCE_ID
+        src_dir.mkdir(parents=True, exist_ok=True)
+        (src_dir / "transcript.en.srt").write_text(_SRT, encoding="utf-8")
+        _write_info(tmp_wiki)
+
+        client = MagicMock()
+        _wire_client_responses(client)
+
+        def _args(**kwargs: object) -> argparse.Namespace:
+            return argparse.Namespace(**kwargs)
+
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id=_SOURCE_ID))
+            rc = approve_reading_cmd.run(_args(source_id=_SOURCE_ID, yes=True))
+
+        assert rc == 0
+        approved = tmp_wiki / "sources" / _SOURCE_ID / "reading.md"
+        assert approved.exists()
+        text = approved.read_text(encoding="utf-8")
+        assert "# Reading:" in text
+        assert "reading_status" not in text
+
+
+class TestPureNoInputOrPrint:
+    def test_engine_module_has_no_input_or_print(self) -> None:
+        """reading_review.py must have no input() or print() calls."""
+        import ast  # noqa: PLC0415
+
+        src = (
+            Path(__file__).resolve().parent.parent
+            / "src"
+            / "auto_lorebook"
+            / "reading_review.py"
+        )
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Name) and func.id in {"input", "print"}:
+                    msg = (
+                        f"reading_review.py calls {func.id}() at line {node.lineno}"
+                        " — engine must be pure-logic (no I/O)"
+                    )
+                    raise AssertionError(msg)

--- a/tests/test_seed_ingest_cmd.py
+++ b/tests/test_seed_ingest_cmd.py
@@ -144,7 +144,7 @@ class TestSeedIngestPerStage:
         approved_path = tmp_wiki / "sources" / sid / "reading.md"
         fm = reading.read_frontmatter(approved_path)
         assert fm["source_id"] == sid
-        assert fm["reading_status"] == "approved"
+        assert "reading_status" not in fm
 
         sidecar = reading_sidecar_mod.read(
             tmp_home / "pending" / sid / "reading" / "reading.yaml"

--- a/tests/test_segment_file.py
+++ b/tests/test_segment_file.py
@@ -111,12 +111,12 @@ class TestDefaultStatusDraft:
 
 
 class TestSetStatus:
-    def test_set_status_flips_to_approved(self, tmp_path: Path) -> None:
+    def test_set_status_flips_to_accepted(self, tmp_path: Path) -> None:
         p = tmp_path / "seg-001.md"
         write(_sf(), p)
-        set_status(p, "approved")
+        set_status(p, "accepted")
         loaded = read(p)
-        assert loaded.frontmatter.segment_status == "approved"
+        assert loaded.frontmatter.segment_status == "accepted"
 
     def test_set_status_rejects_unknown(self, tmp_path: Path) -> None:
         p = tmp_path / "seg-001.md"
@@ -127,8 +127,8 @@ class TestSetStatus:
     def test_with_status_returns_new_text(self, tmp_path: Path) -> None:
         p = tmp_path / "seg-001.md"
         write(_sf(), p)
-        new_text = with_status(p, "approved")
-        assert "segment_status: approved" in new_text
+        new_text = with_status(p, "accepted")
+        assert "segment_status: accepted" in new_text
         # Original file unchanged
         loaded = read(p)
         assert loaded.frontmatter.segment_status == "draft"


### PR DESCRIPTION
### What this fixes

Introduces the per-segment Reading Review state machine that issue #30 calls for, mirroring the existing `review.py` + `Reviewer` protocol pattern used elsewhere in the project.

The new `src/auto_lorebook/reading_review.py` module is a pure-logic engine: it loads pending segments, walks them through a scripted `Reviewer` (Protocol), accumulates per-segment pending marks (`accept` / `skip-bullets` / `regenerate-again` / `undo`) entirely in memory, and only writes anything to disk when `decide_quit` returns a `CommitDecision`. The commit is one transaction: each segment with a pending mark is persisted via `segment_file.write` / `set_status`; for `skipped` segments the body is rewritten to the empty-bullets marker so wiki-side assembly emits the correct stub.

Approval is now derived. The gate-crossing predicate is "every segment is `accepted` or `skipped`". When commit fires the predicate, the engine invokes `reading_assembly.assemble(...)` and writes the wiki-side `reading.md`. The top-level `reading_status` frontmatter flag is removed everywhere — the presence of the wiki-side file is the gate. `reading_pipeline.plan()` now checks file presence instead of the flag, and `reading.with_status` / `set_status` are deleted.

`approve-reading --yes` runs through a new `AutoAcceptReviewer` (in `commands/approve_reading.py`) that marks every still-`draft` segment `accepted` and commits unconditionally. The interactive (non-`--yes`) path is intentionally left at the slice-#29 atomic UX — the hierarchical UX is slice #4.

Status vocabulary in `segment_file.VALID_STATUSES` is tightened from `{draft, approved}` to `{draft, accepted, skipped, regenerating}`.

### QA steps for the human

None — fully covered by the integration smoke. Live exercise on the `tiny-aldara` QA fixture:

1. `auto-lorebook seed-ingest --at approve` → produces `qa-8c3606c1`.
2. `auto-lorebook approve-reading --yes qa-8c3606c1` → wiki-side `reading.md` written (no `reading_status:` in frontmatter); both pending segment files flipped from `segment_status: draft` to `segment_status: accepted`.
3. Re-running `approve-reading --yes` on the already-approved source is idempotent.

### Automated coverage

`uv run ruff check` · `uv run ruff format --check` · `uv run ty check` · `uv run pytest` (530 passed, 4 skipped) · `uv run mkdocs build --strict` — all green on commit `b85a3b7`.

Closes #30

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dd8X9diYs3K1xiTf8xWzjx)_