### PR TITLE
Claim Review: in-memory declined-alias dedup within one run()

### DIFF
--- a/src/auto_lorebook/review.py
+++ b/src/auto_lorebook/review.py
@@ -296,6 +296,7 @@ class _ApprovalContext:
     plan: Plan
     index: entity_index_mod.EntityIndex
     merged_aliases: set[tuple[str, str]] = field(default_factory=set)
+    declined_aliases: set[tuple[str, str]] = field(default_factory=set)
 
 
 def _resolve_entity_path(
@@ -419,6 +420,7 @@ def _build_target_view(ctx: _ApprovalContext, proposal: Proposal) -> TargetView:
         a
         for a in suggested
         if (target_key, normalize_alias_name(a)) not in ctx.merged_aliases
+        and (target_key, normalize_alias_name(a)) not in ctx.declined_aliases
     )
     matched_via = _matched_via_for(ctx.plan, proposal)
     created_earlier = False
@@ -642,20 +644,22 @@ def _process_bundle(
     for i, proposal in enumerate(bundle):
         if i not in selected:
             continue
-        # re-filter aliases against ctx.merged_aliases — earlier
-        # selected siblings in this same bundle may have already merged
-        # an alias that this target also suggests.
+        # re-filter aliases against ctx.merged_aliases and ctx.declined_aliases —
+        # earlier siblings in this bundle (or earlier bundles) may have already
+        # settled the alias.
         target_key = proposal.target_entity.casefold()
         fresh_aliases = tuple(
             a
             for a in _suggested_aliases_for(ctx.plan, proposal)
             if (target_key, normalize_alias_name(a)) not in ctx.merged_aliases
+            and (target_key, normalize_alias_name(a)) not in ctx.declined_aliases
         )
-        confirmed: list[str] = [
-            alias
-            for alias in fresh_aliases
-            if reviewer.confirm_alias(proposal.target_entity, alias)
-        ]
+        confirmed: list[str] = []
+        for alias in fresh_aliases:
+            if reviewer.confirm_alias(proposal.target_entity, alias):
+                confirmed.append(alias)
+            else:
+                ctx.declined_aliases.add((target_key, normalize_alias_name(alias)))
 
         edits = _merge_edits(
             bundle_decision.decision,

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -869,6 +869,51 @@ class TestSiblingAliasDedup:
 
 
 class TestDeclinedAliasMemory:
+    def test_decline_in_first_route_skips_alias_for_sibling_routes(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        # Single bundle: three routes, all targeting Aldara with "the Realm".
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        cg = "cg-001"
+        pids = ["aldara-f001", "aldara-f002", "aldara-f003"]
+        for pid in pids:
+            _write_proposal(
+                source_id,
+                _make_proposal(target="Aldara", proposed_id=pid, cg=cg),
+            )
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(
+                    name="Aldara",
+                    category="locations",
+                    aliases_suggested=["the Realm"],
+                ),
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg=cg,
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        # One bundle decision selects all three routes; alias declined in first.
+        scripted = ScriptedReviewer([ApproveDecision()], alias_responses=[False])
+        review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        # Declined in first route → skipped for the other two.
+        assert len(scripted.alias_calls) == 1
+        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        assert len(e.aliases) == 0
+
     def _setup_two_bundles_same_alias(
         self, cfg: cfg_mod.Config, source_id: str
     ) -> None:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -864,6 +864,129 @@ class TestSiblingAliasDedup:
 
 
 # ---------------------------------------------------------------------------
+# Declined-alias dedup (in-memory, single run)
+# ---------------------------------------------------------------------------
+
+
+class TestDeclinedAliasMemory:
+    def _setup_two_bundles_same_alias(
+        self, cfg: cfg_mod.Config, source_id: str
+    ) -> None:
+        """Two consecutive bundles both suggesting 'the Realm' for Aldara."""
+        _write_info(cfg.wiki_repo_path, source_id)
+        _write_proposal(
+            source_id,
+            _make_proposal(target="Aldara", proposed_id="aldara-f001", cg="cg-001"),
+        )
+        _write_proposal(
+            source_id,
+            _make_proposal(target="Aldara", proposed_id="aldara-f002", cg="cg-002"),
+        )
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(
+                    name="Aldara",
+                    category="locations",
+                    aliases_suggested=["the Realm"],
+                ),
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg="cg-001",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+                _make_claim(
+                    cg="cg-002",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="lore",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    def test_decline_in_first_bundle_skips_alias_in_second_bundle(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        self._setup_two_bundles_same_alias(cfg, source_id)
+        scripted = ScriptedReviewer(
+            [ApproveDecision(), ApproveDecision()], alias_responses=[False]
+        )
+        review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
+        # Declined in first bundle → skipped in second bundle.
+        assert len(scripted.alias_calls) == 1
+        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        assert len(e.aliases) == 0
+
+    def test_second_run_does_not_inherit_declines_from_first(
+        self, cfg: cfg_mod.Config
+    ) -> None:
+        source_id = "yt-x"
+        self._setup_two_bundles_same_alias(cfg, source_id)
+        # First run: decline alias once, entity gets created (both proposals approved).
+        scripted1 = ScriptedReviewer(
+            [ApproveDecision(), ApproveDecision()], alias_responses=[False]
+        )
+        review.run(cfg=cfg, source_id=source_id, reviewer=scripted1)
+        assert len(scripted1.alias_calls) == 1
+
+        # Second run: new plan targeting existing Aldara with same alias.
+        source_id2 = "yt-y"
+        _write_info(cfg.wiki_repo_path, source_id2)
+        _write_proposal(
+            source_id2,
+            _make_proposal(
+                target="Aldara",
+                proposed_id="aldara-g001",
+                cg="cg-001",
+                proposal_type="new_fact",
+            ),
+        )
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id2,
+            entity_resolutions=[
+                plan_yaml.EntityResolution(
+                    mention="the Realm",
+                    resolution="existing",
+                    matched_entity="Aldara",
+                    suggested_aliases_to_add=["the Realm"],
+                ),
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg="cg-001",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="existing",
+                            proposed_section="lore",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        scripted2 = ScriptedReviewer([ApproveDecision()], alias_responses=[True])
+        review.run(cfg=cfg, source_id=source_id2, reviewer=scripted2)
+        # Prompt fires because declines don't persist across run() calls.
+        assert scripted2.alias_calls == [("Aldara", "the Realm")]
+
+
+# ---------------------------------------------------------------------------
 # In-memory index refresh (end-to-end)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
### What this fixes

Declining a planner-suggested alias on route 1 of a bundle previously left the prompt firing again on every sibling route and on every later bundle in the same `run()` that targeted the same entity with the same alias — three identical yes/no prompts within seconds for a single new entity, and the same friction recurring across bundles. This change mirrors the existing `merged_aliases` dedup pattern with a sibling `declined_aliases: set[tuple[str, str]]` field on `_ApprovalContext` (`src/auto_lorebook/review.py`). `_process_bundle` now filters `fresh_aliases` against both the merged and declined sets before issuing prompts, and on `confirm_alias(...) → False` records the `(target_entity.casefold(), normalize_alias_name(alias))` pair into `declined_aliases`. `_build_target_view` also filters the displayed `suggested_aliases` against the decline set so the UI matches what will actually be prompted. Lifetime is one `run()` call only — `_seed_merged_aliases_from_disk` is unchanged, no on-disk artefact is written, and Ctrl-C resume re-asks for declines by design.

### QA steps for the human

None — fully covered by the integration smoke and the three new tests in `tests/test_review.py::TestDeclinedAliasMemory` (within-bundle dedup, cross-bundle dedup within one `run()`, and run-isolation proving declines do not persist across `run()` calls).

### Automated coverage

`uv run ruff check`, `uv run ty check`, `uv run pytest` (533 passed, 4 skipped), and `uv run mkdocs build --strict` all pass; the smoke harness drove three real `review.run()` invocations end-to-end against on-disk plan/proposal YAMLs.

Closes #44

---
_Generated by [Claude Code](https://claude.ai/code/session_01DppUdsDkLcmpEkhUPCurod)_