### PR TITLE
Hierarchical interactive UX for approve-reading (no regenerate-again yet)

### DIFF
--- a/docs/pipeline/reading.md
+++ b/docs/pipeline/reading.md
@@ -283,10 +283,14 @@ gate fires, `reading_assembly.assemble` renders the wiki-side
 file is the approval artefact — there is no `reading_status`
 frontmatter flag.
 
-**Decision verbs (current slice):** `accept`, `skip-bullets`,
-`regenerate-again` (no-op; marks as `regenerating`, gate blocks),
-`undo` (clears the pending mark for one segment), `commit` (the quit
-path that writes and evaluates the gate).
+**Decision verbs:** `accept`, `skip-bullets`,
+`regenerate-again` (deferred — slice #5; no-op in current implementation;
+marks segment as `regenerating`, which blocks the gate),
+`undo` (clears the pending mark for one segment), `commit` (the quit path
+that writes and evaluates the gate).
+
+All committed status changes are produced by the reading-review engine; the
+command layer only translates keystrokes into engine decisions.
 
 ```bash
 auto-lorebook approve-reading <source_id> --yes
@@ -296,23 +300,36 @@ auto-lorebook approve-reading <source_id> --yes
 segment `accepted` and commits unconditionally. The gate always fires
 for fixtures where every segment is decidable.
 
-The interactive per-segment hierarchical UX (keys `[a]/[s]/[r]/[u]/[q]`
-per segment) is deferred to slice #4. In the current slice, the
-interactive `[a]` key at the session level still assembles and copies
-to the wiki in one step (unchanged from slice #29).
+`approve-reading` opens a hierarchical interactive session over the draft.
 
-`approve-reading` opens an interactive session over the draft:
+**Outer view** — numbered list of all segments with their current status and
+any pending mark for the session:
 
 | Key | Action |
 |-----|--------|
-| `a` | Approve: assemble segment files + sidecar into `reading.md`, copy to wiki. |
-| `e` | Preview: assemble draft into a temp file and open in `$EDITOR`. Edits are discarded on exit (preview-only; per-segment editing lands in a future slice). |
-| `r` | Reject: queue the pending reading dir for deletion. Deferred — nothing happens until you `q`. |
-| `u` | Undo: restore all segment files and sidecar to session-start contents and clear any queued reject. |
-| `q` | Quit: if a reject is queued, confirm and delete `pending/<id>/reading/`; otherwise no-op. |
+| `#` | Open the numbered segment in the per-segment prompt. |
+| `n` | Jump to the next undecided `draft` segment. |
+| `m` | Open `reading.yaml` (sidecar) in `$EDITOR`. |
+| `q` | Commit pending marks. If every segment is now decided, write wiki-side `reading.md` (gate fires). |
+
+**Per-segment prompt** — shows segment body (up to 60 lines) and current /
+pending status:
+
+| Key | Action |
+|-----|--------|
+| `a` | Accept: queue this segment for `accepted` status; return to outer. |
+| `s` | Skip-bullets: queue this segment for `skipped` status; return to outer. |
+| `e` | Edit: open the segment file (`seg-NNN.md`) in `$EDITOR`. Stays in per-segment prompt on return. |
+| `u` | Undo: clear this segment's pending mark. Stays in per-segment prompt. |
+| `b` | Back: return to outer without changing any pending mark. |
+
+Pending marks live in memory until `[q]`. On `[q]`, the engine commits
+all marks in one transaction and evaluates the gate. Ctrl-C at any
+prompt exits 130 with no committed mutations; pending marks are not
+persisted.
 
 `--yes` skips the loop and auto-approves; required for non-TTY runs
-(scripts, CI). Ctrl-C exits 130 with no changes.
+(scripts, CI).
 
 After approval, the reading is committed to the wiki alongside the
 raw transcript. The intermediate `structure.yaml` is retained in the

--- a/src/auto_lorebook/commands/approve_reading.py
+++ b/src/auto_lorebook/commands/approve_reading.py
@@ -4,35 +4,40 @@ from __future__ import annotations
 
 import logging
 import os
-import shutil
 import subprocess  # noqa: S404
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from auto_lorebook import config as cfg_mod
+from auto_lorebook import info_yaml as info_yaml_mod
 from auto_lorebook import reading_pipeline as pipeline
+from auto_lorebook import segment_file as segment_file_mod
 from auto_lorebook.interactive import _is_interactive
 from auto_lorebook.reading_review import (
     AcceptDecision,
     CommitDecision,
     SegmentView,
+    SkipBulletsDecision,
     UndoDecision,
 )
+from auto_lorebook.timestamps import format_timestamp
 
 if TYPE_CHECKING:
     import argparse
+    from pathlib import Path
 
     from auto_lorebook.reading_review import SegmentDecision
 
 _logger = logging.getLogger(__name__)
 
