### PR TITLE
Surface gap-check warnings on the Reading Review outer view

### DIFF
--- a/docs/pipeline/reading.md
+++ b/docs/pipeline/reading.md
@@ -121,6 +121,10 @@ surfaces it in reading review:
 The human confirms the stretch is genuinely low-yield or regenerates
 1a with a hint about what to look for.
 
+Warnings are persisted in reading.yaml (gap_warnings: field, schema v2) at generate
+/ regenerate time and re-rendered below the segment list in the approve-reading outer
+view, so the human sees them on every iteration without re-running the generate command.
+
 ## Stage 1b: Summarize
 
 **Purpose.** For each segment from 1a, produce claim bullets — or
@@ -311,6 +315,9 @@ any pending mark for the session:
 | `n` | Jump to the next undecided `draft` segment. |
 | `m` | Open `reading.yaml` (sidecar) in `$EDITOR`. |
 | `q` | Commit pending marks. If every segment is now decided, write wiki-side `reading.md` (gate fires). |
+
+Below the segment list, any persisted gap-check warnings are rendered as
+⚠ Possible coverage gap: blocks (one per stretch, transcript order).
 
 **Per-segment prompt** — shows segment body (up to 60 lines) and current /
 pending status:

--- a/src/auto_lorebook/commands/approve_reading.py
+++ b/src/auto_lorebook/commands/approve_reading.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from auto_lorebook import config as cfg_mod
 from auto_lorebook import info_yaml as info_yaml_mod
 from auto_lorebook import reading_pipeline as pipeline
+from auto_lorebook import reading_sidecar as sidecar_mod
 from auto_lorebook import segment_file as segment_file_mod
 from auto_lorebook.interactive import _is_interactive
 from auto_lorebook.reading_review import (
@@ -20,12 +21,14 @@ from auto_lorebook.reading_review import (
     SkipBulletsDecision,
     UndoDecision,
 )
+from auto_lorebook.reading_sidecar import ReadingSidecarError
 from auto_lorebook.timestamps import format_timestamp
 
 if TYPE_CHECKING:
     import argparse
     from pathlib import Path
 
+    from auto_lorebook.gap_check import GapWarning
     from auto_lorebook.reading_review import SegmentDecision
 
 _logger = logging.getLogger(__name__)
@@ -176,11 +179,30 @@ def _load_summaries(source_id: str) -> list[_SegSummary]:
     return out
 
 
+def _render_gap_warnings(warnings: list[GapWarning]) -> None:
+    """Print gap-warning blocks sorted by start. No output when empty."""
+    if not warnings:
+        return
+    # below segment list, above prompt — keeps warnings in last-screen view
+    print()  # noqa: T201
+    for idx, w in enumerate(sorted(warnings, key=lambda x: x.start)):
+        if idx > 0:
+            print()  # noqa: T201
+        titles = ", ".join(f'"{t}"' for t in w.segment_titles)
+        start_ts = format_timestamp(w.start)
+        end_ts = format_timestamp(w.end)
+        print("⚠ Possible coverage gap:")  # noqa: T201
+        print(f"  {start_ts}–{end_ts} covered only by segments titled")  # noqa: T201, RUF001
+        print(f"  {titles}.")  # noqa: T201
+        print("  If this stretch contained worldbuilding, regenerate with a hint.")  # noqa: T201
+
+
 def _render_outer(
     source_id: str,
     summaries: list[_SegSummary],
     pending_marks: _PendingMarks,
     source_title: str | None,
+    gap_warnings: list[GapWarning] | None = None,
 ) -> None:
     title_str = source_title or source_id
     print(f"\nReading: {source_id} — {title_str}")  # noqa: T201
@@ -193,6 +215,7 @@ def _render_outer(
             f"  {i:>3}. [{s.current_status}]  {start_ts}–{end_ts}  "  # noqa: RUF001
             f"{s.title}  ({s.speaker}){arrow}"
         )
+    _render_gap_warnings(gap_warnings or [])
     print(_OUTER_PROMPT, end="", flush=True)  # noqa: T201
 
 
@@ -342,11 +365,19 @@ def _interactive_session(cfg: cfg_mod.Config, source_id: str) -> int:
     except info_yaml_mod.InfoError:
         pass
 
+    # load gap_warnings from sidecar; fall back to [] on parse failure
+    gap_warnings: list[GapWarning] = []
+    try:
+        sc = sidecar_mod.read(sidecar_path)
+        gap_warnings = sc.gap_warnings
+    except ReadingSidecarError:
+        pass
+
     summaries = _load_summaries(source_id)
     pending_marks: _PendingMarks = {}
 
     while True:
-        _render_outer(source_id, summaries, pending_marks, source_title)
+        _render_outer(source_id, summaries, pending_marks, source_title, gap_warnings)
 
         try:
             choice = input("").strip().lower()

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -431,6 +431,7 @@ def _run_full(cfg: cfg_mod.Config, source_id: str) -> GenerateResult:
         default_speaker=structure.default_speaker,
         name_corrections=name_corrections,
         session_date=session_date,
+        gap_warnings=warnings,
     )
     sidecar_path = pending_sidecar_path(source_id)
     sidecar_mod.write(sc, sidecar_path)
