### PR TITLE
Add CONTEXT.md capturing review-stage domain language

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -69,6 +69,7 @@ One end-to-end run from source to (possibly partial) approved facts. Identified 
 ## Invariants
 
 - **Plan/proposal correspondence**: at the start of `review`, the set of on-disk proposal files must correspond 1:1 to `(claim_group_id, target_entity)` keys in the plan. Missing keys (Ctrl-C resume after partial approval) are allowed — proposals are a subset of plan routes. Extra keys (orphans) raise `ReviewError` and direct the user to `replan`.
+- **Alias decline memory**: declined aliases are remembered in-memory for the duration of one `run()` call only. Ctrl-C resume re-asks for declined aliases (only accepted aliases survive on disk via `added_by_ingest`).
 
 ## Flagged ambiguities
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,72 @@
+# Auto-Lorebook
+
+Pipeline that turns recorded sessions into a structured wiki of facts about
+in-world entities. This file captures the domain language used inside the
+review stage and its immediate neighbours; broader pipeline structure lives
+in `docs/architecture/overview.md`.
+
+## Language
+
+### Pipeline stages
+
+**Reading**:
+LLM-produced summary of one source, organised into sections of bullets, gated by human approval.
+_Avoid_: transcript summary, notes.
+
+**Plan**:
+Routing layer mapping each reading bullet to one or more entities. Intermediate; no approval gate, no filesystem writes.
+_Avoid_: routing pass.
+
+**Extraction**:
+Per-claim-group step that locates the raw transcript span and emits one proposal file per route.
+_Avoid_: claim extraction.
+
+**Review**:
+Per-bundle approval gate; the only point at which entities and facts enter the wiki.
+_Avoid_: approval, fact review (legacy).
+
+### Review-stage terms
+
+**Claim group**:
+Set of routes that share `claim_group_id`. Locator and raw-transcript span are computed once and copied across the group.
+
+**Bundle**:
+The on-screen unit during review — one claim group rendered as a single decision screen.
+_Avoid_: batch, group screen.
+
+**Route**:
+One row in a bundle: a `(claim_group_id, target_entity)` pair. Carries a `proposed_section` and inherits the bundle's claim text.
+_Avoid_: target row, destination (target is fine in code).
+
+**Proposal**:
+On-disk YAML in `pending/<ingest_id>/proposals/` representing one route awaiting review.
+_Avoid_: pending fact.
+
+**Fact**:
+Approved entry inside an entity YAML's `facts` list. Created only by Review; never produced by earlier stages.
+_Avoid_: claim (a claim is pre-approval; a fact is post-approval).
+
+**Bundle-level edit**:
+Edit applied at the bundle screen; propagates to every checked route. Scope is `{text, status, status_reason}` — fields that describe the claim itself, not the routing.
+
+**Per-target override**:
+Edit applied to one route only via `[t]argets`. Scope is `{section, speaker}` — fields that are inherently route-shaped (different entities have different sections; speaker can vary per attribution).
+
+**Alias confirmation**:
+Per-route sub-prompt that fires after approve/edit, before any writes, asking whether a planner-suggested mention should become a permanent alias for the target entity.
+
+**Ingest**:
+One end-to-end run from source to (possibly partial) approved facts. Identified by `ingest_id`; recorded on every entity stub and alias as `created_by_ingest` / `added_by_ingest`.
+
+## Relationships
+
+- A **Reading** produces zero or more **Plans** (one per replan).
+- A **Plan** contains many **Claim groups**; each claim group contains one or more **Routes**.
+- Extraction emits one **Proposal** per **Route**.
+- A **Bundle** is the runtime view of one **Claim group** during review.
+- Approving a **Bundle** appends one **Fact** per checked **Route** to its target entity's YAML.
+
+## Flagged ambiguities
+
+- "Target" appears in code (`target_entity`, `targets:`) and the doc uses both "target" and "route". Resolution: **route** is the preferred domain term for the row; **target** is acceptable when emphasising the destination entity.
+- "Claim" vs "fact": a claim is a pre-approval assertion travelling through reading/plan/proposal; a **fact** only exists once Review has appended it to an entity.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,6 +70,7 @@ One end-to-end run from source to (possibly partial) approved facts. Identified 
 
 - **Plan/proposal correspondence**: at the start of `review`, the set of on-disk proposal files must correspond 1:1 to `(claim_group_id, target_entity)` keys in the plan. Missing keys (Ctrl-C resume after partial approval) are allowed — proposals are a subset of plan routes. Extra keys (orphans) raise `ReviewError` and direct the user to `replan`.
 - **Alias decline memory**: declined aliases are remembered in-memory for the duration of one `run()` call only. Ctrl-C resume re-asks for declined aliases (only accepted aliases survive on disk via `added_by_ingest`).