-_PROMPT = "[a]pprove / [e]dit / [r]eject / [u]ndo / [q]uit > "
+_OUTER_PROMPT = "[#] open  [n] next-draft  [m] meta  [q] quit\n> "
+_SEG_PROMPT = "[a] accept  [e] edit  [s] skip-bullets  [u] undo  [b] back\n> "
 
 
 class AutoAcceptReviewer:
     """Marks every still-draft segment accepted, then commits unconditionally.
 
     Used by `--yes` (non-interactive) path and `reading_pipeline.approve`.
-    Interactive hierarchical UX lands in slice #4.
     """
 
     by_label = "auto-accept"
@@ -50,7 +55,40 @@ class AutoAcceptReviewer:
         return CommitDecision()
 
 
-_RENDER_LINES = 40
+@dataclass
+class _SegSummary:
+    """Flat summary for outer list view."""
+
+    segment_id: str
+    title: str
+    start: float
+    end: float
+    speaker: str
+    current_status: str  # disk truth: draft|accepted|skipped|regenerating
+
+
+# keyed by segment_id; value in {"accepted","skipped"}
+_PendingMarks = dict[str, str]
+
+
+class _ReplayReviewer:
+    """Drives engine with pre-recorded per-segment decisions."""
+
+    by_label = "interactive"
+
+    def __init__(self, marks: _PendingMarks) -> None:
+        self._marks = dict(marks)
+
+    def decide_segment(self, view: SegmentView) -> SegmentDecision:
+        mark = self._marks.get(view.segment_id)
+        if mark == "accepted":
+            return AcceptDecision()
+        if mark == "skipped":
+            return SkipBulletsDecision()
+        return UndoDecision()
+
+    def decide_quit(self, pending: tuple[SegmentView, ...]) -> CommitDecision:  # noqa: ARG002
+        return CommitDecision()
 
 
 def add_parser(
@@ -61,15 +99,16 @@ def add_parser(
     parser = subparsers.add_parser(
         "approve-reading",
         parents=[common_parser],
-        help="Interactively approve, edit, or reject the draft reading",
+        help="Interactively approve or skip draft reading segments",
         description=(
-            "Opens an interactive session over the draft reading under "
-            "~/.auto-lorebook/pending/<source_id>/reading/. Keys: "
-            "[a]pprove (assemble + copy to wiki), "
-            "[e]dit (preview assembled draft in $EDITOR — preview only), "
-            "[r]eject (queue pending dir for delete), "
-            "[u]ndo (restore to session start, clear reject), "
-            "[q]uit (commit a queued reject after confirmation, else no-op). "
+            "Opens a hierarchical interactive session over the draft reading. "
+            "Outer view: numbered segment list with status; "
+            "keys [#] (open segment N), [n] (next draft), "
+            "[m] (open reading.yaml in $EDITOR), "
+            "[q] (commit pending marks; if every segment is decided, "
+            "write wiki-side reading.md). "
+            "Per-segment prompt: [a] accept, [e] edit body in $EDITOR, "
+            "[s] skip-bullets, [u] undo this segment, [b] back. "
             "Pass --yes to skip the loop and auto-approve."
         ),
     )
@@ -114,6 +153,178 @@ def _approve_only(cfg: cfg_mod.Config, source_id: str) -> int:
     return 0
 
 
+def _load_summaries(source_id: str) -> list[_SegSummary]:
+    """Load frontmatter from all seg-NNN.md files, sorted by filename."""
+    segs_dir = pipeline.pending_segments_dir(source_id)
+    if not segs_dir.exists():
+        return []
+    paths = sorted(segs_dir.glob("*.md"))
+    out = []
+    for p in paths:
+        sf = segment_file_mod.read(p)
+        fm = sf.frontmatter
+        out.append(
+            _SegSummary(
+                segment_id=fm.segment_id,
+                title=fm.title,
+                start=fm.start,
+                end=fm.end,
+                speaker=fm.speaker,
+                current_status=fm.segment_status,
+            )
+        )
+    return out
+
+
+def _render_outer(
+    source_id: str,
+    summaries: list[_SegSummary],
+    pending_marks: _PendingMarks,
+    source_title: str | None,
+) -> None:
+    title_str = source_title or source_id
+    print(f"\nReading: {source_id} — {title_str}")  # noqa: T201
+    for i, s in enumerate(summaries, start=1):
+        start_ts = format_timestamp(s.start)
+        end_ts = format_timestamp(s.end)
+        mark = pending_marks.get(s.segment_id)
+        arrow = f" →{mark}" if mark else ""
+        print(  # noqa: T201
+            f"  {i:>3}. [{s.current_status}]  {start_ts}–{end_ts}  "  # noqa: RUF001
+            f"{s.title}  ({s.speaker}){arrow}"
+        )
+    print(_OUTER_PROMPT, end="", flush=True)  # noqa: T201
+
+
+def _render_segment(
+    summary: _SegSummary,
+    pending_mark: str | None,
+    body: str,
+) -> None:
+    start_ts = format_timestamp(summary.start)
+    end_ts = format_timestamp(summary.end)
+    pending_str = pending_mark or "?"
+    print(  # noqa: T201
+        f"\n{summary.segment_id} "
+        f"[{summary.current_status} → {pending_str}]  "
+        f"{start_ts}–{end_ts}  {summary.title}  ({summary.speaker})"  # noqa: RUF001
+    )
+    lines = body.splitlines()
+    limit = 60
+    if len(lines) <= limit:
+        print(body)  # noqa: T201
+    else:
+        print("\n".join(lines[:limit]))  # noqa: T201
+        print(f"... ({len(lines) - limit} more lines)")  # noqa: T201
+    print(_SEG_PROMPT, end="", flush=True)  # noqa: T201
+
+
+def _open_in_editor(path: Path) -> None:
+    editor = os.environ.get("EDITOR", "vi")
+    subprocess.run([editor, str(path)], check=False)  # noqa: S603
+
+
+def _pick_segment_index(raw: str, total: int) -> int | None:
+    """Parse 1-based digit string → 0-based index, or None if out of range."""
+    if not raw.isdigit():
+        return None
+    one_based = int(raw)
+    if 1 <= one_based <= total:
+        return one_based - 1
+    return None
+
+
+def _next_draft_index(
+    summaries: list[_SegSummary],
+    pending_marks: _PendingMarks,
+    start_at: int = 0,
+) -> int | None:
+    """First index ≥ start_at that is draft and not yet pending; wraps once."""
+    n = len(summaries)
+    for offset in range(n):
+        idx = (start_at + offset) % n
+        s = summaries[idx]
+        if s.current_status == "draft" and s.segment_id not in pending_marks:
+            return idx
+    return None
+
+
+def _per_segment_prompt(
+    source_id: str,
+    idx: int,
+    summaries: list[_SegSummary],
+    pending_marks: _PendingMarks,
+) -> None:
+    """Inner per-segment loop; mutates pending_marks in place."""
+    summary = summaries[idx]
+    sid = summary.segment_id
+
+    while True:
+        # re-read body each iteration so edits show
+        seg_path = pipeline.pending_segment_path(source_id, sid)
+        sf = segment_file_mod.read(seg_path)
+        _render_segment(summary, pending_marks.get(sid), sf.body)
+
+        try:
+            choice = input("").strip().lower()
+        except EOFError:
+            return
+        # KeyboardInterrupt propagates to outer
+
+        if choice == "a":
+            pending_marks[sid] = "accepted"
+            return
+        if choice == "s":
+            pending_marks[sid] = "skipped"
+            return
+        if choice == "e":
+            _open_in_editor(pipeline.pending_segment_path(source_id, sid))
+            # reload summary so edits show (status might have changed externally)
+            summaries[idx] = _load_summaries(source_id)[idx]
+            summary = summaries[idx]
+        elif choice == "u":
+            pending_marks.pop(sid, None)
+            # stay in segment prompt
+        elif choice == "b":
+            return
+        # unrecognized → re-prompt
+
+
+def _open_meta(source_id: str) -> None:
+    _open_in_editor(pipeline.pending_sidecar_path(source_id))
+
+
+def _commit_and_exit(
+    cfg: cfg_mod.Config,
+    source_id: str,
+    pending_marks: _PendingMarks,
+) -> int:
+    from auto_lorebook import reading_review as reading_review_mod  # noqa: PLC0415
+
+    try:
+        result = reading_review_mod.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=_ReplayReviewer(pending_marks),
+        )
+    except reading_review_mod.ReadingReviewError as e:
+        _logger.error("%s", e)
+        return 1
+
+    if result.gate_fired and result.wiki_reading_path is not None:
+        print(f"Approved: {result.wiki_reading_path}")  # noqa: T201
+        print(f"Run `auto-lorebook plan {source_id}` next.")  # noqa: T201
+        return 0
+
+    remaining = sum(
+        1
+        for s in _load_summaries(source_id)
+        if s.current_status not in {"accepted", "skipped"}
+    )
+    print(f"Still {remaining} undecided; pending marks committed for the rest.")  # noqa: T201
+    return 0
+
+
 def _interactive_session(cfg: cfg_mod.Config, source_id: str) -> int:
     sidecar_path = pipeline.pending_sidecar_path(source_id)
     if not sidecar_path.exists():
@@ -122,110 +333,52 @@ def _interactive_session(cfg: cfg_mod.Config, source_id: str) -> int:
         )
         return 1
 
