### PR TITLE
Quit-time regenerate-again + accepted-segments context payload

### DIFF
--- a/docs/pipeline/reading.md
+++ b/docs/pipeline/reading.md
@@ -284,8 +284,9 @@ file is the approval artefact — there is no `reading_status`
 frontmatter flag.
 
 **Decision verbs:** `accept`, `skip-bullets`,
-`regenerate-again` (deferred — slice #5; no-op in current implementation;
-marks segment as `regenerating`, which blocks the gate),
+`regenerate-again` (queue segment for quit-time re-summarisation; marks
+segment `regenerating`, blocks gate, triggers parallel Stage 1b call on
+`[q]uit`),
 `undo` (clears the pending mark for one segment), `commit` (the quit path
 that writes and evaluates the gate).
 
@@ -319,6 +320,7 @@ pending status:
 |-----|--------|
 | `a` | Accept: queue this segment for `accepted` status; return to outer. |
 | `s` | Skip-bullets: queue this segment for `skipped` status; return to outer. |
+| `g` | Regenerate-again: queue this segment for `regenerating` status; on `[q]uit`, this segment is re-summarised in parallel against a snapshot of accepted segments and returns to `draft` for re-decision. |
 | `e` | Edit: open the segment file (`seg-NNN.md`) in `$EDITOR`. Stays in per-segment prompt on return. |
 | `u` | Undo: clear this segment's pending mark. Stays in per-segment prompt. |
 | `b` | Back: return to outer without changing any pending mark. |
@@ -327,6 +329,48 @@ Pending marks live in memory until `[q]`. On `[q]`, the engine commits
 all marks in one transaction and evaluates the gate. Ctrl-C at any
 prompt exits 130 with no committed mutations; pending marks are not
 persisted.
+
+The outer segment list shows `→regenerating` for pending regenerate-again
+marks.
+
+## Quit-time regeneration batch
+
+When `[q]` commits and at least one segment has status `regenerating`, the
+engine returns a `RegenBatch` instead of (or alongside) the gate check.
+The gate cannot fire on the same quit that includes regenerating segments —
+`regenerating` is not a decided status.
+
+**Snapshot.** After the commit-write loop, the pipeline takes a snapshot
+of all committed segments with status `accepted`. This snapshot becomes
+the accepted-context for every re-summarised segment; flagged segments do
+not see each other's regenerations.
+
+**Stage 1b user message for a regen call.** The system preamble is
+unchanged. The user message gains a compact accepted-segments block before
+the target segment's transcript slice:
+
+```
+Accepted segments (context only — do not re-extract):
+
+## seg-001 [0:00:00–0:02:15] Introduction (DM)
+- Intro bullet [0:00:15]
+
+---
+
+Segment seg-002: "Rules discussion"
+Range: ...
+
+Transcript for this segment:
+
+<sliced transcript>
+```
+
+**After regen.** Regenerated segments' `bullets.yaml` entries and
+`seg-NNN.md` files are rewritten; status is reset to `draft` for
+re-decision in the next review session.
+
+**Exit message.** `[q]` with a regen batch prints "Still N undecided" —
+the gate cannot fire on the same quit that regenerates.
 
 `--yes` skips the loop and auto-approves; required for non-TTY runs
 (scripts, CI).