+- **Idempotent re-approval**: encountering a proposal whose `proposed_id` already exists on the target entity is a silent skip — the proposal file is removed and the run continues. Covers the Ctrl-C window between `entity_yaml.write` and `proposal_path.unlink`.
 
 ## Flagged ambiguities
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,6 +71,7 @@ One end-to-end run from source to (possibly partial) approved facts. Identified 
 - **Plan/proposal correspondence**: at the start of `review`, the set of on-disk proposal files must correspond 1:1 to `(claim_group_id, target_entity)` keys in the plan. Missing keys (Ctrl-C resume after partial approval) are allowed — proposals are a subset of plan routes. Extra keys (orphans) raise `ReviewError` and direct the user to `replan`.
 - **Alias decline memory**: declined aliases are remembered in-memory for the duration of one `run()` call only. Ctrl-C resume re-asks for declined aliases (only accepted aliases survive on disk via `added_by_ingest`).
 - **Idempotent re-approval**: encountering a proposal whose `proposed_id` already exists on the target entity is a silent skip — the proposal file is removed and the run continues. Covers the Ctrl-C window between `entity_yaml.write` and `proposal_path.unlink`.
+- **Status audit asymmetry**: edits to a fact's `text` preserve the original in `text_source`; edits to `status` / `status_reason` do not preserve the planner's original. `status_history` records only the reviewer's final value. Rationale: text is a literal claim that can be objectively wrong, status is a reviewer judgment call.
 
 ## Flagged ambiguities
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,10 @@ One end-to-end run from source to (possibly partial) approved facts. Identified 
 - A **Bundle** is the runtime view of one **Claim group** during review.
 - Approving a **Bundle** appends one **Fact** per checked **Route** to its target entity's YAML.
 
+## Invariants
+
+- **Plan/proposal correspondence**: at the start of `review`, the set of on-disk proposal files must correspond 1:1 to `(claim_group_id, target_entity)` keys in the plan. Missing keys (Ctrl-C resume after partial approval) are allowed — proposals are a subset of plan routes. Extra keys (orphans) raise `ReviewError` and direct the user to `replan`.
+
 ## Flagged ambiguities
 
 - "Target" appears in code (`target_entity`, `targets:`) and the doc uses both "target" and "route". Resolution: **route** is the preferred domain term for the row; **target** is acceptable when emphasising the destination entity.

--- a/docs/adr/0001-plan-canonicality.md
+++ b/docs/adr/0001-plan-canonicality.md
@@ -1,0 +1,7 @@
+# Plan is canonical for review; orphan proposals are an error
+
+The Stage-3 extractor writes one proposal file per `(claim_group_id, target_entity)` route in the plan, and Review walks the plan to look those up. Today `sorted_proposals` silently appends any proposal whose plan key didn't match — covering up drift between `plan.yaml` and `pending/<ingest_id>/proposals/`.
+
+We pick the plan as canonical: at the start of `run()`, the on-disk proposal set must be a subset of the plan's `(claim_group_id, target_entity)` keys. Missing keys are fine (Ctrl-C resume after partial approval). Extra keys (orphans) raise `ReviewError` and direct the user to `replan`.
+
+Rationale: orphans only realistically arise from manual proposal edits or a partial replan that didn't clean up. Silent recovery hides those bugs and reviews bundles the planner never sanctioned, which `replan` then can't reroute (it discards based on plan membership). Treating drift as an error makes the invariant visible and `replan` the single recovery path.

--- a/docs/adr/0002-status-edit-audit-asymmetry.md
+++ b/docs/adr/0002-status-edit-audit-asymmetry.md
@@ -1,0 +1,7 @@
+# No `status_source` parallel to `text_source`
+
+Approved facts record `text_source` (the planner's original text) and `edited_by_human` whenever the reviewer edits `text`. Status edits get no equivalent — `status_history` records only the reviewer's final value; the planner's `proposed_status` is dropped.
+
+We keep this asymmetric. Text edits track corrections to a literal quotation that can be objectively wrong (mishearings, typos, ASR errors); preserving the original is part of the claim's truthfulness story. Status is a reviewer judgment call — the planner's guess is a model artefact with no lasting truth value, the same reason `plan.yaml` itself isn't archived after extraction.
+
+If we ever need "how often does the reviewer override the planner's status?" for model-quality analysis, add it then. Until then, recording it durably suggests it has lasting value, which it doesn't.


### PR DESCRIPTION
Records the bundle / route / claim-group / proposal / fact vocabulary
resolved during a grill-with-docs session on the Claim Review design.
Flags "target" vs "route" and "claim" vs "fact" as ambiguities with
preferred resolutions.

https://claude.ai/code/session_012gxKfMatwhJqi6ZvHGJj6X