@@ -509,6 +510,7 @@ def _run_summarize_only(
     stage1b_mod.write_bullets(new_bullets, pending_bullets_path(source_id))
 
     # always rewrite sidecar (preserving corrections + session_date)
+    warnings = gap_check_mod.check(structure)
     existing_sc = _load_existing_sidecar(source_id)
     name_corrections = existing_sc.name_corrections if existing_sc else {}
     session_date = existing_sc.session_date if existing_sc else None
@@ -516,6 +518,7 @@ def _run_summarize_only(
         default_speaker=structure.default_speaker,
         name_corrections=name_corrections,
         session_date=session_date,
+        gap_warnings=warnings,
     )
     sidecar_path = pending_sidecar_path(source_id)
     sidecar_mod.write(sc, sidecar_path)
@@ -559,7 +562,7 @@ def _run_summarize_only(
         segments_dir=segs_dir,
         structure_path=pending_structure_path(source_id),
         bullets_path=pending_bullets_path(source_id),
-        gap_warnings=gap_check_mod.check(structure),
+        gap_warnings=warnings,
     )
 
 

--- a/src/auto_lorebook/reading_sidecar.py
+++ b/src/auto_lorebook/reading_sidecar.py
@@ -12,12 +12,14 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 from auto_lorebook._io import atomic_write_text
+from auto_lorebook.gap_check import GapWarning
 from auto_lorebook.schema import SchemaVersionError, read_schema_version
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-_MAX_SCHEMA = 1
+# v2: persist gap_warnings produced at generate time
+_MAX_SCHEMA = 2
 
 
 class ReadingSidecarError(ValueError):
@@ -31,14 +33,43 @@ class Sidecar:
     default_speaker: str
     name_corrections: dict[str, str] = field(default_factory=dict)
     session_date: str | None = None
+    gap_warnings: list[GapWarning] = field(default_factory=list)
+
+
+def _warning_to_dict(w: GapWarning) -> dict[str, Any]:
+    return {
+        "start": w.start,
+        "end": w.end,
+        "segment_ids": list(w.segment_ids),
+        "segment_titles": list(w.segment_titles),
+    }
+
+
+def _warning_from_dict(d: dict[str, Any], path: str) -> GapWarning:
+    """Parse a gap_warnings list entry; raise ReadingSidecarError on bad shape."""
+    try:
+        start = float(d["start"])
+        end = float(d["end"])
+        segment_ids = tuple(str(s) for s in d["segment_ids"])
+        segment_titles = tuple(str(s) for s in d["segment_titles"])
+    except (KeyError, TypeError, ValueError) as e:
+        msg = f"{path}: malformed gap_warnings entry: {e}"
+        raise ReadingSidecarError(msg) from e
+    return GapWarning(
+        start=start,
+        end=end,
+        segment_ids=segment_ids,
+        segment_titles=segment_titles,
+    )
 
 
 def _to_dict(sc: Sidecar) -> dict[str, Any]:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "default_speaker": sc.default_speaker,
         "session_date": sc.session_date,
         "name_corrections": dict(sc.name_corrections),
+        "gap_warnings": [_warning_to_dict(w) for w in sc.gap_warnings],
     }
 
 