--- a/src/auto_lorebook/commands/approve_reading.py
+++ b/src/auto_lorebook/commands/approve_reading.py
@@ -16,6 +16,7 @@ from auto_lorebook.interactive import _is_interactive
 from auto_lorebook.reading_review import (
     AcceptDecision,
     CommitDecision,
+    RegenerateAgainDecision,
     SegmentView,
     SkipBulletsDecision,
     UndoDecision,
@@ -31,7 +32,10 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 _OUTER_PROMPT = "[#] open  [n] next-draft  [m] meta  [q] quit\n> "
-_SEG_PROMPT = "[a] accept  [e] edit  [s] skip-bullets  [u] undo  [b] back\n> "
+_SEG_PROMPT = (
+    "[a] accept  [e] edit  [s] skip-bullets  [g] regenerate-again"
+    "  [u] undo  [b] back\n> "
+)
 
 
 class AutoAcceptReviewer:
@@ -67,7 +71,7 @@ class _SegSummary:
     current_status: str  # disk truth: draft|accepted|skipped|regenerating
 
 
-# keyed by segment_id; value in {"accepted","skipped"}
+# keyed by segment_id; value in {"accepted","skipped","regenerating"}
 _PendingMarks = dict[str, str]
 
 
@@ -85,6 +89,8 @@ class _ReplayReviewer:
             return AcceptDecision()
         if mark == "skipped":
             return SkipBulletsDecision()
+        if mark == "regenerating":
+            return RegenerateAgainDecision()
         return UndoDecision()
 
     def decide_quit(self, pending: tuple[SegmentView, ...]) -> CommitDecision:  # noqa: ARG002
@@ -277,6 +283,9 @@ def _per_segment_prompt(
         if choice == "s":
             pending_marks[sid] = "skipped"
             return
+        if choice == "g":
+            pending_marks[sid] = "regenerating"
+            return
         if choice == "e":
             _open_in_editor(pipeline.pending_segment_path(source_id, sid))
             # reload summary so edits show (status might have changed externally)
@@ -315,6 +324,15 @@ def _commit_and_exit(
         print(f"Approved: {result.wiki_reading_path}")  # noqa: T201
         print(f"Run `auto-lorebook plan {source_id}` next.")  # noqa: T201
         return 0
+
+    if result.regen_batch is not None:
+        n = len(result.regen_batch.regen_segment_ids)
+        print(f"Regenerating {n} segment(s)...")  # noqa: T201
+        try:
+            pipeline.regenerate_after_review(cfg, result.regen_batch)
+        except pipeline.ReadingPipelineError as e:
+            _logger.error("%s", e)
+            return 1
 
     remaining = sum(
         1

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from auto_lorebook.info_yaml import Info
     from auto_lorebook.plan_yaml import Plan
     from auto_lorebook.proposal_yaml import Proposal
+    from auto_lorebook.reading_review import RegenBatch
     from auto_lorebook.reading_sidecar import Sidecar
     from auto_lorebook.segment_file import SegmentFile
 
@@ -105,6 +106,97 @@ def regenerate(
         return _run_summarize_only(cfg, source_id, segment_ids=segment_ids)
     msg = f"unknown --from value: {from_stage!r} (expected structure|summarize)"
     raise ReadingPipelineError(msg)
+
+
+def regenerate_after_review(
+    cfg: cfg_mod.Config,
+    batch: RegenBatch,
+) -> GenerateResult:
+    """Re-run Stage 1b on regenerating segments after a quit-commit.
+
+    Injects accepted-segments context; writes updated bullets.yaml and
+    seg-NNN.md files with status reset to draft.
+    """
+    source_id = batch.source_id
+    structure_path = pending_structure_path(source_id)
+    if not structure_path.exists():
+        msg = (
+            f"No prior structure.yaml for {source_id!r}. "
+            "Run `regenerate-reading --from=structure` or `generate-reading` first."
+        )
+        raise ReadingPipelineError(msg)
+    structure = structure_mod.read(structure_path)
+
+    info, ctx = _load_context(cfg, source_id)
+    client = _build_client(cfg)
+    model = cfg.models.primary
+
+    existing = _load_existing_bullets(source_id)
+    new_bullets = stage1b_mod.run(
+        transcript=ctx.transcript,
+        structure=structure,
+        preamble_text=ctx.preamble_text,
+        client=client,
+        model=model,
+        segment_ids=list(batch.regen_segment_ids),
+        accepted_context=list(batch.accepted_context),
+    )
+    # rebuilt segments overwrite; untouched segments keep existing bullets
+    merged = existing.segments.copy()
+    for sid, bullets_list in new_bullets.segments.items():
+        merged[sid] = bullets_list
+    for seg in structure.segments:
+        merged.setdefault(seg.id, [])
+    new_bullets.segments = merged
+    stage1b_mod.write_bullets(new_bullets, pending_bullets_path(source_id))
+
+    existing_sc = _load_existing_sidecar(source_id)
+    name_corrections = existing_sc.name_corrections if existing_sc else {}
+    session_date = existing_sc.session_date if existing_sc else None
+    sc = sidecar_mod.Sidecar(
+        default_speaker=structure.default_speaker,
+        name_corrections=name_corrections,
+        session_date=session_date,
+    )
+    sidecar_path = pending_sidecar_path(source_id)
+    sidecar_mod.write(sc, sidecar_path)
+
+    segs_dir = pending_segments_dir(source_id)
+    segs_dir.mkdir(parents=True, exist_ok=True)
+    flags_by_seg = _flags_by_segment(structure)
+    target_ids = set(batch.regen_segment_ids)
+    for seg in structure.segments:
+        if seg.id not in target_ids:
+            continue
+        body = build_segment_body(
+            seg,
+            new_bullets.segments.get(seg.id, []),
+            flags_by_seg.get(seg.id, []),
+            info.source_url,
+            name_corrections,
+        )
+        sf = segment_file_mod.SegmentFile(
+            frontmatter=segment_file_mod.SegmentFrontmatter(
+                segment_id=seg.id,
+                segment_status="draft",
+                start=seg.start,
+                end=seg.end,
+                title=seg.title,
+                speaker=seg.speaker,
+                notes=seg.notes,
+                overrides=list(seg.overrides),
+            ),
+            body=body,
+        )
+        segment_file_mod.write(sf, pending_segment_path(source_id, seg.id))
+
+    return GenerateResult(
+        sidecar_path=sidecar_path,
+        segments_dir=segs_dir,
+        structure_path=pending_structure_path(source_id),
+        bullets_path=pending_bullets_path(source_id),
+        gap_warnings=gap_check_mod.check(structure),
+    )
 
 
 def approve(cfg: cfg_mod.Config, source_id: str) -> Path:

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -150,6 +150,7 @@ def regenerate_after_review(
     new_bullets.segments = merged
     stage1b_mod.write_bullets(new_bullets, pending_bullets_path(source_id))
 
+    warnings = gap_check_mod.check(structure)
     existing_sc = _load_existing_sidecar(source_id)
     name_corrections = existing_sc.name_corrections if existing_sc else {}
     session_date = existing_sc.session_date if existing_sc else None
@@ -157,6 +158,7 @@ def regenerate_after_review(
         default_speaker=structure.default_speaker,
         name_corrections=name_corrections,
         session_date=session_date,
+        gap_warnings=warnings,
     )
     sidecar_path = pending_sidecar_path(source_id)
     sidecar_mod.write(sc, sidecar_path)
@@ -195,7 +197,7 @@ def regenerate_after_review(
         segments_dir=segs_dir,
         structure_path=pending_structure_path(source_id),
         bullets_path=pending_bullets_path(source_id),
-        gap_warnings=gap_check_mod.check(structure),
+        gap_warnings=warnings,
     )
 
 

--- a/src/auto_lorebook/reading_review.py
+++ b/src/auto_lorebook/reading_review.py
@@ -26,6 +26,7 @@ from auto_lorebook import reading_assembly as reading_assembly_mod
 from auto_lorebook import reading_pipeline as pipeline_mod
 from auto_lorebook import reading_sidecar as sidecar_mod
 from auto_lorebook import segment_file as segment_file_mod
+from auto_lorebook.stage1b import AcceptedContextEntry
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -96,6 +97,15 @@ class SegmentView:
     source_title: str | None
 
 
+@dataclass(frozen=True)
+class RegenBatch:
+    """Segments queued for quit-time regeneration."""
+
+    source_id: str
+    regen_segment_ids: tuple[str, ...]
+    accepted_context: tuple[AcceptedContextEntry, ...]  # snapshot of accepted at commit
+
+
 @dataclass
 class ReadingReviewResult:
     """Counts per terminal status after a run."""
@@ -106,6 +116,7 @@ class ReadingReviewResult:
     unchanged: int = 0
     gate_fired: bool = False
     wiki_reading_path: Path | None = None
+    regen_batch: RegenBatch | None = None
 
 
 # ------------- reviewer protocol --------------------------------------------
@@ -232,6 +243,31 @@ def run(
                 result.regenerating += 1
             committed_segments.append(new_sf)
 
+    # Build regen_batch if any committed segment is regenerating.
+    regen_ids = tuple(
+        sf.frontmatter.segment_id
+        for sf in committed_segments
+        if sf.frontmatter.segment_status == "regenerating"
+    )
+    if regen_ids:
+        accepted_entries = tuple(
+            AcceptedContextEntry(
+                segment_id=sf.frontmatter.segment_id,
+                start=sf.frontmatter.start,
+                end=sf.frontmatter.end,
+                title=sf.frontmatter.title,
+                speaker=sf.frontmatter.speaker,
+                bullets_body=sf.body,
+            )
+            for sf in committed_segments
+            if sf.frontmatter.segment_status == "accepted"
+        )
+        result.regen_batch = RegenBatch(
+            source_id=source_id,
+            regen_segment_ids=regen_ids,
+            accepted_context=accepted_entries,
+        )
+
     # Gate: all segments decided?
     effective_statuses = {
         sf.frontmatter.segment_id: sf.frontmatter.segment_status
@@ -240,7 +276,7 @@ def run(
     gate = all(s in {"accepted", "skipped"} for s in effective_statuses.values())
     result.gate_fired = gate
 
-    if gate:
+    if gate and result.regen_batch is None:
         text = reading_assembly_mod.assemble(
             segments=committed_segments, sidecar=sc, info=info
         )

--- a/src/auto_lorebook/stage1b.py
+++ b/src/auto_lorebook/stage1b.py
@@ -36,6 +36,20 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 DEFAULT_HINT_WINDOW_SECONDS = 15.0
+
+
+@dataclass(frozen=True)
+class AcceptedContextEntry:
+    """Accepted segment snapshot injected into regen user messages."""
+
+    segment_id: str
+    start: float
+    end: float
+    title: str
+    speaker: str
+    bullets_body: str  # verbatim body from seg-NNN.md
+
+
 DEFAULT_ANCHOR_TOLERANCE_SECONDS = 2.0
 DEFAULT_MAX_CONCURRENCY = 4
 
@@ -130,6 +144,7 @@ def run(
     anchor_tolerance_seconds: float = DEFAULT_ANCHOR_TOLERANCE_SECONDS,
     max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
     segment_ids: list[str] | None = None,
+    accepted_context: list[AcceptedContextEntry] | None = None,
 ) -> ReadingBullets:
     """Run Stage 1b in parallel across `structure.segments`.
 
@@ -137,6 +152,8 @@ def run(
         raise). Default: run all segments.
     :param anchor_tolerance_seconds: anchors this far outside segment bounds
         are clamped; further raises Stage1bError.
+    :param accepted_context: accepted segments injected as context block into
+        user messages. None or empty → legacy message format.
     :raises Stage1bError: any segment's LLM response fails parsing /
         validation
     """
@@ -162,6 +179,7 @@ def run(
                 model,
                 hint_window_seconds,
                 anchor_tolerance_seconds,
+                accepted_context,
             ): seg.id
             for seg in targets
         }
@@ -183,6 +201,7 @@ def _run_one(
     model: str,
     hint_window_seconds: float,
     anchor_tolerance_seconds: float = DEFAULT_ANCHOR_TOLERANCE_SECONDS,
+    accepted_context: list[AcceptedContextEntry] | None = None,
 ) -> list[Bullet]:
     messages = [
         {
@@ -192,7 +211,9 @@ def _run_one(
         {
             "role": "user",
             "content": _build_user(
-                segment, slice_transcript_for_segment(transcript, segment)
+                segment,
+                slice_transcript_for_segment(transcript, segment),
+                accepted_context,
             ),
         },
     ]
@@ -216,13 +237,30 @@ def _run_one(
     ]
 
 
-def _build_user(segment: Segment, segment_text: str) -> str:
-    return (
+def _build_user(
+    segment: Segment,
+    segment_text: str,
+    accepted_context: list[AcceptedContextEntry] | None = None,
+) -> str:
+    parts: list[str] = []
+    if accepted_context:
+        parts.append("Accepted segments (context only — do not re-extract):\n")
+        for entry in accepted_context:
+            start_ts = format_timestamp(entry.start)
+            end_ts = format_timestamp(entry.end)
+            parts.append(
+                f"## {entry.segment_id} [{start_ts}–{end_ts}]"  # noqa: RUF001
+                f" {entry.title} ({entry.speaker})\n"
+                f"{entry.bullets_body}"
+            )
+        parts.append("---\n")
+    parts.append(
         f'Segment {segment.id}: "{segment.title}" '
         f"(speaker: {segment.speaker})\n"
         f"Range: {segment.start:.0f}s - {segment.end:.0f}s\n\n"
         f"Transcript for this segment:\n\n{segment_text}"
     )
+    return "\n".join(parts)
 
 
 def _parse_bullet(

--- a/tests/test_reading_review.py
+++ b/tests/test_reading_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -13,9 +14,11 @@ from auto_lorebook import config as cfg_mod
 from auto_lorebook import reading_pipeline as pipeline
 from auto_lorebook import segment_file as segment_file_mod
 from auto_lorebook.commands.approve_reading import AutoAcceptReviewer
+from auto_lorebook.openrouter import OpenRouterResponse
 from auto_lorebook.reading_review import (
     AcceptDecision,
     CommitDecision,
+    RegenBatch,
     RegenerateAgainDecision,
     SegmentView,
     SkipBulletsDecision,
@@ -400,3 +403,175 @@ class TestPureNoInputOrPrint:
                         " — engine must be pure-logic (no I/O)"
                     )
                     raise AssertionError(msg)
+
+
+class TestRegenBatchAtCommit:
+    """Engine emits RegenBatch when at least one segment is regenerating."""
+
+    def test_regen_decision_produces_regen_batch(
+        self, env: tuple[cfg_mod.Config, Path]
+    ) -> None:
+        cfg, _ = env
+        # seg-001 accepted, seg-002 regen, seg-003 accepted
+        reviewer = _scripted([
+            AcceptDecision(),
+            RegenerateAgainDecision(),
+            AcceptDecision(),
+        ])
+        result = run(cfg=cfg, source_id=_SOURCE_ID, reviewer=reviewer)
+
+        assert result.gate_fired is False
+        assert result.wiki_reading_path is None
+        assert result.regen_batch is not None
+        assert isinstance(result.regen_batch, RegenBatch)
+        assert result.regen_batch.regen_segment_ids == ("seg-002",)
+        assert result.regen_batch.source_id == _SOURCE_ID
+
+    def test_regen_batch_accepted_context_includes_in_quit_commits(
+        self, env: tuple[cfg_mod.Config, Path]
+    ) -> None:
+        cfg, _ = env
+        # seg-001 accepted, seg-002 regen, seg-003 accepted
+        reviewer = _scripted([
+            AcceptDecision(),
+            RegenerateAgainDecision(),
+            AcceptDecision(),
+        ])
+        result = run(cfg=cfg, source_id=_SOURCE_ID, reviewer=reviewer)
+
+        assert result.regen_batch is not None
+        ctx = result.regen_batch.accepted_context
+        # only accepted segments in context
+        ids = tuple(e.segment_id for e in ctx)
+        assert ids == ("seg-001", "seg-003")
+        # bodies present
+        for entry in ctx:
+            assert entry.bullets_body
+
+    def test_regen_batch_accepted_context_excludes_skipped(
+        self, env: tuple[cfg_mod.Config, Path]
+    ) -> None:
+        cfg, _ = env
+        # seg-001 skipped, seg-002 regen, seg-003 accepted
+        reviewer = _scripted([
+            SkipBulletsDecision(),
+            RegenerateAgainDecision(),
+            AcceptDecision(),
+        ])
+        result = run(cfg=cfg, source_id=_SOURCE_ID, reviewer=reviewer)
+
+        assert result.regen_batch is not None
+        ids = tuple(e.segment_id for e in result.regen_batch.accepted_context)
+        # seg-001 is skipped → not in accepted_context; seg-003 is accepted
+        assert ids == ("seg-003",)
+
+    def test_regen_batch_none_when_no_regenerating_segments(
+        self, env: tuple[cfg_mod.Config, Path]
+    ) -> None:
+        cfg, _ = env
+        reviewer = _scripted([
+            AcceptDecision(),
+            AcceptDecision(),
+            AcceptDecision(),
+        ])
+        result = run(cfg=cfg, source_id=_SOURCE_ID, reviewer=reviewer)
+
+        assert result.regen_batch is None
+
+
+class TestRegenAfterReviewIntegrates:
+    """End-to-end: quit with regen → regenerate_after_review → segment back to draft."""
+
+    def test_regenerated_segment_returns_to_draft(
+        self,
+        tmp_path: Path,
+        tmp_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from auto_lorebook.commands import (  # noqa: PLC0415
+            generate_reading as generate_reading_cmd,
+        )
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+        (home / "config.yaml").write_text(
+            f"schema_version: 1\nwiki_repo_path: {tmp_wiki}\n"
+            "openrouter:\n  api_key_env: FAKE_OR_KEY\n"
+            "models:\n  primary: anthropic/claude-sonnet-4-5\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        source_id = "yt-abc12345678"
+        src_dir = tmp_wiki / "sources" / source_id
+        src_dir.mkdir(parents=True, exist_ok=True)
+        (src_dir / "transcript.en.srt").write_text(_SRT, encoding="utf-8")
+        _write_info(tmp_wiki)
+
+        client = MagicMock()
+        _wire_client_responses(client)
+
+        def _args(**kwargs: object) -> argparse.Namespace:
+            return argparse.Namespace(**kwargs)
+
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            generate_reading_cmd.run(_args(source_id=source_id))
+
+        # manually mark seg-001 as accepted on disk, seg-002 as regenerating
+        seg001_path = pipeline.pending_segment_path(source_id, "seg-001")
+        seg002_path = pipeline.pending_segment_path(source_id, "seg-002")
+        segment_file_mod.set_status(seg001_path, "accepted")
+        segment_file_mod.set_status(seg002_path, "regenerating")
+
+        # build regen batch directly and call regenerate_after_review
+        from auto_lorebook import reading_review as rr_mod  # noqa: PLC0415
+        from auto_lorebook.stage1b import AcceptedContextEntry  # noqa: PLC0415
+
+        sf_001 = segment_file_mod.read(seg001_path)
+
+        batch = rr_mod.RegenBatch(
+            source_id=source_id,
+            regen_segment_ids=("seg-002",),
+            accepted_context=(
+                AcceptedContextEntry(
+                    segment_id=sf_001.frontmatter.segment_id,
+                    start=sf_001.frontmatter.start,
+                    end=sf_001.frontmatter.end,
+                    title=sf_001.frontmatter.title,
+                    speaker=sf_001.frontmatter.speaker,
+                    bullets_body=sf_001.body,
+                ),
+            ),
+        )
+
+        cfg = cfg_mod.Config(wiki_repo_path=tmp_wiki)
+
+        # custom mock: always returns a bullet valid for seg-002's range
+        regen_client = MagicMock()
+        regen_client.complete.return_value = OpenRouterResponse(
+            text=json.dumps({
+                "bullets": [{"text": "Regen bullet", "anchor": "0:02:30"}]
+            }),
+            model="m",
+            tokens_in=0,
+            tokens_out=0,
+        )
+
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=regen_client
+        ):
+            pipeline.regenerate_after_review(cfg, batch)
+
+        # seg-002 should be draft after regen
+        sf_002_after = segment_file_mod.read(seg002_path)
+        assert sf_002_after.frontmatter.segment_status == "draft"
+
+        # body rewritten (contains new regen bullet)
+        assert "Regen bullet" in sf_002_after.body
+
+        # no wiki reading.md written (gate not fired)
+        wiki_reading = tmp_wiki / "sources" / source_id / "reading.md"
+        assert not wiki_reading.exists()

--- a/tests/test_reading_review.py
+++ b/tests/test_reading_review.py
@@ -547,7 +547,7 @@ class TestRegenAfterReviewIntegrates:
             ),
         )
 
-        cfg = cfg_mod.Config(wiki_repo_path=tmp_wiki)
+        cfg = cfg_mod.load_config()
 
         # custom mock: always returns a bullet valid for seg-002's range
         regen_client = MagicMock()

--- a/tests/test_stage1b.py
+++ b/tests/test_stage1b.py
@@ -12,6 +12,7 @@ import pytest
 
 from auto_lorebook.openrouter import OpenRouterResponse
 from auto_lorebook.stage1b import (
+    AcceptedContextEntry,
     Bullet,
     ReadingBullets,
     Stage1bError,
@@ -465,3 +466,158 @@ class TestBulletsIO:
         assert len(loaded.segments["seg-001"]) == 1
         assert loaded.segments["seg-001"][0].text == "Hello Aldara"
         assert loaded.segments["seg-002"] == []
+
+
+class TestAcceptedContext:
+    """accepted_context kwarg on run() / _build_user."""
+
+    def _client_routing(
+        self,
+        per_segment: dict[str, list[dict[str, object]]],
+        captured: dict[str, str],
+    ) -> MagicMock:
+        """Capture user message per segment; return canned bullets."""
+        client = MagicMock()
+        lock = threading.Lock()
+
+        def side_effect(
+            messages: list[dict[str, str]], **_kwargs: object
+        ) -> OpenRouterResponse:
+            user = next(m for m in messages if m["role"] == "user")
+            for seg_id, bullets in per_segment.items():
+                if seg_id in user["content"]:
+                    with lock:
+                        captured[seg_id] = user["content"]
+                        return OpenRouterResponse(
+                            text=_bullets_payload(bullets),
+                            model="m",
+                            tokens_in=0,
+                            tokens_out=0,
+                        )
+            msg = f"no canned response: {user['content'][:80]}"
+            raise AssertionError(msg)
+
+        client.complete.side_effect = side_effect
+        return client
+
+    def test_accepted_context_block_in_user_message(self) -> None:
+        captured: dict[str, str] = {}
+        ctx = [
+            AcceptedContextEntry(
+                segment_id="seg-001",
+                start=0.0,
+                end=135.0,
+                title="Introduction",
+                speaker="DM",
+                bullets_body="- Intro bullet\n",
+            ),
+            AcceptedContextEntry(
+                segment_id="seg-003",
+                start=270.0,
+                end=480.0,
+                title="Founding of Aldara",
+                speaker="DM",
+                bullets_body="- King Theron founded Aldara\n",
+            ),
+        ]
+        client = self._client_routing(
+            {"seg-002": [{"text": "x", "anchor": "0:02:30"}]}, captured
+        )
+        s = Structure(
+            source_id="yt-x",
+            generated_at="2026-04-20T00:00:00Z",
+            default_speaker="DM",
+            segments=[
+                Segment(
+                    id="seg-002",
+                    start=120.0,
+                    end=270.0,
+                    title="Rules",
+                    speaker="mixed",
+                ),
+            ],
+        )
+        transcript = LoadedTranscript(
+            text_for_llm="[0:02:30] some rules text\n", total_duration=600.0
+        )
+        run(
+            transcript=transcript,
+            structure=s,
+            preamble_text="",
+            client=client,
+            model="m",
+            accepted_context=ctx,
+        )
+        msg = captured["seg-002"]
+        # accepted-context block present
+        assert "Accepted segments (context only" in msg
+        # both segment headers present
+        assert "## seg-001 [0:00:00–0:02:15] Introduction (DM)" in msg  # noqa: RUF001
+        assert "## seg-003 [0:04:30–0:08:00] Founding of Aldara (DM)" in msg  # noqa: RUF001
+        # bullets verbatim
+        assert "- Intro bullet" in msg
+        assert "- King Theron founded Aldara" in msg
+        # separator present
+        assert "---" in msg
+        # target segment transcript still there
+        assert "Transcript for this segment:" in msg
+        assert "some rules text" in msg
+        # target segment header present
+        assert "Segment seg-002" in msg
+
+    def test_no_accepted_context_block_when_param_omitted(self) -> None:
+        captured: dict[str, str] = {}
+        client = self._client_routing({"seg-001": []}, captured)
+        s = Structure(
+            source_id="yt-x",
+            generated_at="2026-04-20T00:00:00Z",
+            default_speaker="DM",
+            segments=[
+                Segment(
+                    id="seg-001",
+                    start=0.0,
+                    end=120.0,
+                    title="Intro",
+                    speaker="DM",
+                ),
+            ],
+        )
+        transcript = LoadedTranscript(text_for_llm="plain text", total_duration=120.0)
+        run(
+            transcript=transcript,
+            structure=s,
+            preamble_text="",
+            client=client,
+            model="m",
+        )
+        msg = captured["seg-001"]
+        assert "Accepted segments" not in msg
+
+    def test_accepted_context_with_empty_list_omits_block(self) -> None:
+        captured: dict[str, str] = {}
+        client = self._client_routing({"seg-001": []}, captured)
+        s = Structure(
+            source_id="yt-x",
+            generated_at="2026-04-20T00:00:00Z",
+            default_speaker="DM",
+            segments=[
+                Segment(
+                    id="seg-001",
+                    start=0.0,
+                    end=120.0,
+                    title="Intro",
+                    speaker="DM",
+                ),
+            ],
+        )
+        transcript = LoadedTranscript(text_for_llm="plain text", total_duration=120.0)
+        run(
+            transcript=transcript,
+            structure=s,
+            preamble_text="",
+            client=client,
+            model="m",
+            accepted_context=[],
+        )
+        msg = captured["seg-001"]
+        assert "Accepted segments" not in msg


### PR DESCRIPTION
### What this fixes

Wires the `[g]enerate-again` per-segment action end-to-end in the hierarchical reading-review approve UX. Previously the engine accepted `RegenerateAgainDecision` (writing `regenerating` to the segment's `segment_status`) but the prompt key was missing and there was no quit-time path to actually re-run Stage 1b. Now:

- `src/auto_lorebook/stage1b.py` — adds `AcceptedContextEntry` (frozen dataclass: `segment_id`, `start`, `end`, `title`, `speaker`, `bullets_body`) and an `accepted_context` kwarg on `run` / `_run_one` / `_build_user`. When supplied, the user message gains a compact `## seg-NNN [start–end] Title (speaker)` block + bullets bodies (no transcript) before the existing transcript section. Empty list ≡ None.
- `src/auto_lorebook/reading_review.py` — adds `RegenBatch` (`source_id`, `regen_segment_ids`, `accepted_context`) and `ReadingReviewResult.regen_batch`. After the commit-write loop, the engine emits a `RegenBatch` whenever any committed segment is `regenerating`, snapshotting `accepted` segments (including those committed in the same quit) verbatim from `committed_segments`. Wiki-side `reading.md` write is suppressed when a regen batch is present.
- `src/auto_lorebook/reading_pipeline.py` — adds `regenerate_after_review(cfg, batch)`, mirroring `_run_summarize_only`: parallel `stage1b.run` for the flagged ids, merges into `bullets.yaml`, rewrites the targeted `seg-NNN.md` files with `segment_status="draft"`.
- `src/auto_lorebook/commands/approve_reading.py` — `_SEG_PROMPT` exposes `[g] regenerate-again`; `_per_segment_prompt` sets the pending mark to `"regenerating"` (outer view's existing arrow renders `→regenerating`); `_ReplayReviewer.decide_segment` maps `"regenerating"` → `RegenerateAgainDecision()`; `_commit_and_exit` drives `pipeline.regenerate_after_review` then prints "Still N undecided".
- `docs/pipeline/reading.md` — documents the `[g]` key, the `→regenerating` arrow, the quit-time parallel batch, snapshot semantics, accepted-context block format, and the "still N undecided" exit.

### QA steps for the human

1. `uv run auto-lorebook seed-ingest --at=structure --source-id=yt-test12345678` (or use a real ingest).
2. `uv run auto-lorebook approve-reading yt-test12345678`.
3. At outer prompt: pick seg-001 → `a`, pick seg-002 → `g`, then `q`.
4. Expect: console prints "Regenerating 1 segment(s)...", `seg-002.md` body rewritten with fresh bullets, frontmatter `segment_status: draft`, no `wiki/sources/<id>/reading.md` written.
5. Re-enter `approve-reading <id>`, confirm seg-002 is back at `draft` and accepting it now writes the wiki `reading.md`.

### Automated coverage

`uv run ruff check && uv run ruff format --check && uv run ty check && uv run pytest && uv run mkdocs build --strict` — 552 passed, 4 skipped; lint/format/types/docs clean. Targeted: `tests/test_stage1b.py::TestAcceptedContext` (3) + `tests/test_reading_review.py::TestRegenBatchAtCommit` (4) + `TestRegenAfterReviewIntegrates` (1).

Closes #32

https://claude.ai/code/session_01JGeHGm6GftiXQMurz5GJJt

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGeHGm6GftiXQMurz5GJJt)_