-    # snapshot all segment files + sidecar at session start for [u]ndo
-    snapshot = _take_snapshot(source_id)
-    pending_action = "none"
+    # load source title for header
+    source_title: str | None = None
+    try:
+        info_path = cfg.wiki_repo_path / "sources" / source_id / "info.yaml"
+        info = info_yaml_mod.read(info_path)
+        source_title = info.title
+    except info_yaml_mod.InfoError:
+        pass
+
+    summaries = _load_summaries(source_id)
+    pending_marks: _PendingMarks = {}
 
     while True:
-        _render(cfg, source_id, pending_action)
+        _render_outer(source_id, summaries, pending_marks, source_title)
+
         try:
-            choice = input(_PROMPT).strip().lower()
+            choice = input("").strip().lower()
         except EOFError:
-            print()  # noqa: T201
-            return _commit_quit(source_id, pending_action)
+            choice = "q"
         except KeyboardInterrupt:
             print()  # noqa: T201
             return 130
 
-        if choice == "a":
-            return _approve_only(cfg, source_id)
-        if choice == "q":
-            return _commit_quit(source_id, pending_action)
-        if choice == "r":
-            pending_action = "reject"
-            continue
-        if choice == "u":
-            _restore_snapshot(snapshot)
-            pending_action = "none"
-            continue
-        if choice == "e":
-            _preview_edit(cfg, source_id)
-            continue
+        if choice.isdigit():
+            idx = _pick_segment_index(choice, len(summaries))
+            if idx is None:
+                continue
+            try:
+                _per_segment_prompt(source_id, idx, summaries, pending_marks)
+            except KeyboardInterrupt:
+                print()  # noqa: T201
+                return 130
+            summaries = _load_summaries(source_id)
+        elif choice == "n":
+            idx = _next_draft_index(summaries, pending_marks)
+            if idx is None:
+                print("  (no remaining draft segments)")  # noqa: T201
+                continue
+            try:
+                _per_segment_prompt(source_id, idx, summaries, pending_marks)
+            except KeyboardInterrupt:
+                print()  # noqa: T201
+                return 130
+            summaries = _load_summaries(source_id)
+        elif choice == "m":
+            _open_meta(source_id)
+        elif choice == "q":
+            return _commit_and_exit(cfg, source_id, pending_marks)
         # unrecognized → re-prompt