@@ -91,8 +122,15 @@ def read(path: Path) -> Sidecar:
         raise ReadingSidecarError(msg)
     name_corrections = {str(k): str(v) for k, v in raw_corrections.items()}
 
+    raw_warnings = data.get("gap_warnings") or []
+    if not isinstance(raw_warnings, list):
+        msg = f"{path}: gap_warnings must be a list"
+        raise ReadingSidecarError(msg)
+    gap_warnings = [_warning_from_dict(w, str(path)) for w in raw_warnings]
+
     return Sidecar(
         default_speaker=default_speaker,
         name_corrections=name_corrections,
         session_date=session_date,
+        gap_warnings=gap_warnings,
     )

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -259,7 +259,7 @@ class TestGenerateReading:
         import yaml as _yaml  # noqa: PLC0415
 
         sidecar_data = _yaml.safe_load((pending / "reading.yaml").read_text())
-        assert sidecar_data["schema_version"] == 1
+        assert sidecar_data["schema_version"] == 2
         assert sidecar_data["default_speaker"] == "DM"
 
         # seg-002.md contains the Theron claim
@@ -280,6 +280,72 @@ class TestGenerateReading:
         _write_user_config(tmp_home, ingested_wiki)
         rc = generate_reading_cmd.run(_args(source_id="yt-not-ingested"))
         assert rc == 1
