### PR TITLE
Split EditDecision into BundleEdits / TargetEdits / MergedEdits (#42)

### DIFF
--- a/docs/pipeline/review.md
+++ b/docs/pipeline/review.md
@@ -83,12 +83,14 @@ Routes:
 >
 ```
 
-Bundle-level edits to `text`, `status`, or `status_reason` propagate
-to every checked route — those are claim-level facts about the world,
-so they should agree across siblings. Per-target overrides for
-`section` and `speaker` live in the `[t]argets` sub-prompt because
-they're inherently route-shaped (different entities have different
-sections).
+**Bundle-level edits** carry only `text`, `status`, and `status_reason`
+— those are claim-level facts about the world, so they propagate to
+every checked route and should agree across siblings.
+**Per-target overrides** carry only `section` and `speaker` and live
+in the `[t]argets` sub-prompt: different routes point at different
+entities, so section is inherently route-shaped, and speaker
+attribution can vary route-by-route. The two field sets are disjoint
+by design — a reviewer cannot set a bundle-wide `section`.
 
 ### New-entity routes
 
@@ -136,11 +138,12 @@ seeds its dedup set from on-disk alias records whose
 
 - **Approve** — every checked route becomes a fact, appended to its
   target entity's YAML (creating the YAML if this is the first
-  approval for a new entity); summary regenerated. Unchecked routes
-  are dropped — their proposal files are deleted.
+  approval for a new entity). Unchecked routes are dropped — their
+  proposal files are deleted.
 - **Edit** — bundle-level edits to `text`, `status`, and
-  `status_reason` propagate to every checked route. Tracks original
-  text as `text_source` on each affected fact.
+  `status_reason` propagate to every checked route. Per-target
+  `section` / `speaker` overrides are set in `[t]argets`. Tracks
+  original text as `text_source` on each affected fact.
 - **Reject** — discards the whole bundle: every route's proposal
   file is removed, no entity is touched.
 - **Play** — prints the URL; user clicks through to verify against

--- a/src/auto_lorebook/commands/review.py
+++ b/src/auto_lorebook/commands/review.py
@@ -19,9 +19,10 @@ from auto_lorebook.interactive import _is_interactive
 from auto_lorebook.review import (
     ApproveDecision,
     BundleDecision,
+    BundleEdits,
     BundleView,
-    EditDecision,
     RejectDecision,
+    TargetEdits,
     TargetView,
 )
 from auto_lorebook.timestamps import TimestampError, parse_locator_hint
@@ -135,8 +136,8 @@ class InteractiveReviewer:
         # `selected[i]` toggles route i. Default: every route checked.
         selected = [True] * len(view.targets)
         # Per-target overrides accumulated via `[t]`.
-        overrides: dict[int, EditDecision] = {}
-        bundle_edits: EditDecision | None = None
+        overrides: dict[int, TargetEdits] = {}
+        bundle_edits: BundleEdits | None = None
         _render_bundle(view, selected, overrides, bundle_edits)
         while True:
             try:
@@ -201,8 +202,8 @@ class InteractiveReviewer:
 
 
 def _gather_bundle_edits(
-    view: BundleView, current: EditDecision | None
-) -> EditDecision | None:
+    view: BundleView, current: BundleEdits | None
+) -> BundleEdits | None:
     """Bundle-level edits: text / status / status_reason only.
 
     `section` and `speaker` vary per route, so they live in the
@@ -224,7 +225,7 @@ def _gather_bundle_edits(
             else sample.status_reason or ""
         ),
     )
-    edits = EditDecision(
+    edits = BundleEdits(
         new_text=new_text,
         new_status=new_status,
         new_status_reason=new_status_reason,
@@ -235,7 +236,7 @@ def _gather_bundle_edits(
 def _gather_target_toggles(
     view: BundleView,
     selected: list[bool],
-    overrides: dict[int, EditDecision],
+    overrides: dict[int, TargetEdits],
 ) -> None:
     """Toggle inclusion per route; for kept rows, override section / speaker."""
     print("  Targets (per route):")  # noqa: T201
@@ -271,7 +272,7 @@ def _gather_target_toggles(
 
 
 def _edit_target_override(
-    target: TargetView, idx: int, overrides: dict[int, EditDecision]
+    target: TargetView, idx: int, overrides: dict[int, TargetEdits]
 ) -> None:
     """Prompt for per-target section / speaker; merge into overrides."""
     p = target.proposal
@@ -284,7 +285,7 @@ def _edit_target_override(
         "speaker",
         current.new_speaker if current and current.new_speaker else p.speaker,
     )
-    edits = EditDecision(new_section=new_section, new_speaker=new_speaker)
+    edits = TargetEdits(new_section=new_section, new_speaker=new_speaker)
     if edits.is_noop():
         overrides.pop(idx, None)
     else:
@@ -305,8 +306,8 @@ def _prompt_line(view: BundleView) -> str:
 def _render_bundle(
     view: BundleView,
     selected: list[bool],
-    overrides: dict[int, EditDecision],
-    bundle_edits: EditDecision | None,
+    overrides: dict[int, TargetEdits],
+    bundle_edits: BundleEdits | None,
 ) -> None:
     """Render one claim-group bundle.
 

--- a/src/auto_lorebook/review.py
+++ b/src/auto_lorebook/review.py
@@ -53,14 +53,49 @@ class ApproveDecision:
 
 
 @dataclass(frozen=True)
-class EditDecision:
-    """Approve with one or more field overrides.
+class BundleEdits:
+    """Bundle-level overrides: claim-wide fields only.
 
-    Fields default to ``None`` meaning "keep the original value". A
-    non-None ``new_text`` triggers ``edited_by_human=True`` and stashes
-    the original in ``text_source``; the other overrides change the
-    fact value silently (status changes are reflected in
-    ``status_history``).
+    ``new_text`` triggers ``edited_by_human=True`` + ``text_source``
+    on every checked route. Status fields change the recorded value
+    (reflected in ``status_history``). Section/speaker are absent by
+    design — those are route-shaped and live in ``TargetEdits``.
+    """
+
+    new_text: str | None = None
+    new_status: str | None = None
+    new_status_reason: str | None = None
+
+    def is_noop(self) -> bool:
+        """Return True when no field override is set."""
+        return (
+            self.new_text is None
+            and self.new_status is None
+            and self.new_status_reason is None
+        )
+
+
+@dataclass(frozen=True)
+class TargetEdits:
+    """Per-target overrides: route-shaped fields only.
+
+    Section and speaker differ per entity, so they live here rather
+    than in ``BundleEdits``. Text/status fields are absent by design.
+    """
+
+    new_section: str | None = None
+    new_speaker: str | None = None
+
+    def is_noop(self) -> bool:
+        """Return True when no field override is set."""
+        return self.new_section is None and self.new_speaker is None
+
+
+@dataclass(frozen=True)
+class MergedEdits:
+    """Internal shape after layering bundle + per-target overrides.
+
+    Consumed only by ``proposal_to_fact_dict`` and ``_approve``.
     """
 
     new_text: str | None = None
@@ -88,7 +123,7 @@ class RejectDecision:
     """Discard the proposal."""
 
 
-Decision = ApproveDecision | EditDecision | RejectDecision
+Decision = ApproveDecision | BundleEdits | RejectDecision
 
 
 @dataclass(frozen=True)
@@ -119,16 +154,17 @@ class BundleView:
 class BundleDecision:
     """Result of one `decide_bundle` call.
 
-    `decision` is bundle-wide. `selected_indices` lists which target
-    rows the user kept checked. Unselected targets are dropped on
-    Approve / Edit. Reject discards the whole bundle (selection
-    ignored). `per_target_overrides[i]` overlays an `EditDecision`
-    on top of the bundle-level edit, last-write-wins per field.
+    `decision` is bundle-wide: ``ApproveDecision`` or ``BundleEdits``
+    (text/status/status_reason) or ``RejectDecision``. `selected_indices`
+    lists which target rows the user kept checked. Unselected targets are
+    dropped on Approve / Edit; Reject discards the whole bundle (selection
+    ignored). `per_target_overrides[i]` holds ``TargetEdits``
+    (section/speaker) for route `i` — disjoint from bundle-level fields.
     """
 
-    decision: ApproveDecision | EditDecision | RejectDecision
+    decision: ApproveDecision | BundleEdits | RejectDecision
     selected_indices: tuple[int, ...]
-    per_target_overrides: dict[int, EditDecision] = field(default_factory=dict)
+    per_target_overrides: dict[int, TargetEdits] = field(default_factory=dict)
 
 
 class Reviewer(Protocol):
@@ -226,7 +262,7 @@ def _category_for_new(plan: Plan, target_entity: str) -> str | None:
 def proposal_to_fact_dict(
     proposal: Proposal,
     *,
-    edits: EditDecision | None,
+    edits: MergedEdits | None,
     ingest_id: str,
     by_label: str,
 ) -> dict[str, Any]:
@@ -335,7 +371,7 @@ def _approve(
     proposal: Proposal,
     proposal_path: Path,
     *,
-    edits: EditDecision | None,
+    edits: MergedEdits | None,
     confirmed_aliases: list[str],
     by_label: str,
 ) -> bool:
@@ -484,32 +520,34 @@ def _bundle_proposals(ordered: list[Proposal]) -> list[list[Proposal]]:
 
 
 def _merge_edits(
-    bundle_decision: ApproveDecision | EditDecision,
-    override: EditDecision | None,
-) -> EditDecision | None:
-    """Layer per-target override on top of bundle-level edit.
+    bundle_decision: ApproveDecision | BundleEdits,
+    override: TargetEdits | None,
+) -> MergedEdits | None:
+    """Combine bundle-level and per-target edits into a single ``MergedEdits``.
 
-    Per-target wins per field. Returns None when both are absent /
-    no-op so `_approve` takes the plain-approve path.
+    Returns None (plain-approve path) when result would be a no-op.
+    Fields are disjoint: bundle owns text/status/status_reason;
+    override owns section/speaker.
     """
     if isinstance(bundle_decision, ApproveDecision):
         if override is None or override.is_noop():
             return None
-        return override
-    if override is None:
-        return bundle_decision if not bundle_decision.is_noop() else None
-    merged = EditDecision(
-        new_text=override.new_text or bundle_decision.new_text,
-        new_speaker=override.new_speaker or bundle_decision.new_speaker,
-        new_status=override.new_status or bundle_decision.new_status,
-        new_status_reason=(
-            override.new_status_reason
-            if override.new_status_reason is not None
-            else bundle_decision.new_status_reason
-        ),
-        new_section=override.new_section or bundle_decision.new_section,
+        return MergedEdits(
+            new_section=override.new_section,
+            new_speaker=override.new_speaker,
+        )
+    # BundleEdits branch
+    has_bundle = not bundle_decision.is_noop()
+    has_override = override is not None and not override.is_noop()
+    if not has_bundle and not has_override:
+        return None
+    return MergedEdits(
+        new_text=bundle_decision.new_text,
+        new_status=bundle_decision.new_status,
+        new_status_reason=bundle_decision.new_status_reason,
+        new_section=override.new_section if override else None,
+        new_speaker=override.new_speaker if override else None,
     )
-    return None if merged.is_noop() else merged
 
 
 def _count_remaining(source_id: str) -> int:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -18,11 +18,13 @@ from auto_lorebook import (
 from auto_lorebook.review import (
     ApproveDecision,
     BundleDecision,
+    BundleEdits,
     BundleView,
     Decision,
-    EditDecision,
+    MergedEdits,
     RejectDecision,
     ReviewResult,
+    TargetEdits,
 )
 
 if TYPE_CHECKING:
@@ -300,7 +302,7 @@ class TestFactDict:
         p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
         fact = review.proposal_to_fact_dict(
             p,
-            edits=EditDecision(new_text="Aldara was founded earlier than that."),
+            edits=MergedEdits(new_text="Aldara was founded earlier than that."),
             ingest_id="yt-x",
             by_label="human-review",
         )
@@ -322,7 +324,7 @@ class TestFactDict:
         p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
         fact = review.proposal_to_fact_dict(
             p,
-            edits=EditDecision(
+            edits=MergedEdits(
                 new_speaker="Player-Thorin",
                 new_status="hearsay",
                 new_status_reason="Speaker is a tavern rumor source.",
@@ -348,7 +350,7 @@ class TestFactDict:
         p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
         fact = review.proposal_to_fact_dict(
             p,
-            edits=EditDecision(new_status="trustworthy"),
+            edits=MergedEdits(new_status="trustworthy"),
             ingest_id="yt-x",
             by_label="human-review",
         )
@@ -361,7 +363,7 @@ class TestFactDict:
         p = _make_proposal(target="Aldara", proposed_id="aldara-f001")
         fact = review.proposal_to_fact_dict(
             p,
-            edits=EditDecision(),  # no overrides
+            edits=MergedEdits(),  # no overrides
             ingest_id="yt-x",
             by_label="human-review",
         )
@@ -1147,7 +1149,7 @@ class TestBundle:
         scripted = ScriptedReviewer(
             bundle_decisions=[
                 BundleDecision(
-                    decision=EditDecision(new_text="Edited claim text."),
+                    decision=BundleEdits(new_text="Edited claim text."),
                     selected_indices=(0, 1, 2),
                 )
             ]
@@ -1175,7 +1177,7 @@ class TestBundle:
                     decision=ApproveDecision(),
                     selected_indices=(0, 1, 2),
                     per_target_overrides={
-                        1: EditDecision(new_section="bloodlines"),
+                        1: TargetEdits(new_section="bloodlines"),
                     },
                 )
             ]
@@ -1186,6 +1188,102 @@ class TestBundle:
         second = entity_yaml.read(cfg.wiki_repo_path / "events" / "second-age.yaml")
         assert aldara.facts[0]["section"] == "founding"
         assert theron.facts[0]["section"] == "bloodlines"
+        assert second.facts[0]["section"] == "events-in-era"
+
+    def test_bundle_level_edit_propagates_text_status_status_reason_to_all_routes(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        """Bundle-level text/status/status_reason land on every selected route."""
+        source_id = "yt-x"
+        _multi_target_setup(cfg, source_id)
+        scripted = ScriptedReviewer(
+            bundle_decisions=[
+                BundleDecision(
+                    decision=BundleEdits(
+                        new_text="Edited claim.",
+                        new_status="hearsay",
+                        new_status_reason="tavern rumor",
+                    ),
+                    selected_indices=(0, 1, 2),
+                )
+            ]
+        )
+        result = review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        assert result.edited == 3
+        for slug, cat in (
+            ("aldara", "locations"),
+            ("theron", "characters"),
+            ("second-age", "events"),
+        ):
+            e = entity_yaml.read(cfg.wiki_repo_path / cat / f"{slug}.yaml")
+            assert e.facts[0]["text"] == "Edited claim."
+            assert e.facts[0]["status"] == "hearsay"
+            assert e.facts[0]["status_reason"] == "tavern rumor"
+
+    def test_per_target_section_speaker_scoped_to_that_target_only(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        """TargetEdits on idx 1 must not leak to idx 0 or idx 2."""
+        source_id = "yt-x"
+        _multi_target_setup(cfg, source_id)
+        scripted = ScriptedReviewer(
+            bundle_decisions=[
+                BundleDecision(
+                    decision=ApproveDecision(),
+                    selected_indices=(0, 1, 2),
+                    per_target_overrides={
+                        1: TargetEdits(
+                            new_section="bloodlines",
+                            new_speaker="Player-Thorin",
+                        ),
+                    },
+                )
+            ]
+        )
+        review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        aldara = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        theron = entity_yaml.read(cfg.wiki_repo_path / "characters" / "theron.yaml")
+        second = entity_yaml.read(cfg.wiki_repo_path / "events" / "second-age.yaml")
+        # idx 1 (Theron) has both overrides
+        assert theron.facts[0]["section"] == "bloodlines"
+        assert theron.facts[0]["speaker"] == "Player-Thorin"
+        # idx 0 / idx 2 keep proposal values for both fields
+        assert aldara.facts[0]["section"] == "founding"
+        assert aldara.facts[0]["speaker"] == "DM"
+        assert second.facts[0]["section"] == "events-in-era"
+        assert second.facts[0]["speaker"] == "DM"
+
+    def test_bundle_edit_combined_with_per_target_override_layers_disjoint_fields(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        """Bundle text/status + per-target section coexist on the same fact."""
+        source_id = "yt-x"
+        _multi_target_setup(cfg, source_id)
+        scripted = ScriptedReviewer(
+            bundle_decisions=[
+                BundleDecision(
+                    decision=BundleEdits(
+                        new_text="Edited claim.",
+                        new_status="hearsay",
+                    ),
+                    selected_indices=(0, 1, 2),
+                    per_target_overrides={
+                        1: TargetEdits(new_section="bloodlines"),
+                    },
+                )
+            ]
+        )
+        review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        aldara = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        theron = entity_yaml.read(cfg.wiki_repo_path / "characters" / "theron.yaml")
+        second = entity_yaml.read(cfg.wiki_repo_path / "events" / "second-age.yaml")
+        # bundle fields land on every route
+        for e in (aldara, theron, second):
+            assert e.facts[0]["text"] == "Edited claim."
+            assert e.facts[0]["status"] == "hearsay"
+        # only Theron has the per-target section override
+        assert theron.facts[0]["section"] == "bloodlines"
+        assert aldara.facts[0]["section"] == "founding"
         assert second.facts[0]["section"] == "events-in-era"
 
     def test_singleton_claim_group_renders_as_single_target(
@@ -1475,7 +1573,7 @@ class TestEditPath:
         result = review.run(
             cfg=cfg,
             source_id=source_id,
-            reviewer=ScriptedReviewer([EditDecision(new_text="Edited by hand.")]),
+            reviewer=ScriptedReviewer([BundleEdits(new_text="Edited by hand.")]),
         )
         assert result.edited == 1
         assert result.approved == 0


### PR DESCRIPTION
### What this fixes

The single `EditDecision` dataclass in `src/auto_lorebook/review.py` carried five overridable fields (`new_text`, `new_speaker`, `new_status`, `new_status_reason`, `new_section`). Both `BundleDecision.decision` and the values of `BundleDecision.per_target_overrides` used the same shape, so a reviewer could construct a bundle-level edit that set `new_section` and propagate it across every checked route — even routes pointing at entities in different categories — even though the docs said `section` and `speaker` are inherently route-shaped. Type system and docs disagreed.

This PR splits the type into three disjoint frozen dataclasses, with the disjointness enforced by `ty`:

- `BundleEdits` — `text`, `status`, `status_reason` only. `BundleDecision.decision` accepts this (alongside `ApproveDecision` / `RejectDecision`).
- `TargetEdits` — `section`, `speaker` only. `BundleDecision.per_target_overrides[i]` values are this shape.
- `MergedEdits` — internal-only, holds all five fields. `_merge_edits` returns this; `proposal_to_fact_dict` consumes this.

Because the bundle and per-target field sets are now disjoint, `_merge_edits` no longer needs the per-field last-write-wins logic the previous shared-shape version had — there's nothing to conflict on. `commands/review.py` was already de-facto split (its `_gather_bundle_edits` only set bundle fields and `_edit_target_override` only set per-target ones), so the adapter changes are import + type-annotation renames; behaviour unchanged.

### QA steps for the human

None — the existing 46 review tests plus three new `TestBundle` cases (`test_bundle_level_edit_propagates_text_status_status_reason_to_all_routes`, `test_per_target_section_speaker_scoped_to_that_target_only`, `test_bundle_edit_combined_with_per_target_override_layers_disjoint_fields`) cover the propagation + scoping + layered-disjoint behaviours end-to-end. Type-level rejection of `BundleEdits(new_section=...)` falls out of `BundleEdits` not having that field — both `ty check` and Python's runtime `TypeError` flag it without a dedicated negative test.

### Automated coverage

`uv run ruff check` · `uv run ruff format` · `uv run ty check` · `uv run pytest` (533 passed, 4 skipped) · `uv run mkdocs build --strict` — all green.

Closes #42

---
_Generated by [Claude Code](https://claude.ai/code/session_018724B6t3rPXoR9fy5hUiwe)_