-
-
-def _render(cfg: cfg_mod.Config, source_id: str, pending_action: str) -> None:
-    try:
-        text = pipeline.assemble_draft(cfg, source_id)
-    except pipeline.ReadingPipelineError as e:
-        print(f"\n[error assembling draft: {e}]")  # noqa: T201
-        text = ""
-    lines = text.splitlines()
-    head = "\n".join(lines[:_RENDER_LINES])
-    suffix = (
-        f"\n  ... ({len(lines) - _RENDER_LINES} more lines, {len(text)} chars total)"
-        if len(lines) > _RENDER_LINES
-        else ""
-    )
-    pdir = pipeline.pending_dir(source_id)
-    print(f"\n--- {pdir} ---")  # noqa: T201
-    print(head + suffix)  # noqa: T201
-    print(f"--- pending action: {pending_action} ---")  # noqa: T201
-
-
-def _preview_edit(cfg: cfg_mod.Config, source_id: str) -> None:
-    """Open assembled draft in $EDITOR for preview; discard edits on exit."""
-    try:
-        text = pipeline.assemble_draft(cfg, source_id)
-    except pipeline.ReadingPipelineError as e:
-        _logger.error("Could not assemble draft: %s", e)
-        return
-    draft_path = pipeline.pending_dir(source_id) / ".draft-edit.md"
-    draft_path.write_text(text, encoding="utf-8")
-    editor = os.environ.get("EDITOR", "vi")
-    subprocess.run([editor, str(draft_path)], check=False)  # noqa: S603
-    import contextlib  # noqa: PLC0415
-
-    with contextlib.suppress(OSError):
-        draft_path.unlink(missing_ok=True)
-    print(  # noqa: T201
-        "Per-segment editing lands in slice #31. "
-        "This view is preview-only — your edits were not saved."
-    )
-
-
-def _take_snapshot(source_id: str) -> dict[str, bytes]:
-    """Snapshot all segment files + sidecar; keyed by file path string."""
-    snapshot: dict[str, bytes] = {}
-    sidecar = pipeline.pending_sidecar_path(source_id)
-    if sidecar.exists():
-        snapshot[str(sidecar)] = sidecar.read_bytes()
-    segs_dir = pipeline.pending_segments_dir(source_id)
-    if segs_dir.exists():
-        for p in segs_dir.glob("*.md"):
-            snapshot[str(p)] = p.read_bytes()
-    return snapshot
-
-
-def _restore_snapshot(snapshot: dict[str, bytes]) -> None:
-    from pathlib import Path  # noqa: PLC0415
-
-    for path_str, data in snapshot.items():
-        p = Path(path_str)
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_bytes(data)
-
-
-def _commit_quit(source_id: str, pending_action: str) -> int:
-    if pending_action != "reject":
-        return 0
-    pending_dir = pipeline.pending_dir(source_id)
-    try:
-        answer = input(f"Delete {pending_dir}? [y/N] ").strip().lower()
-    except (EOFError, KeyboardInterrupt):
-        print()  # noqa: T201
-        return 0
-    if answer in {"y", "yes"}:
-        shutil.rmtree(pending_dir, ignore_errors=True)
-        print(f"Deleted {pending_dir}")  # noqa: T201
-    return 0

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -319,7 +319,7 @@ class TestApproveReading:
 
 
 class TestApproveReadingInteractive:
-    """Interactive approve-reading loop ([a]/[e]/[r]/[u]/[q] + --yes)."""
+    """Hierarchical interactive approve-reading loop."""
 
     def _patch_inputs(
         self, monkeypatch: pytest.MonkeyPatch, answers: list[str]
@@ -344,34 +344,16 @@ class TestApproveReadingInteractive:
             lambda: True,
         )
 
-    def test_approve_keystroke_runs_full_pipeline(
-        self,
-        tmp_home: Path,
-        ingested_wiki: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        _write_user_config(tmp_home, ingested_wiki)
+    def _generate(self, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+        """Run generate-reading; return mock client."""
         monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
-        self._force_tty(monkeypatch)
-        prompts = self._patch_inputs(monkeypatch, ["a"])
-
         client = MagicMock()
         _wire_client_responses(client)
         with patch(
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
-
-        assert rc == 0
-        # Loop must have prompted before approving.
-        assert len(prompts) >= 1
-        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
-        assert approved.exists()
-        assert "# Reading: Session 3" in approved.read_text(encoding="utf-8")
-        assert "reading_status" not in approved.read_text(encoding="utf-8")
-        # approve-reading no longer cascades into plan/extract
-        assert not (tmp_home / "pending" / "yt-abc12345678" / "plan.yaml").exists()
+        return client
 
     def test_non_tty_without_yes_errors(
         self,
@@ -380,225 +362,355 @@ class TestApproveReadingInteractive:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         _write_user_config(tmp_home, ingested_wiki)
-        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
         monkeypatch.setattr(
             "auto_lorebook.commands.approve_reading._is_interactive",
             lambda: False,
         )
+        self._generate(monkeypatch)
 
-        client = MagicMock()
-        _wire_client_responses(client)
-        with patch(
-            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
-        ):
-            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
 
         assert rc == 1
-        # Pipeline must not have copied to wiki.
         approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
         assert not approved.exists()
 
-    def test_quit_without_action_is_noop(
+    def test_outer_quit_without_marks_writes_nothing(
         self,
         tmp_home: Path,
         ingested_wiki: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         _write_user_config(tmp_home, ingested_wiki)
-        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
         self._force_tty(monkeypatch)
         self._patch_inputs(monkeypatch, ["q"])
+        self._generate(monkeypatch)
 
-        client = MagicMock()
-        _wire_client_responses(client)
-        with patch(
-            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
-        ):
-            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
 
         assert rc == 0
-        # No wiki copy, no plan, pending dir intact.
         approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
         assert not approved.exists()
-        assert not (tmp_home / "pending" / "yt-abc12345678" / "plan.yaml").exists()
-        # sidecar and segments exist; no old reading.md
         pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
         assert (pending / "reading.yaml").exists()
         assert not (pending / "reading.md").exists()
+        # segments still draft
+        import yaml as _yaml  # noqa: PLC0415
 
-    def test_reject_then_quit_with_confirm_deletes_pending(
-        self,
-        tmp_home: Path,
-        ingested_wiki: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        _write_user_config(tmp_home, ingested_wiki)
-        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
-        self._force_tty(monkeypatch)
-        self._patch_inputs(monkeypatch, ["r", "q", "y"])
-
-        client = MagicMock()
-        _wire_client_responses(client)
-        with patch(
-            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
-        ):
-            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
-
-        assert rc == 0
-        assert not (tmp_home / "pending" / "yt-abc12345678" / "reading").exists()
-        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
-        assert not approved.exists()
-
-    def test_reject_then_quit_decline_confirm_keeps_pending(
-        self,
-        tmp_home: Path,
-        ingested_wiki: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        _write_user_config(tmp_home, ingested_wiki)
-        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
-        self._force_tty(monkeypatch)
-        self._patch_inputs(monkeypatch, ["r", "q", "n"])
-
-        client = MagicMock()
-        _wire_client_responses(client)
-        with patch(
-            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
-        ):
-            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
-
-        assert rc == 0
-        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
-        assert (pending / "reading.yaml").exists()
-        assert not (pending / "reading.md").exists()
-
-    def test_reject_then_undo_then_approve(
-        self,
-        tmp_home: Path,
-        ingested_wiki: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        _write_user_config(tmp_home, ingested_wiki)
-        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
-        self._force_tty(monkeypatch)
-        self._patch_inputs(monkeypatch, ["r", "u", "a"])
-
-        client = MagicMock()
-        _wire_client_responses(client)
-        with patch(
-            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
-        ):
-            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
-
-        assert rc == 0
-        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
-        assert approved.exists()
-        assert "# Reading: Session 3" in approved.read_text(encoding="utf-8")
-        assert "reading_status" not in approved.read_text(encoding="utf-8")
-
-    def test_undo_restores_segment_files(
-        self,
-        tmp_home: Path,
-        ingested_wiki: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """[u] rolls back in-session mutations to segment files."""
-        _write_user_config(tmp_home, ingested_wiki)
-        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
-        self._force_tty(monkeypatch)
-
-        seg001_path = (
-            tmp_home
-            / "pending"
-            / "yt-abc12345678"
-            / "reading"
-            / "segments"
-            / "seg-001.md"
+        fm = _yaml.safe_load(
+            (pending / "segments" / "seg-001.md").read_text().split("---")[1]
         )
+        assert fm["segment_status"] == "draft"
 
-        corrupted = (
-            b"---\nschema_version: 1\nsegment_id: seg-001\n"
-            b"segment_status: accepted\nstart: '0:00:00'\nend: '0:02:00'\n"
-            b"title: CORRUPTED\nspeaker: DM\nnotes: null\noverrides: []\n"
-            b"---\nCORRUPTED BODY\n"
-        )
-        call_count = {"n": 0}
-
-        def fake_input(_prompt: str = "") -> str:
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                # first prompt: corrupt seg-001 then say 'u'
-                seg001_path.write_bytes(corrupted)
-                return "u"
-            # after undo, approve
-            return "a"
-
-        monkeypatch.setattr("builtins.input", fake_input)
-
-        client = MagicMock()
-        _wire_client_responses(client)
-        with patch(
-            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
-        ):
-            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
-
-        assert rc == 0
-        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
-        assert approved.exists()
-        # After [u][a]: wiki copy reflects restored content, not corrupted title
-        assert "CORRUPTED" not in approved.read_text(encoding="utf-8")
-        assert "Intro" in approved.read_text(encoding="utf-8")
-
-    def test_edit_invokes_editor_preview_only(
+    def test_open_segment_then_accept_then_quit_one_segment_only(
         self,
         tmp_home: Path,
         ingested_wiki: Path,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
+        """Accept only seg-001; gate doesn't fire; output mentions undecided."""
         _write_user_config(tmp_home, ingested_wiki)
-        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
-        monkeypatch.setenv("EDITOR", "my-fake-editor")
         self._force_tty(monkeypatch)
-        self._patch_inputs(monkeypatch, ["e", "a"])
+        # open seg 1, accept it, then quit
+        self._patch_inputs(monkeypatch, ["1", "a", "q"])
+        self._generate(monkeypatch)
+
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert not approved.exists()
+        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        import yaml as _yaml  # noqa: PLC0415
+
+        fm1 = _yaml.safe_load(
+            (pending / "segments" / "seg-001.md").read_text().split("---")[1]
+        )
+        assert fm1["segment_status"] == "accepted"
+        out = capsys.readouterr().out
+        assert "Still" in out
+        assert "undecided" in out
+
+    def test_full_walkthrough_accept_all_fires_gate(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Accept both segments; gate fires; wiki reading.md written."""
+        _write_user_config(tmp_home, ingested_wiki)
+        self._force_tty(monkeypatch)
+        self._patch_inputs(monkeypatch, ["1", "a", "2", "a", "q"])
+        self._generate(monkeypatch)
+
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert approved.exists()
+        assert "# Reading: Session 3" in approved.read_text(encoding="utf-8")
+        assert "reading_status" not in approved.read_text(encoding="utf-8")
+        out = capsys.readouterr().out
+        assert "Approved" in out
+
+    def test_n_jumps_to_next_draft(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """[n] jumps to next draft; accepting both fires gate."""
+        _write_user_config(tmp_home, ingested_wiki)
+        self._force_tty(monkeypatch)
+        self._patch_inputs(monkeypatch, ["n", "a", "n", "a", "q"])
+        self._generate(monkeypatch)
+
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert approved.exists()
+        out = capsys.readouterr().out
+        assert "Approved" in out
+
+    def test_skip_bullets_in_per_segment(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """[s] skips bullets; gate fires when both segments decided."""
+        _write_user_config(tmp_home, ingested_wiki)
+        self._force_tty(monkeypatch)
+        self._patch_inputs(monkeypatch, ["1", "s", "2", "a", "q"])
+        self._generate(monkeypatch)
+
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert approved.exists()
+        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        import yaml as _yaml  # noqa: PLC0415
+
+        fm1 = _yaml.safe_load(
+            (pending / "segments" / "seg-001.md").read_text().split("---")[1]
+        )
+        assert fm1["segment_status"] == "skipped"
+
+    def test_undo_clears_pending_mark(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """[u] in seg prompt clears mark; [b] returns to outer; seg stays draft."""
+        _write_user_config(tmp_home, ingested_wiki)
+        self._force_tty(monkeypatch)
+        # open 1, accept (returns to outer), re-open 1, undo (stays), back, quit
+        self._patch_inputs(monkeypatch, ["1", "a", "1", "u", "b", "q"])
+        self._generate(monkeypatch)
+
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert not approved.exists()
+        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        import yaml as _yaml  # noqa: PLC0415
+
+        fm1 = _yaml.safe_load(
+            (pending / "segments" / "seg-001.md").read_text().split("---")[1]
+        )
+        assert fm1["segment_status"] == "draft"
+
+    def test_back_returns_to_outer_without_committing(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """[b] from seg prompt returns to outer; nothing committed."""
+        _write_user_config(tmp_home, ingested_wiki)
+        self._force_tty(monkeypatch)
+        self._patch_inputs(monkeypatch, ["1", "b", "q"])
+        self._generate(monkeypatch)
+
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert not approved.exists()
+
+    def test_meta_opens_sidecar_in_editor(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """[m] opens reading.yaml in $EDITOR."""
+        _write_user_config(tmp_home, ingested_wiki)
+        self._force_tty(monkeypatch)
+        monkeypatch.setenv("EDITOR", "my-fake-editor")
+        self._patch_inputs(monkeypatch, ["m", "q"])
+        self._generate(monkeypatch)
 
         calls: list[list[str]] = []
 
         def fake_run(cmd: list[str], **_kwargs: object) -> object:
-            calls.append(cmd)
+            calls.append(list(cmd))
             return MagicMock(returncode=0)
 
         monkeypatch.setattr(
             "auto_lorebook.commands.approve_reading.subprocess.run", fake_run
         )
 
-        client = MagicMock()
-        _wire_client_responses(client)
-        with patch(
-            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
-        ):
-            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
 
         assert rc == 0
         assert len(calls) == 1
         assert calls[0][0] == "my-fake-editor"
-        assert calls[0][1].endswith(".draft-edit.md")
+        assert calls[0][1].endswith("reading.yaml")
 
-        out = capsys.readouterr().out
-        assert "preview-only" in out
-        assert "edits were not saved" in out
+    def test_edit_opens_segment_md_in_editor(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """[e] opens seg-001.md in $EDITOR; status stays draft."""
+        _write_user_config(tmp_home, ingested_wiki)
+        self._force_tty(monkeypatch)
+        monkeypatch.setenv("EDITOR", "my-fake-editor")
+        # open seg 1, edit, back, quit
+        self._patch_inputs(monkeypatch, ["1", "e", "b", "q"])
+        self._generate(monkeypatch)
 
-        # segment files must be unchanged (edits discarded)
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: object) -> object:
+            calls.append(list(cmd))
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(
+            "auto_lorebook.commands.approve_reading.subprocess.run", fake_run
+        )
+
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        assert len(calls) == 1
+        assert calls[0][0] == "my-fake-editor"
+        assert calls[0][1].endswith("seg-001.md")
+
         pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
-        assert (pending / "segments" / "seg-001.md").exists()
-        assert (pending / "segments" / "seg-002.md").exists()
+        import yaml as _yaml  # noqa: PLC0415
+
+        fm1 = _yaml.safe_load(
+            (pending / "segments" / "seg-001.md").read_text().split("---")[1]
+        )
+        assert fm1["segment_status"] == "draft"
+
+    def test_edit_then_accept_persists_body_changes_through_engine(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Editor mutation of seg-001 body reflected in wiki reading.md."""
+        _write_user_config(tmp_home, ingested_wiki)
+        self._force_tty(monkeypatch)
+        monkeypatch.setenv("EDITOR", "my-fake-editor")
+        # open 1, edit, accept; open 2, accept; quit
+        self._patch_inputs(monkeypatch, ["1", "e", "a", "2", "a", "q"])
+        self._generate(monkeypatch)
+
+        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        seg001_path = pending / "segments" / "seg-001.md"
+
+        def fake_run(cmd: list[str], **_kwargs: object) -> object:
+            # editor side effect: append custom text to seg-001 body
+            if cmd[1].endswith("seg-001.md"):
+                current = seg001_path.read_text(encoding="utf-8")
+                seg001_path.write_text(
+                    current + "\n- CUSTOM EDITED BULLET\n", encoding="utf-8"
+                )
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(
+            "auto_lorebook.commands.approve_reading.subprocess.run", fake_run
+        )
+
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert approved.exists()
+        content = approved.read_text(encoding="utf-8")
+        assert "CUSTOM EDITED BULLET" in content
+        import yaml as _yaml  # noqa: PLC0415
+
+        fm1 = _yaml.safe_load(
+            (pending / "segments" / "seg-001.md").read_text().split("---")[1]
+        )
+        assert fm1["segment_status"] == "accepted"
+        out = capsys.readouterr().out
+        assert "Approved" in out
+
+    def test_ctrl_c_in_outer_writes_nothing(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Ctrl-C at outer prompt returns 130; no commits."""
+        _write_user_config(tmp_home, ingested_wiki)
+        self._force_tty(monkeypatch)
+        self._generate(monkeypatch)
+
+        call_count = {"n": 0}
+
+        def fake_input(_prompt: str = "") -> str:
+            call_count["n"] += 1
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("builtins.input", fake_input)
+
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 130
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert not approved.exists()
+
+    def test_ctrl_c_in_segment_writes_nothing(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Ctrl-C inside per-segment prompt returns 130; no commits."""
+        _write_user_config(tmp_home, ingested_wiki)
+        self._force_tty(monkeypatch)
+        self._generate(monkeypatch)
+
+        call_count = {"n": 0}
+
+        def fake_input(_prompt: str = "") -> str:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return "1"  # outer: open segment 1
+            raise KeyboardInterrupt  # inside seg prompt
+
+        monkeypatch.setattr("builtins.input", fake_input)
+
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 130
+        approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
+        assert not approved.exists()
 
 
 class TestRegenerateReading:


### PR DESCRIPTION
### What this fixes

Replaces `approve-reading`'s flat single-loop interactive session (keys `[a]/[e]/[r]/[u]/[q]` operating on the whole draft) with the hierarchical, per-segment UX called for in #31. The rewrite lives entirely in `src/auto_lorebook/commands/approve_reading.py`:

- New `_interactive_session` runs an outer numbered-list view (`_render_outer`) with keys `[#]` (open segment N), `[n]` (next draft), `[m]` (open `reading.yaml` in `$EDITOR`), `[q]` (commit).
- New `_per_segment_prompt` runs the inner view with keys `[a]` accept, `[s]` skip-bullets, `[e]` edit body in `$EDITOR`, `[u]` clear pending mark (stays in segment view), `[b]` back to outer.
- A new `_ReplayReviewer` translates pending marks into `AcceptDecision` / `SkipBulletsDecision` / `UndoDecision` and `decide_quit → CommitDecision()`. It is the only path that mutates segment status — the command layer never calls `segment_file.set_status` / `segment_file.write` for state changes; the existing `reading_review` engine owns them.
- `AutoAcceptReviewer` and `_approve_only` are preserved verbatim, so `approve-reading --yes` and `reading_pipeline.approve` are untouched.
- Deferred-commit invariant: pending marks live in memory until `[q]`; on `[q]` the engine writes segment frontmatter in a single transaction and only writes wiki-side `reading.md` when every segment is decided. Ctrl-C at any prompt exits rc 130 with no committed mutations.

`g`enerate-again is intentionally still out of scope — reserved for slice #5 per the parent (#27).

### QA steps for the human

This is the HITL slice — please pilot the interactive flow before merging:

1. Get a source into pending-reading state (`auto-lorebook ingest <id>` then `auto-lorebook generate-reading <id>` per `docs/pipeline/reading.md`).
2. Run `auto-lorebook approve-reading <id>` in a real terminal.
3. Drive the outer view: `[1]` (or another number) opens that segment; `[n]` jumps to the next draft; `[m]` opens `pending/<id>/reading/reading.yaml` in your `$EDITOR` and returns on save.
4. Inside a segment: `[a]` accepts (returns to outer with `→accepted` marker); `[s]` skip-bullets (returns with `→skipped`); `[e]` opens `seg-NNN.md` in `$EDITOR`, save returns to the segment prompt with the body re-rendered; `[u]` clears the pending mark and stays in the segment view; `[b]` returns to outer.
5. Press `[q]` with mixed pending marks across segments — confirm "Still N undecided; pending marks committed for the rest." prints and no wiki `reading.md` is written.
6. Drive every segment to a decision and `[q]` — confirm "Approved: …/sources/<id>/reading.md" prints and the wiki file exists.
7. Mid-session, hit `Ctrl-C` from both the outer and a per-segment prompt — confirm rc 130 and that no segment frontmatter changed and no wiki `reading.md` was written.

### Automated coverage

`uv run ruff check`, `uv run ruff format`, `uv run ty check`, `uv run pytest` (535 passed, 4 skipped — `TestApproveReadingInteractive` rewritten with 13 hierarchical tests covering all key bindings, deferred-commit, edit-then-accept body persistence, and Ctrl-C in outer + segment), and `uv run mkdocs build --strict` all pass. No new live-integration test added — slice introduces no new external-service boundary; `subprocess.run` for `$EDITOR` and stdin are the only stub points and both are covered by the mocked unit tests.

Closes #31

---
_Generated by [Claude Code](https://claude.ai/code/session_011acqgzE3Lz63c5D6KmT9p1)_