+
+
+class TestGenerateReadingSidecarSchema:
+    """Sidecar written by generate-reading has correct schema and gap_warnings."""
+
+    def test_sidecar_schema_v2_and_gap_warnings_empty(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        client = MagicMock()
+        _wire_client_responses(client)
+        with patch(
+            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        ):
+            rc = generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+        assert rc == 0
+
+        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        sidecar_data = yaml.safe_load((pending / "reading.yaml").read_text())
+        assert sidecar_data["schema_version"] == 2
+        # fixture has only "Intro" + "Founding of Aldara" — no low-yield matches
+        assert sidecar_data["gap_warnings"] == []
+
+    def test_sidecar_gap_warnings_persisted_when_present(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        from auto_lorebook.gap_check import GapWarning  # noqa: PLC0415
+
+        stub_warning = GapWarning(
+            start=2050.0,
+            end=2902.0,
+            segment_ids=("seg-005",),
+            segment_titles=("Pizza discussion",),
+        )
+        client = MagicMock()
+        _wire_client_responses(client)
+        with (
+            patch(
+                "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+            ),
+            patch(
+                "auto_lorebook.reading_pipeline.gap_check_mod.check",
+                return_value=[stub_warning],
+            ),
+        ):
+            rc = generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+        assert rc == 0
+
+        from auto_lorebook import reading_sidecar as sidecar_mod  # noqa: PLC0415
+
+        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        sc = sidecar_mod.read(pending / "reading.yaml")
+        assert len(sc.gap_warnings) == 1
+        assert sc.gap_warnings[0].start == pytest.approx(2050.0)
+        assert sc.gap_warnings[0].segment_titles == ("Pizza discussion",)
 
 
 class TestApproveReading:
@@ -839,6 +905,79 @@ class TestPlan:
 
         out = capsys.readouterr().out
         assert "Plan:" in out
+
+
+class TestRenderOuterGapWarnings:
+    """_render_outer renders gap warnings below segment list, above prompt."""
+
+    def _make_summaries(self) -> list:
+        from auto_lorebook.commands.approve_reading import (  # noqa: PLC0415
+            _SegSummary,  # noqa: PLC2701
+        )
+
+        return [
+            _SegSummary(
+                segment_id="seg-001",
+                title="Intro",
+                start=0.0,
+                end=120.0,
+                speaker="DM",
+                current_status="draft",
+            )
+        ]
+
+    def test_empty_warnings_no_gap_block(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from auto_lorebook.commands.approve_reading import (  # noqa: PLC0415
+            _render_outer,  # noqa: PLC2701
+        )
+
+        summaries = self._make_summaries()
+        _render_outer("yt-test", summaries, {}, "Test Session", gap_warnings=[])
+        out = capsys.readouterr().out
+        assert "seg-001" in out or "Intro" in out
+        assert "Possible coverage gap" not in out
+        assert "⚠" not in out
+
+    def test_nonempty_warnings_renders_blocks(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from auto_lorebook.commands.approve_reading import (  # noqa: PLC0415
+            _render_outer,  # noqa: PLC2701
+        )
+        from auto_lorebook.gap_check import GapWarning  # noqa: PLC0415
+
+        w1 = GapWarning(
+            start=2050.0,
+            end=2902.0,
+            segment_ids=("seg-005", "seg-006", "seg-007"),
+            segment_titles=("Pizza discussion", "Break", "Rules: initiative"),
+        )
+        w2 = GapWarning(
+            start=5400.0,
+            end=6100.0,
+            segment_ids=("seg-012",),
+            segment_titles=("Silence",),
+        )
+        summaries = self._make_summaries()
+        _render_outer("yt-test", summaries, {}, "Test Session", gap_warnings=[w1, w2])
+        out = capsys.readouterr().out
+        assert "⚠ Possible coverage gap:" in out
+        # w1 timestamps
+        assert "0:34:10" in out
+        assert "0:48:22" in out
+        assert '"Pizza discussion"' in out
+        assert '"Break"' in out
+        assert '"Rules: initiative"' in out
+        assert "If this stretch contained worldbuilding" in out
+        # w2 timestamps
+        assert "1:30:00" in out
+        assert "1:41:40" in out
+        # w1 before w2 in output
+        idx1 = out.index("0:34:10")
+        idx2 = out.index("1:30:00")
+        assert idx1 < idx2
 
 
 class TestExtract:

--- a/tests/test_reading_sidecar.py
+++ b/tests/test_reading_sidecar.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 import yaml
 
+from auto_lorebook.gap_check import GapWarning
 from auto_lorebook.reading_sidecar import ReadingSidecarError, Sidecar, read, write
 
 if TYPE_CHECKING:
@@ -19,6 +20,23 @@ def _full_sidecar() -> Sidecar:
         name_corrections={"Fair-on": "Theron", "Aldera": "Aldara"},
         session_date="2026-01-15",
     )
+
+
+def _two_warnings() -> list[GapWarning]:
+    return [
+        GapWarning(
+            start=2050.0,
+            end=2902.0,
+            segment_ids=("seg-005", "seg-006", "seg-007"),
+            segment_titles=("Pizza discussion", "Break", "Rules: initiative"),
+        ),
+        GapWarning(
+            start=5400.0,
+            end=6100.0,
+            segment_ids=("seg-012",),
+            segment_titles=("Silence",),
+        ),
+    ]
 
 
 class TestRoundTripFull:
@@ -35,7 +53,7 @@ class TestRoundTripFull:
         p = tmp_path / "reading.yaml"
         write(_full_sidecar(), p)
         first_line = p.read_text(encoding="utf-8").splitlines()[0]
-        assert first_line == "schema_version: 1"
+        assert first_line == "schema_version: 2"
 
     def test_key_order(self, tmp_path: Path) -> None:
         p = tmp_path / "reading.yaml"
@@ -47,6 +65,7 @@ class TestRoundTripFull:
             "default_speaker",
             "session_date",
             "name_corrections",
+            "gap_warnings",
         ]
 
     def test_byte_identical_round_trip(self, tmp_path: Path) -> None:
@@ -101,3 +120,48 @@ class TestFutureSchemaRaises:
         )
         with pytest.raises(ReadingSidecarError, match="schema_version"):
             read(p)
+
+
+class TestGapWarnings:
+    def test_round_trip_two_warnings(self, tmp_path: Path) -> None:
+        warnings = _two_warnings()
+        sc = Sidecar(default_speaker="DM", gap_warnings=warnings)
+        p = tmp_path / "reading.yaml"
+        write(sc, p)
+        loaded = read(p)
+        assert len(loaded.gap_warnings) == 2
+        w0 = loaded.gap_warnings[0]
+        assert w0.start == pytest.approx(2050.0)
+        assert w0.end == pytest.approx(2902.0)
+        assert w0.segment_ids == ("seg-005", "seg-006", "seg-007")
+        assert w0.segment_titles == ("Pizza discussion", "Break", "Rules: initiative")
+        w1 = loaded.gap_warnings[1]
+        assert w1.start == pytest.approx(5400.0)
+        assert w1.end == pytest.approx(6100.0)
+        assert w1.segment_ids == ("seg-012",)
+        assert w1.segment_titles == ("Silence",)
+
+    def test_schema_version_is_2(self, tmp_path: Path) -> None:
+        sc = Sidecar(default_speaker="DM", gap_warnings=_two_warnings())
+        p = tmp_path / "reading.yaml"
+        write(sc, p)
+        first_line = p.read_text(encoding="utf-8").splitlines()[0]
+        assert first_line == "schema_version: 2"
+
+    def test_key_order_ends_with_gap_warnings(self, tmp_path: Path) -> None:
+        sc = Sidecar(default_speaker="DM", gap_warnings=_two_warnings())
+        p = tmp_path / "reading.yaml"
+        write(sc, p)
+        parsed = yaml.safe_load(p.read_text(encoding="utf-8"))
+        assert list(parsed.keys())[-1] == "gap_warnings"
+
+    def test_v1_back_compat_reads_empty_gap_warnings(self, tmp_path: Path) -> None:
+        # v1 YAML without gap_warnings key — should read as []
+        p = tmp_path / "reading.yaml"
+        p.write_text(
+            "schema_version: 1\ndefault_speaker: DM\n"
+            "session_date: null\nname_corrections: {}\n",
+            encoding="utf-8",
+        )
+        loaded = read(p)
+        assert loaded.gap_warnings == []


### PR DESCRIPTION
### What this fixes

Stage 1a's mechanical gap check (`gap_check_mod.check(structure)` in `reading_pipeline._run_full` / `_run_summarize_only`) already produced `GapWarning` objects, but they were only printed at command exit and not persisted. Once the human moved on to `approve-reading`, the warnings were gone and they had to re-run `generate-reading` to see them again.

This slice persists the warnings into the reading sidecar and renders them on the outer hierarchical view of `approve-reading`, so coverage gaps are visible on every iteration of the review loop without leaving it.

- `src/auto_lorebook/reading_sidecar.py` — schema bumped 1→2; new `gap_warnings: list[GapWarning]` field with tuple↔list (de)serialization helpers (`_warning_to_dict`, `_warning_from_dict`); v1 files read back with missing field as `[]` (back-compat preserved).
- `src/auto_lorebook/reading_pipeline.py` — `_run_full` and `_run_summarize_only` now pass `gap_warnings=warnings` into the `Sidecar(...)` constructor at write time.
- `src/auto_lorebook/commands/approve_reading.py` — `_render_outer` accepts `gap_warnings: list[GapWarning]`; new `_render_gap_warnings` helper renders `⚠ Possible coverage gap:` blocks (sorted by `w.start`, blank line above, blank lines between, advisory trailer line). Empty list renders nothing. Placement: below the segment list, above the outer prompt — keeps warnings in the last-screen view of `less`-style scrollback. `_interactive_session` reads the sidecar and passes warnings to every `_render_outer` call, with a `try/except ReadingSidecarError → []` fallback so a malformed sidecar can't crash the loop.
- `docs/pipeline/reading.md` — gap-check section and outer-view section updated to reflect persistence + render placement.

### QA steps for the human

None — fully covered by the integration smoke. The smoke drove `generate-reading` end-to-end on the test SRT fixture (empty + forced non-empty `gap_warnings`), confirmed the on-disk YAML round-trips, exercised the v1 back-compat path with a hand-crafted v1 sidecar, exercised the `ReadingSidecarError` path with malformed payloads, and ran `approve-reading` in both `--yes` mode and a scripted interactive session against a corrupted sidecar to confirm the fallback to `[]` works. The visual render block matches the issue example verbatim (`0:34:10–0:48:22 covered only by segments titled "Pizza discussion", "Break", "Rules: initiative". If this stretch contained worldbuilding, regenerate with a hint.`).

### Automated coverage

`uv run ruff check` · `uv run ty check` · `uv run pytest -q` (552 passed, 4 live-marked skipped) · `uv run mkdocs build --strict` — all green.

Closes #33

https://claude.ai/code/session_01JfSbz9H5Aq2Qw5VxkAYWNa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfSbz9H5Aq2Qw5VxkAYWNa)_