### PR TITLE
Claim Review: validate plan/proposals correspondence at run() start; orphans error

### DIFF
--- a/docs/pipeline/review.md
+++ b/docs/pipeline/review.md
@@ -155,6 +155,30 @@ seeds its dedup set from on-disk alias records whose
   screen — once a bundle has been approved or rejected and the next
   one is shown, undo cannot bring it back.
 
+### Crash recovery
+
+Review writes happen in two steps: `entity_yaml.write` then
+`proposal_path.unlink`. A Ctrl-C between them leaves a proposal file on
+disk that references a fact already written. Two recovery invariants cover
+this:
+
+1. **Idempotent skip.** When `_approve` finds the proposal's `proposed_id`
+   already present in the entity's facts list, it skips the append and
+   unlinks the proposal file anyway. The approved and edited counters do not
+   increment — the resume run sees the correct totals.
+
+2. **Proposals as subset.** At the start of `run()`, the engine validates
+   that every on-disk proposal corresponds to a `(claim_group_id,
+   target_entity)` key in the plan. Missing keys are normal after a partial
+   run (already-approved proposals were unlinked). Extra keys — orphans
+   whose plan key doesn't exist — raise `ReviewError` and name each
+   offending file. The recovery path is
+   [`replan`](planner.md#replan-escape-hatch), which rebuilds the plan and
+   discards proposals no longer sanctioned by it.
+
+See also [ADR 0001](../adr/0001-plan-canonicality.md) for the decision
+rationale.
+
 ## No skip, no defer
 
 A "come back to it later" action would accumulate stale state that

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,3 +75,6 @@ nav:
       - reference/audit.md
   - Roadmap: roadmap/index.md
   - Contributing: contributing.md
+  - ADRs:
+      - adr/0001-plan-canonicality.md
+      - adr/0002-status-edit-audit-asymmetry.md

--- a/src/auto_lorebook/review.py
+++ b/src/auto_lorebook/review.py
@@ -155,8 +155,47 @@ class ReviewResult:
 # ------------- ordering / lookup helpers ---------------------------------
 
 
+def _validate_proposals_subset_of_plan(plan: Plan, source_id: str) -> None:
+    """Raise ReviewError if any on-disk proposal is not in plan keys.
+
+    Missing keys are fine (subset allowed — covers Ctrl-C resume).
+    Orphans (extra keys) indicate drift; user must replan.
+    """
+    proposals_dir = reading_pipeline.pending_proposals_dir(source_id)
+    if not proposals_dir.is_dir():
+        return
+    plan_keys: set[tuple[str, str]] = {
+        (claim.claim_group_id, target.entity)
+        for claim in plan.planned_claims
+        for target in claim.targets
+    }
+    orphans: list[str] = []
+    for path in sorted(proposals_dir.glob("*.yaml")):
+        try:
+            p = proposal_yaml_mod.read(path)
+        except proposal_yaml_mod.ProposalError:
+            _logger.warning("review: could not parse %s; skipping", path)
+            continue
+        if (p.claim_group_id, p.target_entity) not in plan_keys:
+            orphans.append(
+                f"  - {path}  (claim_group_id={p.claim_group_id},"
+                f" target_entity={p.target_entity})"
+            )
+    if orphans:
+        lines = "\n".join(orphans)
+        msg = (
+            f"Orphan proposals not in plan"
+            f" (run `auto-lorebook replan {source_id}` to recover):\n{lines}"
+        )
+        raise ReviewError(msg)
+
+
 def sorted_proposals(plan: Plan, source_id: str) -> list[Proposal]:
-    """Walk plan in order; yield proposals still on disk."""
+    """Walk plan in order; yield proposals still on disk.
+
+    Precondition: on-disk proposals are a subset of plan keys
+    (enforced by _validate_proposals_subset_of_plan before this runs).
+    """
     proposals_dir = reading_pipeline.pending_proposals_dir(source_id)
     if not proposals_dir.is_dir():
         return []
@@ -176,9 +215,6 @@ def sorted_proposals(plan: Plan, source_id: str) -> list[Proposal]:
             p = by_key.pop(key, None)
             if p is not None:
                 out.append(p)
-    # Any proposal whose plan-key didn't match (orphan) gets appended
-    # deterministically by file order so we never silently drop work.
-    out.extend(by_key[key] for key in sorted(by_key))
     return out
 
 
@@ -573,6 +609,7 @@ def run(
         msg = f"No plan at {plan_path}; run `approve-reading {source_id}` first."
         raise ReviewError(msg)
     plan = plan_yaml_mod.read(plan_path)
+    _validate_proposals_subset_of_plan(plan, source_id)
     index = entity_index_mod.build(wiki_repo)
     ctx = _ApprovalContext(
         cfg=cfg, source_id=source_id, info=info, plan=plan, index=index

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -275,6 +275,134 @@ class TestSortedProposals:
 
 
 # ---------------------------------------------------------------------------
+# Validate proposals subset of plan
+# ---------------------------------------------------------------------------
+
+
+class TestValidateProposalsSubsetOfPlan:
+    def test_exact_match_succeeds(self, cfg: cfg_mod.Config) -> None:
+        """Proposals exactly matching plan keys → run() succeeds."""
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        proposal = _make_proposal(target="Aldara", proposed_id="aldara-f001")
+        _write_proposal(source_id, proposal)
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
+            ],
+            planned_claims=[
+                _make_claim(
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        result = review.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=ScriptedReviewer([ApproveDecision()]),
+        )
+        assert result.approved == 1
+
+    def test_strict_subset_succeeds(self, cfg: cfg_mod.Config) -> None:
+        """Plan has two claim groups; only one proposal on disk (Ctrl-C resume)."""
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        # Only write proposal for cg-001, not cg-002
+        proposal = _make_proposal(
+            target="Aldara", proposed_id="aldara-f001", cg="cg-001"
+        )
+        _write_proposal(source_id, proposal)
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
+                plan_yaml.NewEntityProposal(name="Theron", category="characters"),
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg="cg-001",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+                _make_claim(
+                    cg="cg-002",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Theron",
+                            entity_state="new",
+                            proposed_section="lineage",
+                            proposed_category="characters",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        result = review.run(
+            cfg=cfg,
+            source_id=source_id,
+            reviewer=ScriptedReviewer([ApproveDecision()]),
+        )
+        assert result.approved == 1
+
+    def test_orphan_raises_review_error(self, cfg: cfg_mod.Config) -> None:
+        """Proposal whose (claim_group_id, target_entity) not in plan → ReviewError."""
+        source_id = "yt-x"
+        _write_info(cfg.wiki_repo_path, source_id)
+        # In-plan proposal
+        valid = _make_proposal(target="Aldara", proposed_id="aldara-f001", cg="cg-001")
+        _write_proposal(source_id, valid)
+        # Orphan proposal — cg-999 not in the plan
+        orphan = _make_proposal(target="Ghost", proposed_id="ghost-f001", cg="cg-999")
+        _write_proposal(source_id, orphan)
+        _write_plan(
+            cfg.wiki_repo_path,
+            source_id,
+            new_entities=[
+                plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
+            ],
+            planned_claims=[
+                _make_claim(
+                    cg="cg-001",
+                    targets=[
+                        plan_yaml.ClaimTarget(
+                            entity="Aldara",
+                            entity_state="new",
+                            proposed_section="founding",
+                            proposed_category="locations",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        with pytest.raises(review.ReviewError) as exc_info:
+            review.run(
+                cfg=cfg,
+                source_id=source_id,
+                reviewer=ScriptedReviewer([ApproveDecision()]),
+            )
+        msg = str(exc_info.value)
+        orphan_path = reading_pipeline.pending_proposal_path(source_id, "ghost-f001")
+        assert str(orphan_path) in msg
+        assert "replan" in msg
+
+
+# ---------------------------------------------------------------------------
 # Fact dict shape
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
### What this fixes

Implements ADR 0001's plan-canonicality decision for Claim Review. `review.run()` now calls a new private validator `_validate_proposals_subset_of_plan(plan, source_id)` (in `src/auto_lorebook/review.py`) immediately after reading `plan.yaml` and before any bundle iteration. The validator builds the plan key set from `plan.planned_claims` × `claim.targets` (`(claim_group_id, target_entity)`), walks `pending/<source_id>/proposals/*.yaml` in sorted order, and raises `ReviewError` with a multi-line message naming each orphan path and pointing the user to `auto-lorebook replan <source_id>` when an on-disk proposal's key is not in the plan. Strict-subset states are still tolerated, which preserves the Ctrl-C-after-partial-approval resume path documented alongside the existing idempotent-skip behaviour in `_approve`.

With the validator running upstream, the orphan-tolerant tail in `sorted_proposals` (`out.extend(by_key[key] for key in sorted(by_key))`) is unreachable and has been removed; the docstring now records the subset precondition so the next reader sees why. `docs/pipeline/review.md` gains a `### Crash recovery` subsection inside `## MVP: terminal review` (between `### Actions` and `## No skip, no defer`) covering both recovery stories and linking ADR 0001. `mkdocs.yml` adds the previously-orphaned `docs/adr/` files to the nav so `mkdocs build --strict` and `tests/test_docs.py::test_no_orphaned_docs` stay green.

### QA steps for the human

None — fully covered by the integration smoke. The smoke drove `auto-lorebook review yt-smoke43abc --auto-approve` against an ephemeral memory dir with one in-plan and one orphan proposal, observed exit 1 with stderr `ERROR: Orphan proposals not in plan (run \`auto-lorebook replan yt-smoke43abc\` to recover):` followed by the orphan path; then verified the happy path (orphan removed → exit 0) and the strict-subset path (plan has more keys than disk → exit 0, no false positive).

### Automated coverage

`uv run ruff check`, `uv run ruff format`, `uv run ty check`, `uv run pytest` (533 passed, 4 live-skipped), `uv run mkdocs build --strict` — all green on `92dc9d4`.

Closes #43

---
_Generated by [Claude Code](https://claude.ai/code/session_01R32rYmGkRvzCeAC6J6JkdA)_