### PR TITLE
Wiki registry: schema v2 + first-run setup (slice 1 of #51)

### DIFF
--- a/src/auto_lorebook/commands/_shared.py
+++ b/src/auto_lorebook/commands/_shared.py
@@ -35,7 +35,7 @@ def finalize_context(
     Shared tail for `ingest` and `configure-context` commands.
     Returns the CLI exit code.
     """
-    wiki_repo = cfg.wiki_repo_path
+    wiki_repo = cfg.resolve_active_wiki(None)
     wc = wiki_context.read(wiki_repo / ".wiki-context.yaml")
     cors = corrections.read(wiki_repo / ".transcription-corrections.yaml")
     last_ctx = cfg_mod.load_last_context()

--- a/src/auto_lorebook/commands/approve_reading.py
+++ b/src/auto_lorebook/commands/approve_reading.py
@@ -377,7 +377,7 @@ def _interactive_session(cfg: cfg_mod.Config, source_id: str) -> int:
     # load source title for header
     source_title: str | None = None
     try:
-        info_path = cfg.wiki_repo_path / "sources" / source_id / "info.yaml"
+        info_path = cfg.resolve_active_wiki(None) / "sources" / source_id / "info.yaml"
         info = info_yaml_mod.read(info_path)
         source_title = info.title
     except info_yaml_mod.InfoError:

--- a/src/auto_lorebook/commands/configure_context.py
+++ b/src/auto_lorebook/commands/configure_context.py
@@ -61,7 +61,7 @@ def run(args: argparse.Namespace) -> int:
         _logger.error("%s", e)
         return 1
 
-    info_path = cfg.wiki_repo_path / "sources" / args.source_id / "info.yaml"
+    info_path = cfg.resolve_active_wiki(None) / "sources" / args.source_id / "info.yaml"
 
     if not info_path.exists():
         _logger.error(

--- a/src/auto_lorebook/commands/entities.py
+++ b/src/auto_lorebook/commands/entities.py
@@ -103,7 +103,7 @@ def run(args: argparse.Namespace) -> int:
     """Dispatch to the matching `_run_*` based on `entities_action`."""
     action = args.entities_action
     cfg = cfg_mod.load_config()
-    wiki = cfg.wiki_repo_path
+    wiki = cfg.resolve_active_wiki(None)
 
     if action == "list":
         return _run_list(args, wiki)

--- a/src/auto_lorebook/commands/ingest.py
+++ b/src/auto_lorebook/commands/ingest.py
@@ -117,7 +117,7 @@ def run(args: argparse.Namespace) -> int:
     except KeyboardInterrupt:
         return 130
 
-    wiki_repo = cfg.wiki_repo_path
+    wiki_repo = cfg.resolve_active_wiki(None)
 
     if args.url_or_path.startswith(("http://", "https://")):
         return _run_from_url(args, cfg, wiki_repo)

--- a/src/auto_lorebook/commands/seed_ingest.py
+++ b/src/auto_lorebook/commands/seed_ingest.py
@@ -130,22 +130,23 @@ def _mint_source_id(cfg: cfg_mod.Config) -> str:
 
 
 def _source_collides(cfg: cfg_mod.Config, sid: str) -> bool:
-    wiki_src = cfg.wiki_repo_path / "sources" / sid
+    wiki_src = cfg.resolve_active_wiki(None) / "sources" / sid
     pending = cfg_mod.config_dir() / "pending" / sid
     return wiki_src.exists() or pending.exists()
 
 
 def _seed(cfg: cfg_mod.Config, sid: str, at: str, fixture_name: str) -> None:
+    wiki_repo = cfg.resolve_active_wiki(None)
     if _source_collides(cfg, sid):
         msg = (
             f"source {sid!r} already exists under "
-            f"{cfg.wiki_repo_path / 'sources' / sid} or "
+            f"{wiki_repo / 'sources' / sid} or "
             f"{cfg_mod.config_dir() / 'pending' / sid}"
         )
         raise SeedIngestError(msg)
 
     fixture_root = _resolve_fixture(fixture_name)
-    wiki_src = cfg.wiki_repo_path / "sources" / sid
+    wiki_src = wiki_repo / "sources" / sid
     pending_reading = cfg_mod.config_dir() / "pending" / sid / "reading"
 
     # wiki side first so a half-failed seed leaves only sources/<sid>

--- a/src/auto_lorebook/config.py
+++ b/src/auto_lorebook/config.py
@@ -13,10 +13,11 @@ import yaml
 
 from auto_lorebook._io import atomic_write_text
 from auto_lorebook.schema import SchemaVersionError, read_schema_version
+from auto_lorebook.wiki_registry import WikiEntry
 
 _logger = logging.getLogger(__name__)
 
-_MAX_SCHEMA = 1
+_MAX_SCHEMA = 2
 _CONFIG_DIR_ENV = "AUTO_LOREBOOK_HOME"
 
 
@@ -48,7 +49,8 @@ class PreambleConfig:
 class Config:
     """Loaded ~/.auto-lorebook/config.yaml."""
 
-    wiki_repo_path: Path
+    wikis: list[WikiEntry]
+    active_wiki: str | None
     openrouter: OpenRouterConfig = field(default_factory=OpenRouterConfig)
     models: ModelsConfig = field(default_factory=ModelsConfig)
     preamble: PreambleConfig = field(default_factory=PreambleConfig)
@@ -59,6 +61,30 @@ class Config:
         if env_value:
             return env_value
         return _read_credentials()
+
+    def resolve_active_wiki(self, override: str | None) -> Path:
+        """Resolve the active wiki path.
+
+        Precedence: override > active_wiki.
+
+        :raises ConfigError: override unknown, active unset, or path missing on disk
+        """
+        known: dict[str, Path] = {e.nickname: e.path for e in self.wikis}
+        nick = override if override is not None else self.active_wiki
+        if nick is None:
+            msg = "No active wiki configured. Set active_wiki in config.yaml."
+            raise ConfigError(msg)
+        if nick not in known:
+            msg = f"Unknown wiki nickname: {nick!r}. Check config.yaml."
+            raise ConfigError(msg)
+        path = known[nick]
+        if not path.exists():
+            msg = (
+                f"Wiki {nick!r} path does not exist: {path}. "
+                "Update or remove the entry in config.yaml."
+            )
+            raise ConfigError(msg)
+        return path
 
 
 @dataclass
@@ -105,14 +131,32 @@ def load_config(home: Path | None = None) -> Config:
     if not isinstance(raw, dict):
         msg = f"{cfg_path}: expected a YAML mapping, got {type(raw).__name__}"
         raise ConfigError(msg)
+
+    # v1 hard error: schema_version == 1 or wiki_repo_path key present
+    if raw.get("schema_version") == 1 or "wiki_repo_path" in raw:
+        msg = (
+            f"{cfg_path}: schema_version 1 is not supported. "
+            "Delete this file and re-run `auto-lorebook ingest` "
+            "to create a v2 config."
+        )
+        raise ConfigError(msg)
+
     try:
         read_schema_version(raw, str(cfg_path), max_supported=_MAX_SCHEMA)
     except SchemaVersionError as e:
         raise ConfigError(str(e)) from e
 
-    wiki_repo_path_raw = raw.get("wiki_repo_path")
-    if not wiki_repo_path_raw:
-        msg = f"{cfg_path}: wiki_repo_path is required"
+    wikis_raw = raw.get("wikis")
+    if not wikis_raw:
+        msg = f"{cfg_path}: wikis is required"
+        raise ConfigError(msg)
+
+    wikis = [WikiEntry(d["nickname"], Path(d["path"])) for d in wikis_raw]
+    active_wiki: str | None = raw.get("active_wiki") or None
+
+    known = {e.nickname for e in wikis}
+    if active_wiki is not None and active_wiki not in known:
+        msg = f"{cfg_path}: active_wiki {active_wiki!r} not found in wikis"
         raise ConfigError(msg)
 
     or_raw: dict[str, Any] = raw.get("openrouter") or {}
@@ -133,7 +177,8 @@ def load_config(home: Path | None = None) -> Config:
     )
 
     return Config(
-        wiki_repo_path=Path(wiki_repo_path_raw),
+        wikis=wikis,
+        active_wiki=active_wiki,
         openrouter=openrouter,
         models=models,
         preamble=preamble,
@@ -237,6 +282,7 @@ def interactive_setup(home: Path | None = None) -> Config:
     print("First run: setting up ~/.auto-lorebook/config.yaml.")  # noqa: T201
     print()  # noqa: T201
 
+    nick = _prompt("Wiki nickname")
     wiki_raw = _prompt("Wiki repository directory")
     wiki = Path(wiki_raw).expanduser().resolve()
     api_key = getpass.getpass(
@@ -249,8 +295,9 @@ def interactive_setup(home: Path | None = None) -> Config:
     )
 
     data: dict[str, Any] = {
-        "schema_version": 1,
-        "wiki_repo_path": str(wiki),
+        "schema_version": 2,
+        "active_wiki": nick,
+        "wikis": [{"nickname": nick, "path": str(wiki)}],
         "openrouter": {"api_key_env": _DEFAULT_API_KEY_ENV},
         "models": {"primary": model},
     }

--- a/src/auto_lorebook/ingest_cleanup.py
+++ b/src/auto_lorebook/ingest_cleanup.py
@@ -95,7 +95,7 @@ def _walk_entity_paths(wiki_repo: Path) -> list[Path]:
 def preview(cfg: Config, source_id: str) -> RejectResult:
     """Read-only count of what `reject_ingest` would change."""
     result = RejectResult()
-    for path in _walk_entity_paths(cfg.wiki_repo_path):
+    for path in _walk_entity_paths(cfg.resolve_active_wiki(None)):
         try:
             entity = entity_yaml.read(path)
         except entity_yaml.EntityError:
@@ -113,7 +113,7 @@ def preview(cfg: Config, source_id: str) -> RejectResult:
 def reject_ingest(cfg: Config, source_id: str) -> RejectResult:
     """Remove `source_id`'s contributions from every entity; clean pending."""
     result = RejectResult()
-    for path in _walk_entity_paths(cfg.wiki_repo_path):
+    for path in _walk_entity_paths(cfg.resolve_active_wiki(None)):
         try:
             entity = entity_yaml.read(path)
         except entity_yaml.EntityError:

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -238,7 +238,7 @@ def assemble_draft(cfg: cfg_mod.Config, source_id: str) -> str:
         msg = f"No draft reading for {source_id!r}. Run `generate-reading` first."
         raise ReadingPipelineError(msg)
 
-    wiki_repo = cfg.wiki_repo_path
+    wiki_repo = cfg.resolve_active_wiki(None)
     info_path = wiki_repo / "sources" / source_id / "info.yaml"
     try:
         info = info_yaml_mod.read(info_path)
@@ -299,7 +299,7 @@ def plan(cfg: cfg_mod.Config, source_id: str) -> PlanResult:
     :raises ReadingPipelineError: reading not approved, prior pipeline
         artifacts missing, or planner / preamble failure.
     """
-    wiki_repo = cfg.wiki_repo_path
+    wiki_repo = cfg.resolve_active_wiki(None)
     approved_path = wiki_repo / "sources" / source_id / "reading.md"
     if not approved_path.exists():
         msg = (
@@ -373,7 +373,7 @@ def extract(cfg: cfg_mod.Config, source_id: str) -> ExtractResult:
     :raises ReadingPipelineError: missing plan, plain-text source, or
         Stage 3 failure (bad LLM output, schema violation).
     """
-    wiki_repo = cfg.wiki_repo_path
+    wiki_repo = cfg.resolve_active_wiki(None)
     plan_path = pending_plan_path(source_id)
     if not plan_path.exists():
         msg = f"No plan at {plan_path}. Run `plan {source_id}` first."
@@ -667,7 +667,7 @@ class _Context:
 
 
 def _load_context(cfg: cfg_mod.Config, source_id: str) -> tuple[Info, _Context]:
-    wiki_repo = cfg.wiki_repo_path
+    wiki_repo = cfg.resolve_active_wiki(None)
     info_path = wiki_repo / "sources" / source_id / "info.yaml"
     if not info_path.exists():
         msg = f"info.yaml not found for {source_id!r}: run `ingest` first"

--- a/src/auto_lorebook/reading_review.py
+++ b/src/auto_lorebook/reading_review.py
@@ -153,7 +153,7 @@ def run(
     Returns a `ReadingReviewResult` describing what happened. When the gate
     fires (every segment decided), writes the wiki-side `reading.md`.
     """
-    wiki_repo = cfg.wiki_repo_path
+    wiki_repo = cfg.resolve_active_wiki(None)
     info_path = wiki_repo / "sources" / source_id / "info.yaml"
     try:
         info = info_yaml_mod.read(info_path)

--- a/src/auto_lorebook/review.py
+++ b/src/auto_lorebook/review.py
@@ -389,7 +389,7 @@ def _resolve_entity_path(
             )
             raise ReviewError(msg)
         slug = entity_yaml_mod.slugify(proposal.target_entity)
-        path = ctx.cfg.wiki_repo_path / category / f"{slug}.yaml"
+        path = ctx.cfg.resolve_active_wiki(None) / category / f"{slug}.yaml"
         return path, slug, category
 
     entry = ctx.index.lookup(proposal.target_entity)
@@ -399,7 +399,7 @@ def _resolve_entity_path(
             f"is marked existing but not found in entity index"
         )
         raise ReviewError(msg)
-    path = ctx.cfg.wiki_repo_path / entry.category / f"{entry.slug}.yaml"
+    path = ctx.cfg.resolve_active_wiki(None) / entry.category / f"{entry.slug}.yaml"
     return path, entry.slug, entry.category
 
 
@@ -467,7 +467,7 @@ def _approve(
     entity_yaml_mod.write(entity, path)
     proposal_path.unlink(missing_ok=True)
     # refresh in-memory index so siblings later in the loop see this entity
-    ctx.index = entity_index_mod.build(ctx.cfg.wiki_repo_path)
+    ctx.index = entity_index_mod.build(ctx.cfg.resolve_active_wiki(None))
     # record merged aliases so sibling prompts skip them
     target_key = proposal.target_entity.casefold()
     for alias in confirmed_aliases:
@@ -500,7 +500,7 @@ def _build_target_view(ctx: _ApprovalContext, proposal: Proposal) -> TargetView:
         existing_entry = ctx.index.lookup(proposal.target_entity)
         if existing_entry is not None:
             entity_path = (
-                ctx.cfg.wiki_repo_path
+                ctx.cfg.resolve_active_wiki(None)
                 / existing_entry.category
                 / f"{existing_entry.slug}.yaml"
             )
@@ -612,7 +612,11 @@ def _seed_merged_aliases_from_disk(ctx: _ApprovalContext) -> None:
             entry = ctx.index.lookup(target.entity)
             if entry is None:
                 continue
-            path = ctx.cfg.wiki_repo_path / entry.category / f"{entry.slug}.yaml"
+            path = (
+                ctx.cfg.resolve_active_wiki(None)
+                / entry.category
+                / f"{entry.slug}.yaml"
+            )
             if not path.exists():
                 continue
             try:
@@ -641,7 +645,7 @@ def run(
     route. KeyboardInterrupt propagates after recording the count of
     proposal files left on disk as `remaining`.
     """
-    wiki_repo = cfg.wiki_repo_path
+    wiki_repo = cfg.resolve_active_wiki(None)
     info_path = wiki_repo / "sources" / source_id / "info.yaml"
     info = info_yaml_mod.read(info_path)
     plan_path = reading_pipeline.pending_plan_path(source_id)

--- a/src/auto_lorebook/wiki_registry.py
+++ b/src/auto_lorebook/wiki_registry.py
@@ -1,0 +1,95 @@
+"""Pure data layer for the wiki registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+class WikiRegistryError(ValueError):
+    """Raised on invalid registry mutation."""
+
+
+@dataclass
+class WikiEntry:
+    """Single wiki entry: nickname + filesystem path."""
+
+    nickname: str
+    path: Path
+
+
+@dataclass
+class WikiRegistry:
+    """Ordered list of wiki entries + active pointer. No filesystem IO."""
+
+    entries: list[WikiEntry] = field(default_factory=list)
+    active: str | None = None
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_list(self) -> list[dict[str, str]]:
+        """Serialize entries to list of {nickname, path} dicts."""
+        return [{"nickname": e.nickname, "path": str(e.path)} for e in self.entries]
+
+    @classmethod
+    def from_list(
+        cls,
+        data: list[dict[str, Any]],
+        *,
+        active: str | None,
+    ) -> WikiRegistry:
+        """Deserialize from list of {nickname, path} dicts."""
+        entries = [WikiEntry(d["nickname"], Path(d["path"])) for d in data]
+        return cls(entries=entries, active=active)
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+
+    def _known_nicknames(self) -> set[str]:
+        return {e.nickname for e in self.entries}
+
+    def add(self, entry: WikiEntry) -> None:
+        """Append entry; raises if nickname already exists."""
+        if entry.nickname in self._known_nicknames():
+            msg = f"nickname already registered: {entry.nickname!r}"
+            raise WikiRegistryError(msg)
+        self.entries.append(entry)
+
+    def remove(self, nickname: str) -> None:
+        """Drop entry by nickname; refuses if it is the active entry."""
+        if nickname == self.active:
+            msg = f"cannot remove active wiki: {nickname!r}"
+            raise WikiRegistryError(msg)
+        idx = next(
+            (i for i, e in enumerate(self.entries) if e.nickname == nickname), None
+        )
+        if idx is None:
+            msg = f"unknown nickname: {nickname!r}"
+            raise WikiRegistryError(msg)
+        del self.entries[idx]
+
+    def rename(self, old: str, new: str) -> None:
+        """Rename entry; updates active pointer if matched."""
+        if old not in self._known_nicknames():
+            msg = f"unknown nickname: {old!r}"
+            raise WikiRegistryError(msg)
+        if new != old and new in self._known_nicknames():
+            msg = f"nickname already registered: {new!r}"
+            raise WikiRegistryError(msg)
+        for e in self.entries:
+            if e.nickname == old:
+                e.nickname = new
+                break
+        if self.active == old:
+            self.active = new
+
+    def set_active(self, nickname: str) -> None:
+        """Set active; raises if nickname unknown."""
+        if nickname not in self._known_nicknames():
+            msg = f"unknown nickname: {nickname!r}"
+            raise WikiRegistryError(msg)
+        self.active = nickname

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ from auto_lorebook.config import (
     load_last_context,
     save_last_context,
 )
+from auto_lorebook.wiki_registry import WikiEntry
 
 
 def _write_config(path: Path, data: dict) -> None:
@@ -24,8 +25,16 @@ def _write_config(path: Path, data: dict) -> None:
     path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
 
 
+def _cfg(wiki_path: Path) -> Config:
+    """Build a minimal v2 Config for tests."""
+    return Config(
+        wikis=[WikiEntry("test", wiki_path)],
+        active_wiki="test",
+    )
+
+
 # ---------------------------------------------------------------------------
-# load_config
+# load_config — v2 schema
 # ---------------------------------------------------------------------------
 
 
@@ -34,14 +43,16 @@ def test_load_config_minimal(tmp_path: Path) -> None:
     _write_config(
         tmp_path / "config.yaml",
         {
-            "schema_version": 1,
-            "wiki_repo_path": wiki_path,
+            "schema_version": 2,
+            "wikis": [{"nickname": "home", "path": wiki_path}],
+            "active_wiki": "home",
             "openrouter": {"api_key_env": "OPENROUTER_API_KEY"},
             "models": {"primary": "anthropic/claude-sonnet-4-5"},
         },
     )
     cfg = load_config(home=tmp_path)
-    assert cfg.wiki_repo_path == Path(wiki_path)
+    assert cfg.wikis == [WikiEntry("home", Path(wiki_path))]
+    assert cfg.active_wiki == "home"
     assert cfg.openrouter.api_key_env == "OPENROUTER_API_KEY"
     assert cfg.models.primary == "anthropic/claude-sonnet-4-5"
     assert cfg.models.primary_context_window == 200_000
@@ -53,8 +64,9 @@ def test_load_config_with_all_fields(tmp_path: Path) -> None:
     _write_config(
         tmp_path / "config.yaml",
         {
-            "schema_version": 1,
-            "wiki_repo_path": wiki_path,
+            "schema_version": 2,
+            "wikis": [{"nickname": "main", "path": wiki_path}],
+            "active_wiki": "main",
             "openrouter": {"api_key_env": "MY_KEY"},
             "models": {
                 "primary": "anthropic/claude-opus-4-7",
@@ -77,8 +89,133 @@ def test_load_config_missing_file_raises(tmp_path: Path) -> None:
         load_config(home=tmp_path)
 
 
+def test_load_config_v1_hard_errors(tmp_path: Path) -> None:
+    wiki_path = str(tmp_path / "wiki")
+    _write_config(
+        tmp_path / "config.yaml",
+        {"schema_version": 1, "wiki_repo_path": wiki_path},
+    )
+    with pytest.raises(ConfigError) as exc_info:
+        load_config(home=tmp_path)
+    msg = str(exc_info.value)
+    assert str(tmp_path / "config.yaml") in msg
+    assert "delete" in msg.lower()
+    assert "re-run" in msg.lower()
+
+
+def test_load_config_v1_detected_by_wiki_repo_path_key(tmp_path: Path) -> None:
+    """wiki_repo_path key without schema_version also triggers v1 error."""
+    wiki_path = str(tmp_path / "wiki")
+    _write_config(
+        tmp_path / "config.yaml",
+        {"schema_version": 2, "wiki_repo_path": wiki_path},
+    )
+    with pytest.raises(ConfigError) as exc_info:
+        load_config(home=tmp_path)
+    msg = str(exc_info.value)
+    assert "delete" in msg.lower()
+
+
+def test_load_config_missing_wikis_raises(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path / "config.yaml",
+        {"schema_version": 2, "active_wiki": "home"},
+    )
+    with pytest.raises(ConfigError, match="wikis"):
+        load_config(home=tmp_path)
+
+
+def test_load_config_unknown_active_wiki_raises(tmp_path: Path) -> None:
+    wiki_path = str(tmp_path / "wiki")
+    _write_config(
+        tmp_path / "config.yaml",
+        {
+            "schema_version": 2,
+            "wikis": [{"nickname": "home", "path": wiki_path}],
+            "active_wiki": "nonexistent",
+        },
+    )
+    with pytest.raises(ConfigError, match="nonexistent"):
+        load_config(home=tmp_path)
+
+
+def test_load_config_bad_schema_version_raises(tmp_path: Path) -> None:
+    wiki_path = str(tmp_path / "wiki")
+    _write_config(
+        tmp_path / "config.yaml",
+        {
+            "schema_version": 99,
+            "wikis": [{"nickname": "home", "path": wiki_path}],
+            "active_wiki": "home",
+        },
+    )
+    with pytest.raises(ConfigError, match="exceeds max supported"):
+        load_config(home=tmp_path)
+
+
+def test_load_config_missing_schema_version_raises(tmp_path: Path) -> None:
+    wiki_path = str(tmp_path / "wiki")
+    _write_config(
+        tmp_path / "config.yaml",
+        {
+            "wikis": [{"nickname": "home", "path": wiki_path}],
+            "active_wiki": "home",
+        },
+    )
+    with pytest.raises(ConfigError, match="missing schema_version"):
+        load_config(home=tmp_path)
+
+
 # ---------------------------------------------------------------------------
-# interactive_setup
+# Config.resolve_active_wiki
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_active_wiki_returns_active_path(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    cfg = _cfg(wiki)
+    assert cfg.resolve_active_wiki(None) == wiki
+
+
+def test_resolve_active_wiki_override_wins(tmp_path: Path) -> None:
+    wiki1 = tmp_path / "wiki1"
+    wiki1.mkdir()
+    wiki2 = tmp_path / "wiki2"
+    wiki2.mkdir()
+    cfg = Config(
+        wikis=[WikiEntry("main", wiki1), WikiEntry("alt", wiki2)],
+        active_wiki="main",
+    )
+    assert cfg.resolve_active_wiki("alt") == wiki2
+
+
+def test_resolve_active_wiki_unknown_override_raises(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    cfg = _cfg(wiki)
+    with pytest.raises(ConfigError, match="nope"):
+        cfg.resolve_active_wiki("nope")
+
+
+def test_resolve_active_wiki_unset_raises(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    cfg = Config(wikis=[WikiEntry("home", wiki)], active_wiki=None)
+    with pytest.raises(ConfigError):
+        cfg.resolve_active_wiki(None)
+
+
+def test_resolve_active_wiki_missing_path_raises(tmp_path: Path) -> None:
+    wiki = tmp_path / "missing"
+    # don't create the directory
+    cfg = _cfg(wiki)
+    with pytest.raises(ConfigError, match="test"):
+        cfg.resolve_active_wiki(None)
+
+
+# ---------------------------------------------------------------------------
+# interactive_setup — v2
 # ---------------------------------------------------------------------------
 
 
@@ -99,12 +236,16 @@ def test_interactive_setup_writes_config_and_skeleton(
 ) -> None:
     home = tmp_path / "home"
     wiki = tmp_path / "wiki"
-    _patch_setup_inputs(monkeypatch, inputs=[str(wiki), ""])
+    nick = "mywiki"
+    _patch_setup_inputs(monkeypatch, inputs=[nick, str(wiki), ""])
 
     cfg = interactive_setup(home=home)
 
-    assert (home / "config.yaml").exists()
-    assert cfg.wiki_repo_path == wiki.resolve()
+    raw = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    assert raw["schema_version"] == 2
+    assert raw["active_wiki"] == nick
+    assert raw["wikis"][0] == {"nickname": nick, "path": str(wiki.resolve())}
+    assert cfg.resolve_active_wiki(None) == wiki.resolve()
     assert cfg.openrouter.api_key_env == "OPENROUTER_API_KEY"
     assert cfg.models.primary == "anthropic/claude-sonnet-4-5"
     # wiki skeleton created
@@ -119,7 +260,9 @@ def test_interactive_setup_custom_model(
 ) -> None:
     home = tmp_path / "home"
     wiki = tmp_path / "mywiki"
-    _patch_setup_inputs(monkeypatch, inputs=[str(wiki), "anthropic/claude-opus-4-7"])
+    _patch_setup_inputs(
+        monkeypatch, inputs=["main", str(wiki), "anthropic/claude-opus-4-7"]
+    )
 
     cfg = interactive_setup(home=home)
 
@@ -132,11 +275,11 @@ def test_interactive_setup_reprompts_on_blank_required(
 ) -> None:
     home = tmp_path / "home"
     wiki = tmp_path / "wiki"
-    # first answer blank for wiki, second valid; default accepted for model
-    _patch_setup_inputs(monkeypatch, inputs=["", str(wiki), ""])
+    # blank nickname, then valid nickname; then wiki path; default model
+    _patch_setup_inputs(monkeypatch, inputs=["", "home", str(wiki), ""])
 
     cfg = interactive_setup(home=home)
-    assert cfg.wiki_repo_path == wiki.resolve()
+    assert cfg.resolve_active_wiki(None) == wiki.resolve()
 
 
 def test_interactive_setup_preserves_existing_wiki_files(
@@ -150,7 +293,7 @@ def test_interactive_setup_preserves_existing_wiki_files(
         "schema_version: 1\nsetting:\n  name: Aether\n", encoding="utf-8"
     )
 
-    _patch_setup_inputs(monkeypatch, inputs=[str(wiki), ""])
+    _patch_setup_inputs(monkeypatch, inputs=["home", str(wiki), ""])
 
     interactive_setup(home=home)
     # existing content preserved
@@ -168,7 +311,9 @@ def test_interactive_setup_writes_credentials_file_with_strict_perms(
     """Hidden API-key prompt → 0600 credentials file alongside config.yaml."""
     home = tmp_path / "home"
     wiki = tmp_path / "wiki"
-    _patch_setup_inputs(monkeypatch, inputs=[str(wiki), ""], api_key="sk-or-v1-test")
+    _patch_setup_inputs(
+        monkeypatch, inputs=["home", str(wiki), ""], api_key="sk-or-v1-test"
+    )
 
     interactive_setup(home=home)
 
@@ -185,7 +330,7 @@ def test_interactive_setup_blank_api_key_skips_credentials(
     """Blank → no credentials file written; user expected to use env var."""
     home = tmp_path / "home"
     wiki = tmp_path / "wiki"
-    _patch_setup_inputs(monkeypatch, inputs=[str(wiki), ""], api_key="")
+    _patch_setup_inputs(monkeypatch, inputs=["home", str(wiki), ""], api_key="")
 
     interactive_setup(home=home)
 
@@ -198,7 +343,7 @@ def test_get_api_key_falls_back_to_credentials_file(
     monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(tmp_path))
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     (tmp_path / "credentials").write_text("sk-or-v1-fromfile\n", encoding="utf-8")
-    cfg = Config(wiki_repo_path=tmp_path / "wiki")
+    cfg = _cfg(tmp_path / "wiki")
     assert cfg.get_api_key() == "sk-or-v1-fromfile"
 
 
@@ -208,7 +353,7 @@ def test_get_api_key_env_var_wins_over_credentials_file(
     monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(tmp_path))
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-fromenv")
     (tmp_path / "credentials").write_text("sk-or-v1-fromfile", encoding="utf-8")
-    cfg = Config(wiki_repo_path=tmp_path / "wiki")
+    cfg = _cfg(tmp_path / "wiki")
     assert cfg.get_api_key() == "sk-or-v1-fromenv"
 
 
@@ -217,30 +362,8 @@ def test_get_api_key_returns_none_when_neither_present(
 ) -> None:
     monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(tmp_path))
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-    cfg = Config(wiki_repo_path=tmp_path / "wiki")
+    cfg = _cfg(tmp_path / "wiki")
     assert cfg.get_api_key() is None
-
-
-def test_load_config_missing_wiki_repo_raises(tmp_path: Path) -> None:
-    _write_config(tmp_path / "config.yaml", {"schema_version": 1})
-    with pytest.raises(ConfigError, match="wiki_repo_path"):
-        load_config(home=tmp_path)
-
-
-def test_load_config_bad_schema_version_raises(tmp_path: Path) -> None:
-    wiki_path = str(tmp_path / "wiki")
-    _write_config(
-        tmp_path / "config.yaml",
-        {"schema_version": 99, "wiki_repo_path": wiki_path},
-    )
-    with pytest.raises(ConfigError, match="exceeds max supported"):
-        load_config(home=tmp_path)
-
-
-def test_load_config_missing_schema_version_raises(tmp_path: Path) -> None:
-    _write_config(tmp_path / "config.yaml", {"wiki_repo_path": str(tmp_path / "wiki")})
-    with pytest.raises(ConfigError, match="missing schema_version"):
-        load_config(home=tmp_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_entities_cmd.py
+++ b/tests/test_entities_cmd.py
@@ -26,9 +26,15 @@ def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 @pytest.fixture
 def configured_wiki(tmp_wiki: Path, tmp_home: Path) -> Path:
     """tmp_wiki + a config.yaml pointing at it."""
+    import yaml  # noqa: PLC0415
+
+    data = {
+        "schema_version": 2,
+        "active_wiki": "main",
+        "wikis": [{"nickname": "main", "path": str(tmp_wiki)}],
+    }
     (tmp_home / "config.yaml").write_text(
-        f"schema_version: 1\nwiki_repo_path: {tmp_wiki}\n",
-        encoding="utf-8",
+        yaml.safe_dump(data, sort_keys=False), encoding="utf-8"
     )
     return tmp_wiki
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 def _mock_config(wiki: Path) -> MagicMock:
     cfg = MagicMock()
-    cfg.wiki_repo_path = wiki
+    cfg.resolve_active_wiki.return_value = wiki
     cfg.models.primary_context_window = 200000
     cfg.preamble.budget_fraction = 0.8
     return cfg

--- a/tests/test_ingest_cleanup.py
+++ b/tests/test_ingest_cleanup.py
@@ -11,6 +11,7 @@ from auto_lorebook import config as cfg_mod
 from auto_lorebook import entity_yaml, reading_pipeline
 from auto_lorebook.entity_yaml import Alias, Entity
 from auto_lorebook.ingest_cleanup import RejectResult, preview, reject_ingest
+from auto_lorebook.wiki_registry import WikiEntry
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -28,7 +29,7 @@ def cfg(
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
-    return cfg_mod.Config(wiki_repo_path=tmp_wiki)
+    return cfg_mod.Config(wikis=[WikiEntry("test", tmp_wiki)], active_wiki="test")
 
 
 def _fact(
@@ -115,7 +116,7 @@ def _write_pending(home: Path, source_id: str) -> tuple[Path, Path, Path]:
 class TestFactRemoval:
     def test_removes_matching_facts(self, cfg: cfg_mod.Config) -> None:
         path = _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             category="locations",
             slug="aldara",
@@ -136,7 +137,7 @@ class TestFactRemoval:
 class TestAliasRemoval:
     def test_removes_matching_aliases(self, cfg: cfg_mod.Config) -> None:
         path = _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             category="locations",
             slug="aldara",
@@ -169,7 +170,7 @@ class TestStubDeletion:
         self, cfg: cfg_mod.Config
     ) -> None:
         path = _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             category="locations",
             slug="aldara",
@@ -184,7 +185,7 @@ class TestStubDeletion:
     def test_keeps_stub_when_created_by_differs(self, cfg: cfg_mod.Config) -> None:
         # Pre-existing entity, all facts happen to be from yt-x.
         path = _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             category="locations",
             slug="aldara",
@@ -203,7 +204,7 @@ class TestStubDeletion:
     ) -> None:
         # Created by yt-x but a later ingest also added facts.
         path = _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             category="locations",
             slug="aldara",
@@ -224,7 +225,7 @@ class TestStubDeletion:
 class TestMixedFacts:
     def test_only_target_ingest_facts_removed(self, cfg: cfg_mod.Config) -> None:
         path = _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             category="locations",
             slug="aldara",
@@ -246,7 +247,7 @@ class TestAliasOnlyChange:
         self, cfg: cfg_mod.Config
     ) -> None:
         path = _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             category="locations",
             slug="aldara",
@@ -277,7 +278,7 @@ class TestHandEdited:
         f = _fact("aldara-f001", ingest="yt-x")
         f.pop("created_by_ingest")
         path = _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             category="locations",
             slug="aldara",
@@ -291,7 +292,7 @@ class TestHandEdited:
 
     def test_alias_without_ingest_tag_kept(self, cfg: cfg_mod.Config) -> None:
         path = _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             category="locations",
             slug="aldara",
@@ -328,7 +329,7 @@ class TestPendingCleanup:
         assert (reading_dir / "structure.yaml").exists()
 
     def test_sources_dir_untouched(self, cfg: cfg_mod.Config) -> None:
-        src = cfg.wiki_repo_path / "sources" / "yt-x"
+        src = cfg.resolve_active_wiki(None) / "sources" / "yt-x"
         src.mkdir(parents=True)
         (src / "info.yaml").write_text("placeholder", encoding="utf-8")
         (src / "transcript.en.srt").write_text("placeholder", encoding="utf-8")
@@ -345,7 +346,7 @@ class TestPendingCleanup:
 class TestIdempotency:
     def test_second_call_returns_zeros(self, cfg: cfg_mod.Config) -> None:
         _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             category="locations",
             slug="aldara",
@@ -369,7 +370,7 @@ class TestMalformed:
         self, cfg: cfg_mod.Config, caplog: pytest.LogCaptureFixture
     ) -> None:
         _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Good",
             category="locations",
             slug="good",
@@ -377,7 +378,7 @@ class TestMalformed:
             facts=[_fact("good-f001", ingest="yt-x")],
         )
         # Malformed entity in the same dir: no schema_version
-        (cfg.wiki_repo_path / "locations" / "bad.yaml").write_text(
+        (cfg.resolve_active_wiki(None) / "locations" / "bad.yaml").write_text(
             "entity: Bad\ncategory: locations\nslug: bad\n",
             encoding="utf-8",
         )
@@ -397,7 +398,7 @@ class TestPreviewMatches:
     def test_preview_matches_reject_counts(self, cfg: cfg_mod.Config) -> None:
         # Several entities with mixed ingests
         _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             category="locations",
             slug="aldara",
@@ -408,7 +409,7 @@ class TestPreviewMatches:
             ],
         )
         _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Theron",
             category="characters",
             slug="theron",
@@ -439,7 +440,7 @@ class TestProposalsDirAbsent:
     def test_runs_clean_when_no_pending(self, cfg: cfg_mod.Config) -> None:
         # Just an entity, no pending dir
         _write_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             category="locations",
             slug="aldara",

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -210,8 +210,11 @@ def _write_user_config(
 ) -> None:
     cfg_path = home / "config.yaml"
     cfg_path.write_text(
-        f"""schema_version: 1
-wiki_repo_path: {wiki}
+        f"""schema_version: 2
+active_wiki: main
+wikis:
+- nickname: main
+  path: {wiki}
 openrouter:
   api_key_env: FAKE_OR_KEY
 models:

--- a/tests/test_reading_review.py
+++ b/tests/test_reading_review.py
@@ -25,6 +25,7 @@ from auto_lorebook.reading_review import (
     UndoDecision,
     run,
 )
+from auto_lorebook.wiki_registry import WikiEntry
 from tests._reading_fixtures import _info, _segment_files, _sidecar
 from tests.test_reading_commands import _SRT, _wire_client_responses
 
@@ -104,7 +105,7 @@ def env(
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
-    cfg = cfg_mod.Config(wiki_repo_path=tmp_wiki)
+    cfg = cfg_mod.Config(wikis=[WikiEntry("test", tmp_wiki)], active_wiki="test")
     _write_info(tmp_wiki)
     _write_pending()
     return cfg, tmp_wiki
@@ -350,7 +351,8 @@ class TestYesShortcut:
         home.mkdir()
         monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
         (home / "config.yaml").write_text(
-            f"schema_version: 1\nwiki_repo_path: {tmp_wiki}\n"
+            f"schema_version: 2\nactive_wiki: main\n"
+            f"wikis:\n- nickname: main\n  path: {tmp_wiki}\n"
             "openrouter:\n  api_key_env: FAKE_OR_KEY\n"
             "models:\n  primary: anthropic/claude-sonnet-4-5\n",
             encoding="utf-8",
@@ -496,7 +498,8 @@ class TestRegenAfterReviewIntegrates:
         home.mkdir()
         monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
         (home / "config.yaml").write_text(
-            f"schema_version: 1\nwiki_repo_path: {tmp_wiki}\n"
+            f"schema_version: 2\nactive_wiki: main\n"
+            f"wikis:\n- nickname: main\n  path: {tmp_wiki}\n"
             "openrouter:\n  api_key_env: FAKE_OR_KEY\n"
             "models:\n  primary: anthropic/claude-sonnet-4-5\n",
             encoding="utf-8",

--- a/tests/test_reject_ingest_cmd.py
+++ b/tests/test_reject_ingest_cmd.py
@@ -186,8 +186,11 @@ def ingested_wiki(tmp_wiki: Path, tmp_home: Path) -> Path:  # noqa: ARG001
 def _write_user_config(home: Path, wiki: Path) -> None:
     cfg_path = home / "config.yaml"
     cfg_path.write_text(
-        f"""schema_version: 1
-wiki_repo_path: {wiki}
+        f"""schema_version: 2
+active_wiki: main
+wikis:
+- nickname: main
+  path: {wiki}
 openrouter:
   api_key_env: FAKE_OR_KEY
 models:

--- a/tests/test_replan_cmd.py
+++ b/tests/test_replan_cmd.py
@@ -186,8 +186,11 @@ def ingested_wiki(tmp_wiki: Path, tmp_home: Path) -> Path:  # noqa: ARG001
 def _write_user_config(home: Path, wiki: Path) -> None:
     cfg_path = home / "config.yaml"
     cfg_path.write_text(
-        f"""schema_version: 1
-wiki_repo_path: {wiki}
+        f"""schema_version: 2
+active_wiki: main
+wikis:
+- nickname: main
+  path: {wiki}
 openrouter:
   api_key_env: FAKE_OR_KEY
 models:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -26,6 +26,7 @@ from auto_lorebook.review import (
     ReviewResult,
     TargetEdits,
 )
+from auto_lorebook.wiki_registry import WikiEntry
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -43,7 +44,7 @@ def cfg(
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
-    return cfg_mod.Config(wiki_repo_path=tmp_wiki)
+    return cfg_mod.Config(wikis=[WikiEntry("test", tmp_wiki)], active_wiki="test")
 
 
 def _write_info(wiki: Path, source_id: str = "yt-x") -> None:
@@ -218,7 +219,7 @@ class TestSortedProposals:
     def test_groups_siblings_in_target_order(self, cfg: cfg_mod.Config) -> None:
         """Plan order beats lex sort: targets ordered as in claim.targets."""
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         # cg-001: War of the Dusk first, then Aldara — slug-sort would invert.
         claim1 = _make_claim(
             cg="cg-001",
@@ -249,7 +250,7 @@ class TestSortedProposals:
             ],
         )
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(name="War of the Dusk", category="events"),
@@ -285,11 +286,11 @@ class TestValidateProposalsSubsetOfPlan:
     def test_exact_match_succeeds(self, cfg: cfg_mod.Config) -> None:
         """Proposals exactly matching plan keys → run() succeeds."""
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         proposal = _make_proposal(target="Aldara", proposed_id="aldara-f001")
         _write_proposal(source_id, proposal)
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
@@ -317,14 +318,14 @@ class TestValidateProposalsSubsetOfPlan:
     def test_strict_subset_succeeds(self, cfg: cfg_mod.Config) -> None:
         """Plan has two claim groups; only one proposal on disk (Ctrl-C resume)."""
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         # Only write proposal for cg-001, not cg-002
         proposal = _make_proposal(
             target="Aldara", proposed_id="aldara-f001", cg="cg-001"
         )
         _write_proposal(source_id, proposal)
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
@@ -365,7 +366,7 @@ class TestValidateProposalsSubsetOfPlan:
     def test_orphan_raises_review_error(self, cfg: cfg_mod.Config) -> None:
         """Proposal whose (claim_group_id, target_entity) not in plan → ReviewError."""
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         # In-plan proposal
         valid = _make_proposal(target="Aldara", proposed_id="aldara-f001", cg="cg-001")
         _write_proposal(source_id, valid)
@@ -373,7 +374,7 @@ class TestValidateProposalsSubsetOfPlan:
         orphan = _make_proposal(target="Ghost", proposed_id="ghost-f001", cg="cg-999")
         _write_proposal(source_id, orphan)
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
@@ -510,15 +511,17 @@ class TestFactDict:
 class TestExistingEntityApprove:
     def test_appends_fact_and_deletes_proposal(self, cfg: cfg_mod.Config) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
-        _seed_existing_entity(cfg.wiki_repo_path, name="Aldara", slug="aldara")
+        _write_info(cfg.resolve_active_wiki(None), source_id)
+        _seed_existing_entity(
+            cfg.resolve_active_wiki(None), name="Aldara", slug="aldara"
+        )
 
         proposal = _make_proposal(
             target="Aldara", proposed_id="aldara-f001", proposal_type="new_fact"
         )
         _write_proposal(source_id, proposal)
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             entity_resolutions=[
                 plan_yaml.EntityResolution(
@@ -552,7 +555,9 @@ class TestExistingEntityApprove:
             source_id, "aldara-f001"
         ).exists()
         # entity grew by one fact
-        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        e = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         assert len(e.facts) == 1
         assert e.facts[0]["id"] == "aldara-f001"
 
@@ -565,9 +570,9 @@ class TestExistingEntityApprove:
 class TestIdempotentGuard:
     def test_does_not_double_append(self, cfg: cfg_mod.Config) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         _seed_existing_entity(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             name="Aldara",
             slug="aldara",
             facts=[{"id": "aldara-f001", "text": "previously approved."}],
@@ -578,7 +583,7 @@ class TestIdempotentGuard:
         )
         _write_proposal(source_id, proposal)
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             planned_claims=[
                 _make_claim(
@@ -605,7 +610,9 @@ class TestIdempotentGuard:
             source_id, "aldara-f001"
         ).exists()
         # only the original fact remains
-        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        e = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         assert len(e.facts) == 1
 
 
@@ -617,11 +624,11 @@ class TestIdempotentGuard:
 class TestNewEntityStub:
     def test_creates_stub_with_timestamps(self, cfg: cfg_mod.Config) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         proposal = _make_proposal(target="Aldara", proposed_id="aldara-f001")
         _write_proposal(source_id, proposal)
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
@@ -646,7 +653,7 @@ class TestNewEntityStub:
             reviewer=ScriptedReviewer([ApproveDecision()]),
         )
         assert result.approved == 1
-        path = cfg.wiki_repo_path / "locations" / "aldara.yaml"
+        path = cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
         assert path.exists()
         e = entity_yaml.read(path)
         assert e.entity == "Aldara"
@@ -660,11 +667,11 @@ class TestNewEntityStub:
         self, cfg: cfg_mod.Config
     ) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         proposal = _make_proposal(target="Aldara", proposed_id="aldara-f001")
         _write_proposal(source_id, proposal)
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(
@@ -693,7 +700,9 @@ class TestNewEntityStub:
             reviewer=ScriptedReviewer([ApproveDecision()], alias_responses=[True]),
         )
         assert result.approved == 1
-        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        e = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         assert len(e.aliases) == 1
         assert e.aliases[0].name == "the Realm"
         assert e.aliases[0].source == "stub-creation"
@@ -703,14 +712,16 @@ class TestNewEntityStub:
         self, cfg: cfg_mod.Config
     ) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
-        _seed_existing_entity(cfg.wiki_repo_path, name="Aldara", slug="aldara")
+        _write_info(cfg.resolve_active_wiki(None), source_id)
+        _seed_existing_entity(
+            cfg.resolve_active_wiki(None), name="Aldara", slug="aldara"
+        )
         proposal = _make_proposal(
             target="Aldara", proposed_id="aldara-f001", proposal_type="new_fact"
         )
         _write_proposal(source_id, proposal)
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             entity_resolutions=[
                 plan_yaml.EntityResolution(
@@ -737,7 +748,9 @@ class TestNewEntityStub:
             source_id=source_id,
             reviewer=ScriptedReviewer([ApproveDecision()], alias_responses=[True]),
         )
-        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        e = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         assert len(e.aliases) == 1
         assert e.aliases[0].source == "alias-confirmation"
 
@@ -752,14 +765,16 @@ class TestReject:
         self, cfg: cfg_mod.Config
     ) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
-        _seed_existing_entity(cfg.wiki_repo_path, name="Aldara", slug="aldara")
+        _write_info(cfg.resolve_active_wiki(None), source_id)
+        _seed_existing_entity(
+            cfg.resolve_active_wiki(None), name="Aldara", slug="aldara"
+        )
         proposal = _make_proposal(
             target="Aldara", proposed_id="aldara-f001", proposal_type="new_fact"
         )
         _write_proposal(source_id, proposal)
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             planned_claims=[
                 _make_claim(
@@ -780,7 +795,9 @@ class TestReject:
         )
         assert result.rejected == 1
         assert result.approved == 0
-        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        e = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         assert e.facts == []
         assert not reading_pipeline.pending_proposal_path(
             source_id, "aldara-f001"
@@ -795,7 +812,7 @@ class TestReject:
 class TestMultiTargetDedup:
     def test_two_proposals_share_one_stub(self, cfg: cfg_mod.Config) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         # Two new-entity proposals in the same claim group both targeting Aldara.
         # (Multi-target onto a brand-new entity is rare but legal.)
         # In practice they'd be different entities; we contrive same-target to
@@ -825,7 +842,7 @@ class TestMultiTargetDedup:
             ),
         )
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
@@ -860,7 +877,9 @@ class TestMultiTargetDedup:
             source_id=source_id,
             reviewer=ScriptedReviewer([ApproveDecision(), ApproveDecision()]),
         )
-        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        e = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         assert len(e.facts) == 2
         assert {f["id"] for f in e.facts} == {"aldara-f001", "aldara-f002"}
         # created_by_ingest stays as the first-approval ingest
@@ -879,7 +898,7 @@ class TestCreatedEarlierInSession:
         self, cfg: cfg_mod.Config
     ) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         _write_proposal(
             source_id,
             _make_proposal(target="Aldara", proposed_id="aldara-f001", cg="cg-001"),
@@ -889,7 +908,7 @@ class TestCreatedEarlierInSession:
             _make_proposal(target="Aldara", proposed_id="aldara-f002", cg="cg-002"),
         )
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
@@ -937,7 +956,7 @@ class TestSiblingAliasDedup:
         self, cfg: cfg_mod.Config
     ) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         _write_proposal(
             source_id,
             _make_proposal(target="Aldara", proposed_id="aldara-f001", cg="cg-001"),
@@ -947,7 +966,7 @@ class TestSiblingAliasDedup:
             _make_proposal(target="Aldara", proposed_id="aldara-f002", cg="cg-002"),
         )
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(
@@ -989,7 +1008,9 @@ class TestSiblingAliasDedup:
         # already merged.
         assert len(scripted.alias_calls) == 1
         # And only one alias landed.
-        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        e = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         assert len(e.aliases) == 1
 
 
@@ -1004,7 +1025,7 @@ class TestDeclinedAliasMemory:
     ) -> None:
         # Single bundle: three routes, all targeting Aldara with "the Realm".
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         cg = "cg-001"
         pids = ["aldara-f001", "aldara-f002", "aldara-f003"]
         for pid in pids:
@@ -1013,7 +1034,7 @@ class TestDeclinedAliasMemory:
                 _make_proposal(target="Aldara", proposed_id=pid, cg=cg),
             )
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(
@@ -1041,14 +1062,16 @@ class TestDeclinedAliasMemory:
         review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
         # Declined in first route → skipped for the other two.
         assert len(scripted.alias_calls) == 1
-        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        e = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         assert len(e.aliases) == 0
 
     def _setup_two_bundles_same_alias(
         self, cfg: cfg_mod.Config, source_id: str
     ) -> None:
         """Two consecutive bundles both suggesting 'the Realm' for Aldara."""
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         _write_proposal(
             source_id,
             _make_proposal(target="Aldara", proposed_id="aldara-f001", cg="cg-001"),
@@ -1058,7 +1081,7 @@ class TestDeclinedAliasMemory:
             _make_proposal(target="Aldara", proposed_id="aldara-f002", cg="cg-002"),
         )
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(
@@ -1104,7 +1127,9 @@ class TestDeclinedAliasMemory:
         review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
         # Declined in first bundle → skipped in second bundle.
         assert len(scripted.alias_calls) == 1
-        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        e = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         assert len(e.aliases) == 0
 
     def test_second_run_does_not_inherit_declines_from_first(
@@ -1121,7 +1146,7 @@ class TestDeclinedAliasMemory:
 
         # Second run: new plan targeting existing Aldara with same alias.
         source_id2 = "yt-y"
-        _write_info(cfg.wiki_repo_path, source_id2)
+        _write_info(cfg.resolve_active_wiki(None), source_id2)
         _write_proposal(
             source_id2,
             _make_proposal(
@@ -1132,7 +1157,7 @@ class TestDeclinedAliasMemory:
             ),
         )
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id2,
             entity_resolutions=[
                 plan_yaml.EntityResolution(
@@ -1171,7 +1196,7 @@ class TestIndexRefresh:
         self, cfg: cfg_mod.Config
     ) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         # A targets new entity Aldara; B is a `new_fact` proposal claiming
         # Aldara as existing. B can only succeed if the index refresh after A's
         # approval surfaces Aldara as existing.
@@ -1194,7 +1219,7 @@ class TestIndexRefresh:
             ),
         )
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
@@ -1229,7 +1254,9 @@ class TestIndexRefresh:
             reviewer=ScriptedReviewer([ApproveDecision(), ApproveDecision()]),
         )
         assert result.approved == 2
-        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        e = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         assert len(e.facts) == 2
 
 
@@ -1263,7 +1290,7 @@ class TestResumeAndEmpty:
         self, cfg: cfg_mod.Config
     ) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         for i in range(1, 4):
             _write_proposal(
                 source_id,
@@ -1274,7 +1301,7 @@ class TestResumeAndEmpty:
                 ),
             )
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(name=f"E{i}", category="concepts")
@@ -1311,8 +1338,8 @@ class TestResumeAndEmpty:
         self, cfg: cfg_mod.Config
     ) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
-        _write_plan(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
+        _write_plan(cfg.resolve_active_wiki(None), source_id)
         result = review.run(
             cfg=cfg,
             source_id=source_id,
@@ -1340,7 +1367,7 @@ def _multi_target_setup(
 ) -> None:
     """Plan with one cg routing to (Aldara, Theron, Second Age), all NEW."""
     aliases_per_entity = aliases_per_entity or {}
-    _write_info(cfg.wiki_repo_path, source_id)
+    _write_info(cfg.resolve_active_wiki(None), source_id)
     cg = "cg-multi"
     targets = [
         ("Aldara", "locations", sections[0], "aldara-f001"),
@@ -1367,7 +1394,7 @@ def _multi_target_setup(
             ),
         )
     _write_plan(
-        cfg.wiki_repo_path,
+        cfg.resolve_active_wiki(None),
         source_id,
         new_entities=[
             plan_yaml.NewEntityProposal(
@@ -1411,7 +1438,7 @@ class TestBundle:
             ("theron", "characters"),
             ("second-age", "events"),
         ):
-            assert (cfg.wiki_repo_path / cat / f"{slug}.yaml").exists()
+            assert (cfg.resolve_active_wiki(None) / cat / f"{slug}.yaml").exists()
 
     def test_targets_drop_unchecks_a_route(self, cfg: cfg_mod.Config) -> None:
         source_id = "yt-x"
@@ -1428,10 +1455,12 @@ class TestBundle:
         result = review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
         assert result.approved == 2
         assert result.rejected == 1
-        assert (cfg.wiki_repo_path / "locations" / "aldara.yaml").exists()
-        assert (cfg.wiki_repo_path / "events" / "second-age.yaml").exists()
+        assert (cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml").exists()
+        assert (cfg.resolve_active_wiki(None) / "events" / "second-age.yaml").exists()
         # Theron stub never created.
-        assert not (cfg.wiki_repo_path / "characters" / "theron.yaml").exists()
+        assert not (
+            cfg.resolve_active_wiki(None) / "characters" / "theron.yaml"
+        ).exists()
         # Theron proposal file gone.
         assert not reading_pipeline.pending_proposal_path(
             source_id, "theron-f001"
@@ -1457,7 +1486,7 @@ class TestBundle:
             ("theron", "characters"),
             ("second-age", "events"),
         ):
-            e = entity_yaml.read(cfg.wiki_repo_path / cat / f"{slug}.yaml")
+            e = entity_yaml.read(cfg.resolve_active_wiki(None) / cat / f"{slug}.yaml")
             assert e.facts[0]["text"] == "Edited claim text."
             assert e.facts[0]["text_source"] is not None
             assert e.facts[0]["edited_by_human"] is True
@@ -1479,9 +1508,15 @@ class TestBundle:
             ]
         )
         review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
-        aldara = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
-        theron = entity_yaml.read(cfg.wiki_repo_path / "characters" / "theron.yaml")
-        second = entity_yaml.read(cfg.wiki_repo_path / "events" / "second-age.yaml")
+        aldara = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
+        theron = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "characters" / "theron.yaml"
+        )
+        second = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "events" / "second-age.yaml"
+        )
         assert aldara.facts[0]["section"] == "founding"
         assert theron.facts[0]["section"] == "bloodlines"
         assert second.facts[0]["section"] == "events-in-era"
@@ -1511,7 +1546,7 @@ class TestBundle:
             ("theron", "characters"),
             ("second-age", "events"),
         ):
-            e = entity_yaml.read(cfg.wiki_repo_path / cat / f"{slug}.yaml")
+            e = entity_yaml.read(cfg.resolve_active_wiki(None) / cat / f"{slug}.yaml")
             assert e.facts[0]["text"] == "Edited claim."
             assert e.facts[0]["status"] == "hearsay"
             assert e.facts[0]["status_reason"] == "tavern rumor"
@@ -1537,9 +1572,15 @@ class TestBundle:
             ]
         )
         review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
-        aldara = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
-        theron = entity_yaml.read(cfg.wiki_repo_path / "characters" / "theron.yaml")
-        second = entity_yaml.read(cfg.wiki_repo_path / "events" / "second-age.yaml")
+        aldara = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
+        theron = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "characters" / "theron.yaml"
+        )
+        second = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "events" / "second-age.yaml"
+        )
         # idx 1 (Theron) has both overrides
         assert theron.facts[0]["section"] == "bloodlines"
         assert theron.facts[0]["speaker"] == "Player-Thorin"
@@ -1570,9 +1611,15 @@ class TestBundle:
             ]
         )
         review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
-        aldara = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
-        theron = entity_yaml.read(cfg.wiki_repo_path / "characters" / "theron.yaml")
-        second = entity_yaml.read(cfg.wiki_repo_path / "events" / "second-age.yaml")
+        aldara = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
+        theron = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "characters" / "theron.yaml"
+        )
+        second = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "events" / "second-age.yaml"
+        )
         # bundle fields land on every route
         for e in (aldara, theron, second):
             assert e.facts[0]["text"] == "Edited claim."
@@ -1586,13 +1633,13 @@ class TestBundle:
         self, cfg: cfg_mod.Config
     ) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         _write_proposal(
             source_id,
             _make_proposal(target="Aldara", proposed_id="aldara-f001", cg="cg-001"),
         )
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
@@ -1629,7 +1676,7 @@ class TestBundle:
             ("theron", "characters"),
             ("second-age", "events"),
         ):
-            assert not (cfg.wiki_repo_path / cat / f"{slug}.yaml").exists()
+            assert not (cfg.resolve_active_wiki(None) / cat / f"{slug}.yaml").exists()
         # All proposal files gone.
         for pid in ("aldara-f001", "theron-f001", "second-age-f001"):
             assert not reading_pipeline.pending_proposal_path(source_id, pid).exists()
@@ -1697,7 +1744,7 @@ class TestBundle:
     def test_resume_seeds_merged_aliases_from_disk(self, cfg: cfg_mod.Config) -> None:
         """Alias added by this ingest in a prior run() must not re-prompt."""
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
+        _write_info(cfg.resolve_active_wiki(None), source_id)
         # Pre-existing entity with an alias added by THIS ingest.
         prior = entity_yaml.Entity(
             entity="Aldara",
@@ -1716,7 +1763,9 @@ class TestBundle:
             updated_at="2026-04-20T00:00:00Z",
             facts=[],
         )
-        entity_yaml.write(prior, cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        entity_yaml.write(
+            prior, cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         proposal = _make_proposal(
             target="Aldara",
             proposed_id="aldara-f002",
@@ -1725,7 +1774,7 @@ class TestBundle:
         )
         _write_proposal(source_id, proposal)
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             entity_resolutions=[
                 plan_yaml.EntityResolution(
@@ -1752,7 +1801,9 @@ class TestBundle:
         review.run(cfg=cfg, source_id=source_id, reviewer=scripted)
         # No alias prompt fired — already seeded from disk.
         assert scripted.alias_calls == []
-        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        e = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         # Still exactly one alias (no double-add).
         assert len(e.aliases) == 1
 
@@ -1787,7 +1838,7 @@ class TestBundle:
         # disk are unaffected). Aldara has no suggestion → its
         # confirm_alias is never called → KI fires on Theron's prompt.
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             new_entities=[
                 plan_yaml.NewEntityProposal(name="Aldara", category="locations"),
@@ -1842,8 +1893,10 @@ class TestEditPath:
         self, cfg: cfg_mod.Config
     ) -> None:
         source_id = "yt-x"
-        _write_info(cfg.wiki_repo_path, source_id)
-        _seed_existing_entity(cfg.wiki_repo_path, name="Aldara", slug="aldara")
+        _write_info(cfg.resolve_active_wiki(None), source_id)
+        _seed_existing_entity(
+            cfg.resolve_active_wiki(None), name="Aldara", slug="aldara"
+        )
         proposal = _make_proposal(
             target="Aldara",
             proposed_id="aldara-f001",
@@ -1852,7 +1905,7 @@ class TestEditPath:
         )
         _write_proposal(source_id, proposal)
         _write_plan(
-            cfg.wiki_repo_path,
+            cfg.resolve_active_wiki(None),
             source_id,
             planned_claims=[
                 _make_claim(
@@ -1873,7 +1926,9 @@ class TestEditPath:
         )
         assert result.edited == 1
         assert result.approved == 0
-        e = entity_yaml.read(cfg.wiki_repo_path / "locations" / "aldara.yaml")
+        e = entity_yaml.read(
+            cfg.resolve_active_wiki(None) / "locations" / "aldara.yaml"
+        )
         assert e.facts[0]["text"] == "Edited by hand."
         assert e.facts[0]["text_source"] == "Original LLM text."
         assert e.facts[0]["edited_by_human"] is True

--- a/tests/test_review_cmd.py
+++ b/tests/test_review_cmd.py
@@ -311,8 +311,11 @@ def ingested_wiki(tmp_wiki: Path, tmp_home: Path) -> Path:  # noqa: ARG001
 def _write_user_config(home: Path, wiki: Path) -> None:
     cfg_path = home / "config.yaml"
     cfg_path.write_text(
-        f"""schema_version: 1
-wiki_repo_path: {wiki}
+        f"""schema_version: 2
+active_wiki: main
+wikis:
+- nickname: main
+  path: {wiki}
 openrouter:
   api_key_env: FAKE_OR_KEY
 models:

--- a/tests/test_seed_ingest_cmd.py
+++ b/tests/test_seed_ingest_cmd.py
@@ -38,8 +38,11 @@ def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 def _write_user_config(home: Path, wiki: Path) -> None:
     (home / "config.yaml").write_text(
-        f"""schema_version: 1
-wiki_repo_path: {wiki}
+        f"""schema_version: 2
+active_wiki: main
+wikis:
+- nickname: main
+  path: {wiki}
 openrouter:
   api_key_env: FAKE_OR_KEY
 models:

--- a/tests/test_wiki_registry.py
+++ b/tests/test_wiki_registry.py
@@ -1,0 +1,158 @@
+"""Tests for wiki_registry.py — pure data layer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from auto_lorebook.wiki_registry import (
+    WikiEntry,
+    WikiRegistry,
+    WikiRegistryError,
+)
+
+# ---------------------------------------------------------------------------
+# WikiEntry
+# ---------------------------------------------------------------------------
+
+
+def test_wiki_entry_holds_nickname_and_path() -> None:
+    e = WikiEntry("home", Path("/a"))
+    assert e.nickname == "home"
+    assert e.path == Path("/a")
+
+
+# ---------------------------------------------------------------------------
+# Round-trip serialization
+# ---------------------------------------------------------------------------
+
+
+def test_registry_roundtrip_to_dict_list() -> None:
+    entries = [
+        WikiEntry("alpha", Path("/a")),
+        WikiEntry("beta", Path("/b")),
+    ]
+    reg = WikiRegistry(entries=entries, active="alpha")
+    serialized = reg.to_list()
+    assert serialized == [
+        {"nickname": "alpha", "path": str(Path("/a"))},
+        {"nickname": "beta", "path": str(Path("/b"))},
+    ]
+    reg2 = WikiRegistry.from_list(serialized, active="alpha")
+    assert reg2.entries == entries
+    assert reg2.active == "alpha"
+
+
+def test_from_list_preserves_order() -> None:
+    raw = [
+        {"nickname": "z", "path": "/z"},
+        {"nickname": "a", "path": "/a"},
+    ]
+    reg = WikiRegistry.from_list(raw, active="z")
+    assert [e.nickname for e in reg.entries] == ["z", "a"]
+
+
+# ---------------------------------------------------------------------------
+# add
+# ---------------------------------------------------------------------------
+
+
+def test_add_appends_entry() -> None:
+    reg = WikiRegistry(entries=[], active=None)
+    reg.add(WikiEntry("home", Path("/wiki")))
+    assert len(reg.entries) == 1
+    assert reg.entries[0].nickname == "home"
+
+
+def test_add_rejects_duplicate_nickname() -> None:
+    reg = WikiRegistry(entries=[WikiEntry("home", Path("/a"))], active="home")
+    with pytest.raises(WikiRegistryError, match="home"):
+        reg.add(WikiEntry("home", Path("/b")))
+
+
+# ---------------------------------------------------------------------------
+# remove
+# ---------------------------------------------------------------------------
+
+
+def test_remove_drops_entry() -> None:
+    reg = WikiRegistry(
+        entries=[WikiEntry("home", Path("/a")), WikiEntry("other", Path("/b"))],
+        active="other",
+    )
+    reg.remove("home")
+    assert len(reg.entries) == 1
+    assert reg.entries[0].nickname == "other"
+
+
+def test_remove_refuses_active_entry() -> None:
+    reg = WikiRegistry(entries=[WikiEntry("home", Path("/a"))], active="home")
+    with pytest.raises(WikiRegistryError, match="home"):
+        reg.remove("home")
+
+
+def test_remove_unknown_nickname_raises() -> None:
+    reg = WikiRegistry(entries=[], active=None)
+    with pytest.raises(WikiRegistryError, match="nope"):
+        reg.remove("nope")
+
+
+# ---------------------------------------------------------------------------
+# rename
+# ---------------------------------------------------------------------------
+
+
+def test_rename_updates_entry_and_active_pointer() -> None:
+    reg = WikiRegistry(
+        entries=[WikiEntry("old", Path("/a")), WikiEntry("other", Path("/b"))],
+        active="old",
+    )
+    reg.rename("old", "new")
+    assert reg.entries[0].nickname == "new"
+    assert reg.active == "new"
+
+
+def test_rename_updates_active_when_not_matched() -> None:
+    reg = WikiRegistry(
+        entries=[WikiEntry("alpha", Path("/a")), WikiEntry("beta", Path("/b"))],
+        active="beta",
+    )
+    reg.rename("alpha", "gamma")
+    assert reg.entries[0].nickname == "gamma"
+    assert reg.active == "beta"  # unchanged
+
+
+def test_rename_rejects_duplicate_target() -> None:
+    reg = WikiRegistry(
+        entries=[WikiEntry("a", Path("/a")), WikiEntry("b", Path("/b"))],
+        active="a",
+    )
+    with pytest.raises(WikiRegistryError, match="b"):
+        reg.rename("a", "b")
+
+
+def test_rename_unknown_source_raises() -> None:
+    reg = WikiRegistry(entries=[], active=None)
+    with pytest.raises(WikiRegistryError, match="nope"):
+        reg.rename("nope", "new")
+
+
+# ---------------------------------------------------------------------------
+# set_active
+# ---------------------------------------------------------------------------
+
+
+def test_set_active_accepts_known_nickname() -> None:
+    reg = WikiRegistry(
+        entries=[WikiEntry("home", Path("/a")), WikiEntry("other", Path("/b"))],
+        active="home",
+    )
+    reg.set_active("other")
+    assert reg.active == "other"
+
+
+def test_set_active_rejects_unknown_nickname() -> None:
+    reg = WikiRegistry(entries=[WikiEntry("home", Path("/a"))], active="home")
+    with pytest.raises(WikiRegistryError, match="unknown"):
+        reg.set_active("nope")


### PR DESCRIPTION
### What this fixes

Lays the data-layer foundation for multi-wiki support. `~/.auto-lorebook/config.yaml` jumps to `schema_version: 2`: the single `wiki_repo_path` field is gone, replaced by a `wikis: list[{nickname, path}]` registry and an `active_wiki` nickname. `Config.resolve_active_wiki(override)` (in `src/auto_lorebook/config.py`) is now the single place every code path asks "which wiki should I use?" — override beats `active_wiki`, and unset / unknown / missing-on-disk all raise `ConfigError` with a remediation message that names the offending file/nickname/path. A new `src/auto_lorebook/wiki_registry.py` holds `WikiEntry` + `WikiRegistry` (pure data, no IO) with `add` / `remove` / `rename` / `set_active`, enforcing nickname uniqueness and refusing removal of the active entry. `interactive_setup` now prompts for `(nickname, path)` and writes a v2 file. A v1 file produces a hard `ConfigError` naming the file and telling the user to delete it and re-run setup — no auto-migration. Every prior `cfg.wiki_repo_path` read in `commands/_shared.py`, `commands/ingest.py`, `commands/configure_context.py`, `commands/seed_ingest.py`, `commands/approve_reading.py`, `commands/entities.py`, `reading_pipeline.py`, `reading_review.py`, `review.py`, and `ingest_cleanup.py` now goes through the resolver. No new CLI verbs and no state-location change in this slice — those are slices 2 and 3 of #51.

### QA steps for the human

1. **Fresh-user first-run.** With `HOME` pointed at a clean temp dir, run `auto-lorebook ingest <some-text-file>`. Confirm the prompt asks for a wiki nickname before the path, that `~/.auto-lorebook/config.yaml` ends up with `schema_version: 2`, `active_wiki: <nick>`, and a one-entry `wikis:` list with the resolved absolute path.
2. **Hand-edit a second wiki.** Append a second `{nickname: secondary, path: <other-dir>}` to the registry, set `active_wiki: secondary`, re-run any read-only subcommand (e.g. `auto-lorebook review` if you have artifacts). It should target the secondary path.
3. **v1 hard-error.** Replace the file with a `schema_version: 1` + `wiki_repo_path:` config and run any subcommand. Confirm the error message names the config file path and tells you to delete + re-run setup. No silent migration.

### Automated coverage

`uv run ruff check && uv run ruff format --check && uv run ty check && uv run pytest -q` (582 passed, 4 skipped) and `uv run mkdocs build --strict`, all green on commit `00ee1a4`. Live integration smoke exercised `interactive_setup`, multi-entry registry resolution with override precedence, the v1 hard-error message, and all three resolver failure modes (missing path, active unset, unknown override).

Closes #53

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjPC6Uo8F9KvLvBu1X1GEL)_