### PR TITLE
Move pending state into `/.wiki-state/` (slice 3 of #51)

### DIFF
--- a/docs/pipeline/context.md
+++ b/docs/pipeline/context.md
@@ -206,7 +206,7 @@ The tool does not silently truncate.
 
 After fetching the source, the tool prompts interactively. Every field
 is skippable (Enter to skip). Defaults pre-fill from flags, then
-`.wiki-context.yaml`, then `~/.auto-lorebook/last-context.yaml`
+`.wiki-context.yaml`, then `<wiki>/.wiki-state/last-context.yaml`
 (perspective and source_nature from the most recent ingest).
 
 ```

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -78,7 +78,7 @@ Every YAML file carries `schema_version` as its first key — see
 - **Purpose** — model selection, wiki repo path, API key env var name.
 - **Details** — [installation](../getting-started/installation.md#configure).
 
-### `~/.auto-lorebook/pending/<ingest_id>/reading/structure.yaml`
+### `<wiki>/.wiki-state/pending/<ingest_id>/reading/structure.yaml`
 
 - **Stage** — Stage 1a output.
 - **Purpose** — segments, speaker attribution, sub-segment overrides,
@@ -86,14 +86,14 @@ Every YAML file carries `schema_version` as its first key — see
   ingest lifetime.
 - **Details** — [Stage 1a](../pipeline/reading.md#stage-1a-structure).
 
-### `~/.auto-lorebook/pending/<ingest_id>/reading/reading.yaml`
+### `<wiki>/.wiki-state/pending/<ingest_id>/reading/reading.yaml`
 
 - **Stage** — Stage 1b output; sidecar.
 - **Purpose** — session metadata: `default_speaker`, `name_corrections`,
   `session_date`. Preserved across regenerations.
 - **Details** — [Stage 1b](../pipeline/reading.md#stage-1b-summarize).
 
-### `~/.auto-lorebook/pending/<ingest_id>/reading/segments/<segment_id>.md`
+### `<wiki>/.wiki-state/pending/<ingest_id>/reading/segments/<segment_id>.md`
 
 - **Stage** — Stage 1b output; per-segment.
 - **Purpose** — YAML frontmatter (segment metadata, `segment_status`)
@@ -101,14 +101,14 @@ Every YAML file carries `schema_version` as its first key — see
   `reading.md` at approval time.
 - **Details** — [reading assembly](../pipeline/reading.md#reading-assembly).
 
-### `~/.auto-lorebook/pending/<ingest_id>/plan.yaml`
+### `<wiki>/.wiki-state/pending/<ingest_id>/plan.yaml`
 
 - **Stage** — Stage 2 output.
 - **Purpose** — entity resolutions, new-entity proposals, routed
   claims. No filesystem side effects.
 - **Details** — [Stage 2: planner](../pipeline/planner.md#output).
 
-### `~/.auto-lorebook/pending/<ingest_id>/proposals/<proposal_id>.yaml`
+### `<wiki>/.wiki-state/pending/<ingest_id>/proposals/<proposal_id>.yaml`
 
 - **Stage** — Stage 3 output.
 - **Purpose** — one proposed fact per file, with verbatim span,

--- a/src/auto_lorebook/commands/_shared.py
+++ b/src/auto_lorebook/commands/_shared.py
@@ -38,7 +38,7 @@ def finalize_context(
     wiki_repo = cfg.resolve_active_wiki(None)
     wc = wiki_context.read(wiki_repo / ".wiki-context.yaml")
     cors = corrections.read(wiki_repo / ".transcription-corrections.yaml")
-    last_ctx = cfg_mod.load_last_context()
+    last_ctx = cfg_mod.load_last_context(wiki_root=wiki_repo)
 
     flags = {
         "session_date": args.session_date,
@@ -66,7 +66,8 @@ def finalize_context(
         cfg_mod.LastContext(
             perspective=info.context.perspective,
             source_nature=info.context.source_nature,
-        )
+        ),
+        wiki_root=wiki_repo,
     )
 
     idx = entity_index.build(wiki_repo)

--- a/src/auto_lorebook/commands/generate_reading.py
+++ b/src/auto_lorebook/commands/generate_reading.py
@@ -26,7 +26,7 @@ def add_parser(
         description=(
             "Run Stage 1a (structure) and Stage 1b (summarize) on an "
             "already-ingested source, producing a draft reading.md under "
-            "~/.auto-lorebook/pending/<source_id>/reading/ for human review."
+            "<wiki>/.wiki-state/pending/<source_id>/reading/ for human review."
         ),
     )
     parser.add_argument(

--- a/src/auto_lorebook/commands/plans.py
+++ b/src/auto_lorebook/commands/plans.py
@@ -2,7 +2,7 @@
 
 Inspection-only commands. Mirrors `entities` shape: nested subparser
 with action dispatch on `args.plans_action`. Plans are intermediate
-artifacts in `~/.auto-lorebook/pending/<source_id>/plan.yaml` — there
+artifacts in `<wiki>/.wiki-state/pending/<source_id>/plan.yaml` — there
 is no approval gate at this stage.
 """
 

--- a/src/auto_lorebook/commands/plans.py
+++ b/src/auto_lorebook/commands/plans.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from auto_lorebook import config as cfg_mod
 from auto_lorebook import plan_yaml
+from auto_lorebook import wiki_state as wiki_state_mod
 
 if TYPE_CHECKING:
     import argparse
@@ -72,7 +73,8 @@ def run(args: argparse.Namespace) -> int:
 
 
 def _pending_root() -> Path:
-    return cfg_mod.config_dir() / "pending"
+    wiki = cfg_mod.load_config().resolve_active_wiki(None)
+    return wiki_state_mod.pending_dir(wiki)
 
 
 def _run_list() -> int:
@@ -111,7 +113,8 @@ def _run_list() -> int:
 
 
 def _run_show(source_id: str) -> int:
-    plan_path = _pending_root() / source_id / "plan.yaml"
+    wiki = cfg_mod.load_config().resolve_active_wiki(None)
+    plan_path = wiki_state_mod.pending_plan_path(wiki, source_id)
     if not plan_path.is_file():
         print(f"No plan for {source_id!r}")  # noqa: T201
         return 1

--- a/src/auto_lorebook/commands/seed_ingest.py
+++ b/src/auto_lorebook/commands/seed_ingest.py
@@ -14,6 +14,7 @@ from importlib import resources
 from typing import TYPE_CHECKING
 
 from auto_lorebook import config as cfg_mod
+from auto_lorebook import wiki_state as wiki_state_mod
 from auto_lorebook._io import atomic_write_text
 
 if TYPE_CHECKING:
@@ -130,8 +131,9 @@ def _mint_source_id(cfg: cfg_mod.Config) -> str:
 
 
 def _source_collides(cfg: cfg_mod.Config, sid: str) -> bool:
-    wiki_src = cfg.resolve_active_wiki(None) / "sources" / sid
-    pending = cfg_mod.config_dir() / "pending" / sid
+    wiki = cfg.resolve_active_wiki(None)
+    wiki_src = wiki / "sources" / sid
+    pending = wiki_state_mod.pending_source_dir(wiki, sid)
     return wiki_src.exists() or pending.exists()
 
 
@@ -141,13 +143,13 @@ def _seed(cfg: cfg_mod.Config, sid: str, at: str, fixture_name: str) -> None:
         msg = (
             f"source {sid!r} already exists under "
             f"{wiki_repo / 'sources' / sid} or "
-            f"{cfg_mod.config_dir() / 'pending' / sid}"
+            f"{wiki_state_mod.pending_source_dir(wiki_repo, sid)}"
         )
         raise SeedIngestError(msg)
 
     fixture_root = _resolve_fixture(fixture_name)
     wiki_src = wiki_repo / "sources" / sid
-    pending_reading = cfg_mod.config_dir() / "pending" / sid / "reading"
+    pending_reading = wiki_state_mod.pending_reading_dir(wiki_repo, sid)
 
     # wiki side first so a half-failed seed leaves only sources/<sid>
     # behind, which `reject-ingest` will tolerate.

--- a/src/auto_lorebook/config.py
+++ b/src/auto_lorebook/config.py
@@ -1,4 +1,4 @@
-"""Config loader for ~/.auto-lorebook/config.yaml + last-context.yaml."""
+"""Config loader: ~/.auto-lorebook/config.yaml + <wiki>/.wiki-state/last-context."""
 
 from __future__ import annotations
 

--- a/src/auto_lorebook/config.py
+++ b/src/auto_lorebook/config.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import yaml
 
+from auto_lorebook import wiki_bootstrap as wiki_bootstrap_mod
+from auto_lorebook import wiki_state as wiki_state_mod
 from auto_lorebook._io import atomic_write_text
 from auto_lorebook.schema import SchemaVersionError, read_schema_version
 from auto_lorebook.wiki_registry import WikiEntry
@@ -185,9 +187,19 @@ def load_config(home: Path | None = None) -> Config:
     )
 
 
-def load_last_context(home: Path | None = None) -> LastContext:
-    """Load ~/.auto-lorebook/last-context.yaml; missing/corrupt → empty."""
-    path = config_dir(home) / "last-context.yaml"
+def load_last_context(
+    home: Path | None = None,
+    wiki_root: Path | None = None,
+) -> LastContext:
+    """Load last-context.yaml; missing/corrupt → empty.
+
+    If `wiki_root` is given, reads from `<wiki>/.wiki-state/last-context.yaml`.
+    Otherwise falls back to `<config_dir>/last-context.yaml` (legacy).
+    """
+    if wiki_root is not None:
+        path = wiki_state_mod.last_context_path(wiki_root)
+    else:
+        path = config_dir(home) / "last-context.yaml"
     if not path.exists():
         return LastContext()
     try:
@@ -203,11 +215,24 @@ def load_last_context(home: Path | None = None) -> LastContext:
         return LastContext()
 
 
-def save_last_context(last: LastContext, home: Path | None = None) -> None:
-    """Atomically write perspective and source_nature to last-context.yaml."""
-    cfg_dir = config_dir(home)
-    cfg_dir.mkdir(parents=True, exist_ok=True)
-    path = cfg_dir / "last-context.yaml"
+def save_last_context(
+    last: LastContext,
+    home: Path | None = None,
+    wiki_root: Path | None = None,
+) -> None:
+    """Atomically write perspective and source_nature to last-context.yaml.
+
+    If `wiki_root` is given, writes to `<wiki>/.wiki-state/last-context.yaml`
+    (creating `.wiki-state/` if needed). Otherwise writes to `<config_dir>/`.
+    """
+    if wiki_root is not None:
+        state_dir = wiki_state_mod.wiki_state_dir(wiki_root)
+        state_dir.mkdir(parents=True, exist_ok=True)
+        path = wiki_state_mod.last_context_path(wiki_root)
+    else:
+        cfg_dir = config_dir(home)
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        path = cfg_dir / "last-context.yaml"
     data: dict[str, Any] = {}
     if last.perspective is not None:
         data["perspective"] = last.perspective
@@ -218,7 +243,6 @@ def save_last_context(last: LastContext, home: Path | None = None) -> None:
 
 _DEFAULT_API_KEY_ENV = "OPENROUTER_API_KEY"
 _DEFAULT_MODEL = "anthropic/claude-sonnet-4-5"
-_WIKI_SUBDIRS = ("characters", "locations", "factions", "events", "items", "concepts")
 _CREDENTIALS_FILE = "credentials"
 
 
@@ -311,7 +335,7 @@ def interactive_setup(home: Path | None = None) -> Config:
     if api_key:
         cred_path = _write_credentials(api_key, home=home)
 
-    _bootstrap_wiki(wiki)
+    wiki_bootstrap_mod.bootstrap(wiki)
 
     print()  # noqa: T201
     print(f"Wrote {cfg_path}")  # noqa: T201
@@ -324,14 +348,3 @@ def interactive_setup(home: Path | None = None) -> Config:
         )
 
     return load_config(home=home)
-
-
-def _bootstrap_wiki(wiki: Path) -> None:
-    """Create the wiki entity dirs and tolerant-yaml stubs if absent."""
-    wiki.mkdir(parents=True, exist_ok=True)
-    for sub in _WIKI_SUBDIRS:
-        (wiki / sub).mkdir(exist_ok=True)
-    for fname in (".wiki-context.yaml", ".transcription-corrections.yaml"):
-        path = wiki / fname
-        if not path.exists():
-            atomic_write_text(path, "schema_version: 1\n")

--- a/src/auto_lorebook/reading_pipeline.py
+++ b/src/auto_lorebook/reading_pipeline.py
@@ -36,6 +36,7 @@ from auto_lorebook import stage3 as stage3_mod
 from auto_lorebook import structure as structure_mod
 from auto_lorebook import transcript as transcript_mod
 from auto_lorebook import wiki_context as wiki_context_mod
+from auto_lorebook import wiki_state as wiki_state_mod
 from auto_lorebook.openrouter import OpenRouterClient, OpenRouterError
 
 if TYPE_CHECKING:
@@ -254,9 +255,14 @@ def assemble_draft(cfg: cfg_mod.Config, source_id: str) -> str:
     return reading_assembly_mod.assemble(segments=segments, sidecar=sc, info=info)
 
 
+def _active_wiki_root() -> Path:
+    """Resolve active wiki from loaded config."""
+    return cfg_mod.load_config().resolve_active_wiki(None)
+
+
 def pending_dir(source_id: str) -> Path:
-    """Return the pending directory for a source."""
-    return cfg_mod.config_dir() / "pending" / source_id / "reading"
+    """Return the reading pending dir for a source under the active wiki."""
+    return wiki_state_mod.pending_reading_dir(_active_wiki_root(), source_id)
 
 
 def pending_sidecar_path(source_id: str) -> Path:
@@ -280,13 +286,13 @@ def pending_bullets_path(source_id: str) -> Path:
 
 
 def pending_plan_path(source_id: str) -> Path:
-    """Plan artifact path. Sibling to the `reading/` subdir."""
-    return cfg_mod.config_dir() / "pending" / source_id / "plan.yaml"
+    """Plan artifact path under the active wiki's .wiki-state/."""
+    return wiki_state_mod.pending_plan_path(_active_wiki_root(), source_id)
 
 
 def pending_proposals_dir(source_id: str) -> Path:
-    """Stage 3 proposal directory. Sibling to `plan.yaml`."""
-    return cfg_mod.config_dir() / "pending" / source_id / "proposals"
+    """Stage 3 proposal directory under the active wiki's .wiki-state/."""
+    return wiki_state_mod.pending_proposals_dir(_active_wiki_root(), source_id)
 
 
 def pending_proposal_path(source_id: str, proposal_id: str) -> Path:

--- a/src/auto_lorebook/wiki_bootstrap.py
+++ b/src/auto_lorebook/wiki_bootstrap.py
@@ -1,0 +1,44 @@
+"""Idempotent wiki skeleton creation under a wiki root."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from auto_lorebook import wiki_state
+from auto_lorebook._io import atomic_write_text
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+WIKI_SUBDIRS: tuple[str, ...] = (
+    "characters",
+    "locations",
+    "factions",
+    "events",
+    "items",
+    "concepts",
+)
+DOTTED_YAML_STUBS: tuple[str, ...] = (
+    ".wiki-context.yaml",
+    ".transcription-corrections.yaml",
+)
+STUB_BODY = "schema_version: 1\n"
+
+
+def bootstrap(wiki_root: Path) -> None:
+    """Create wiki skeleton if not present; safe to call repeatedly.
+
+    Creates: entity dirs, dotted-yaml stubs (only if absent),
+    .wiki-state/ dir, and .wiki-state/.gitignore (only if absent).
+    """
+    wiki_root.mkdir(parents=True, exist_ok=True)
+    for sub in WIKI_SUBDIRS:
+        (wiki_root / sub).mkdir(exist_ok=True)
+    for fname in DOTTED_YAML_STUBS:
+        path = wiki_root / fname
+        if not path.exists():
+            atomic_write_text(path, STUB_BODY)
+    wiki_state.wiki_state_dir(wiki_root).mkdir(exist_ok=True)
+    gi = wiki_state.gitignore_path(wiki_root)
+    if not gi.exists():
+        atomic_write_text(gi, wiki_state.GITIGNORE_BODY)

--- a/src/auto_lorebook/wiki_state.py
+++ b/src/auto_lorebook/wiki_state.py
@@ -1,0 +1,62 @@
+"""Pure path arithmetic for per-wiki tool state under <wiki>/.wiki-state/."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+WIKI_STATE_DIRNAME = ".wiki-state"
+PENDING_DIRNAME = "pending"
+READING_DIRNAME = "reading"
+PROPOSALS_DIRNAME = "proposals"
+PLAN_FILENAME = "plan.yaml"
+LAST_CONTEXT_FILENAME = "last-context.yaml"
+GITIGNORE_FILENAME = ".gitignore"
+GITIGNORE_BODY = "pending/\n"
+
+
+def wiki_state_dir(wiki_root: Path) -> Path:
+    """Return <wiki>/.wiki-state/."""
+    return wiki_root / WIKI_STATE_DIRNAME
+
+
+def pending_dir(wiki_root: Path) -> Path:
+    """Return <wiki>/.wiki-state/pending/."""
+    return wiki_state_dir(wiki_root) / PENDING_DIRNAME
+
+
+def pending_source_dir(wiki_root: Path, source_id: str) -> Path:
+    """Return <wiki>/.wiki-state/pending/<source_id>/."""
+    return pending_dir(wiki_root) / source_id
+
+
+def pending_reading_dir(wiki_root: Path, source_id: str) -> Path:
+    """Return <wiki>/.wiki-state/pending/<source_id>/reading/."""
+    return pending_source_dir(wiki_root, source_id) / READING_DIRNAME
+
+
+def pending_plan_path(wiki_root: Path, source_id: str) -> Path:
+    """Return <wiki>/.wiki-state/pending/<source_id>/plan.yaml."""
+    return pending_source_dir(wiki_root, source_id) / PLAN_FILENAME
+
+
+def pending_proposals_dir(wiki_root: Path, source_id: str) -> Path:
+    """Return <wiki>/.wiki-state/pending/<source_id>/proposals/."""
+    return pending_source_dir(wiki_root, source_id) / PROPOSALS_DIRNAME
+
+
+def pending_proposal_path(wiki_root: Path, source_id: str, proposal_id: str) -> Path:
+    """Return <wiki>/.wiki-state/pending/<source_id>/proposals/<proposal_id>.yaml."""
+    return pending_proposals_dir(wiki_root, source_id) / f"{proposal_id}.yaml"
+
+
+def last_context_path(wiki_root: Path) -> Path:
+    """Return <wiki>/.wiki-state/last-context.yaml."""
+    return wiki_state_dir(wiki_root) / LAST_CONTEXT_FILENAME
+
+
+def gitignore_path(wiki_root: Path) -> Path:
+    """Return <wiki>/.wiki-state/.gitignore."""
+    return wiki_state_dir(wiki_root) / GITIGNORE_FILENAME

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -253,6 +253,7 @@ def test_interactive_setup_writes_config_and_skeleton(
     assert (wiki / "concepts").is_dir()
     assert (wiki / ".wiki-context.yaml").exists()
     assert (wiki / ".transcription-corrections.yaml").exists()
+    assert (wiki / ".wiki-state" / ".gitignore").exists()
 
 
 def test_interactive_setup_custom_model(
@@ -408,3 +409,49 @@ def test_save_last_context_atomic(tmp_path: Path) -> None:
     assert path.exists()
     raw = yaml.safe_load(path.read_text())
     assert raw["perspective"] == "x"
+
+
+# ---------------------------------------------------------------------------
+# last-context.yaml — per-wiki location (wiki_root param)
+# ---------------------------------------------------------------------------
+
+
+def test_save_last_context_creates_wiki_state_dir(tmp_path: Path) -> None:
+    """save_last_context(wiki_root=…) creates .wiki-state/ if needed."""
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    lc = LastContext(perspective="p", source_nature="actual-play")
+    save_last_context(lc, wiki_root=wiki)
+    from auto_lorebook import wiki_state  # noqa: PLC0415
+
+    assert wiki_state.last_context_path(wiki).exists()
+
+
+def test_load_last_context_per_wiki_isolation(tmp_path: Path) -> None:
+    """Two wikis store independent last-context.yaml files."""
+    wiki_a = tmp_path / "wiki_a"
+    wiki_b = tmp_path / "wiki_b"
+    wiki_a.mkdir()
+    wiki_b.mkdir()
+    save_last_context(
+        LastContext(perspective="Cor playing Kiki", source_nature="actual-play"),
+        wiki_root=wiki_a,
+    )
+    save_last_context(
+        LastContext(perspective="narrator", source_nature="notes"),
+        wiki_root=wiki_b,
+    )
+    lc_a = load_last_context(wiki_root=wiki_a)
+    lc_b = load_last_context(wiki_root=wiki_b)
+    assert lc_a.perspective == "Cor playing Kiki"
+    assert lc_b.perspective == "narrator"
+    assert lc_a.source_nature != lc_b.source_nature
+
+
+def test_load_last_context_wiki_root_missing_returns_empty(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    # no .wiki-state/ → missing file → empty context
+    lc = load_last_context(wiki_root=wiki)
+    assert lc.perspective is None
+    assert lc.source_nature is None

--- a/tests/test_ingest_cleanup.py
+++ b/tests/test_ingest_cleanup.py
@@ -29,6 +29,11 @@ def cfg(
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    (home / "config.yaml").write_text(
+        "schema_version: 2\nactive_wiki: test\nwikis:\n"
+        f"- nickname: test\n  path: {tmp_wiki}\n",
+        encoding="utf-8",
+    )
     return cfg_mod.Config(wikis=[WikiEntry("test", tmp_wiki)], active_wiki="test")
 
 
@@ -82,12 +87,13 @@ def _write_entity(
     return path
 
 
-def _write_pending(home: Path, source_id: str) -> tuple[Path, Path, Path]:
-    """Materialise plan.yaml, proposals/, and reading/ for a source."""
-    pending_root = home / "pending" / source_id
-    plan_path = pending_root / "plan.yaml"
-    proposals_dir = pending_root / "proposals"
-    reading_dir = pending_root / "reading"
+def _write_pending(wiki: Path, source_id: str) -> tuple[Path, Path, Path]:
+    """Materialise plan.yaml, proposals/, and reading/ under <wiki>/.wiki-state/."""
+    from auto_lorebook import wiki_state  # noqa: PLC0415
+
+    plan_path = wiki_state.pending_plan_path(wiki, source_id)
+    proposals_dir = wiki_state.pending_proposals_dir(wiki, source_id)
+    reading_dir = wiki_state.pending_reading_dir(wiki, source_id)
     plan_path.parent.mkdir(parents=True, exist_ok=True)
     plan_path.write_text(
         yaml.safe_dump({
@@ -320,8 +326,8 @@ class TestHandEdited:
 
 class TestPendingCleanup:
     def test_drops_plan_and_proposals_keeps_reading(self, cfg: cfg_mod.Config) -> None:
-        home = cfg_mod.config_dir()
-        plan_path, proposals_dir, reading_dir = _write_pending(home, "yt-x")
+        wiki = cfg.resolve_active_wiki(None)
+        plan_path, proposals_dir, reading_dir = _write_pending(wiki, "yt-x")
         reject_ingest(cfg, "yt-x")
         assert not plan_path.exists()
         assert not proposals_dir.exists()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,8 +3,10 @@
 import re
 import subprocess  # noqa: S404
 import sys
+from pathlib import Path
 
 import pytest
+import yaml
 
 # Get package name dynamically - import from the actual package
 import auto_lorebook
@@ -154,6 +156,52 @@ print("SUCCESS")
     )
     assert result.returncode == 0
     assert "SUCCESS" in result.stdout
+
+
+def test_pending_state_lives_under_wiki(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pending artifacts and .gitignore land under <wiki>/.wiki-state/, not home."""
+    from auto_lorebook import wiki_bootstrap, wiki_state  # noqa: PLC0415
+    from auto_lorebook.commands import seed_ingest_cmd  # noqa: PLC0415
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+
+    wiki = tmp_path / "wiki"
+    wiki_bootstrap.bootstrap(wiki)
+
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 2,
+                "active_wiki": "main",
+                "wikis": [{"nickname": "main", "path": str(wiki)}],
+                "openrouter": {"api_key_env": "FAKE_OR_KEY"},
+                "models": {"primary": "anthropic/claude-sonnet-4-5"},
+            },
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    import argparse  # noqa: PLC0415
+
+    args = argparse.Namespace(at="plan", fixture="tiny-aldara", source_id="qa-inttest")
+    rc = seed_ingest_cmd.run(args)
+    assert rc == 0
+
+    sid = "qa-inttest"
+    # reading/structure.yaml lives under <wiki>/.wiki-state/pending/
+    assert (wiki_state.pending_reading_dir(wiki, sid) / "structure.yaml").exists()
+    # .gitignore exists and contains pending/
+    gi = wiki_state.gitignore_path(wiki)
+    assert gi.exists()
+    assert "pending/" in gi.read_text(encoding="utf-8")
+    # nothing under home/pending/
+    assert not (home / "pending").exists()
 
 
 @pytest.mark.skip(reason="Example command not registered - template only")

--- a/tests/test_plans_cmd.py
+++ b/tests/test_plans_cmd.py
@@ -30,11 +30,21 @@ def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return home
 
 
+def _write_config(home: Path, wiki: Path) -> None:
+    (home / "config.yaml").write_text(
+        "schema_version: 2\nactive_wiki: main\nwikis:\n"
+        f"- nickname: main\n  path: {wiki}\n",
+        encoding="utf-8",
+    )
+
+
 def _args(**kwargs: object) -> argparse.Namespace:
     return argparse.Namespace(**kwargs)
 
 
-def _write_plan(home: Path, source_id: str) -> Path:
+def _write_plan(wiki: Path, source_id: str) -> Path:
+    from auto_lorebook import wiki_state  # noqa: PLC0415
+
     plan = Plan(
         source_id=source_id,
         planned_at="2026-04-20T14:58:33Z",
@@ -80,7 +90,7 @@ def _write_plan(home: Path, source_id: str) -> Path:
             )
         ],
     )
-    path = home / "pending" / source_id / "plan.yaml"
+    path = wiki_state.pending_plan_path(wiki, source_id)
     plan_yaml.write(plan, path)
     return path
 
@@ -88,9 +98,11 @@ def _write_plan(home: Path, source_id: str) -> Path:
 class TestPlansList:
     def test_empty(
         self,
-        tmp_home: Path,  # noqa: ARG002
+        tmp_home: Path,
+        tmp_wiki: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
+        _write_config(tmp_home, tmp_wiki)
         rc = plans_cmd.run(_args(plans_action="list"))
         assert rc == 0
         out = capsys.readouterr().out
@@ -99,10 +111,12 @@ class TestPlansList:
     def test_lists_pending(
         self,
         tmp_home: Path,
+        tmp_wiki: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        _write_plan(tmp_home, "yt-aaa")
-        _write_plan(tmp_home, "yt-bbb")
+        _write_config(tmp_home, tmp_wiki)
+        _write_plan(tmp_wiki, "yt-aaa")
+        _write_plan(tmp_wiki, "yt-bbb")
         rc = plans_cmd.run(_args(plans_action="list"))
         assert rc == 0
         out = capsys.readouterr().out
@@ -113,10 +127,14 @@ class TestPlansList:
     def test_skips_non_plan_dirs(
         self,
         tmp_home: Path,
+        tmp_wiki: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
+        from auto_lorebook import wiki_state  # noqa: PLC0415
+
+        _write_config(tmp_home, tmp_wiki)
         # An ingest dir without plan.yaml should be ignored
-        (tmp_home / "pending" / "yt-no-plan").mkdir(parents=True)
+        wiki_state.pending_source_dir(tmp_wiki, "yt-no-plan").mkdir(parents=True)
         rc = plans_cmd.run(_args(plans_action="list"))
         assert rc == 0
         out = capsys.readouterr().out
@@ -127,9 +145,11 @@ class TestPlansShow:
     def test_renders_summary(
         self,
         tmp_home: Path,
+        tmp_wiki: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        _write_plan(tmp_home, "yt-aaa")
+        _write_config(tmp_home, tmp_wiki)
+        _write_plan(tmp_wiki, "yt-aaa")
         rc = plans_cmd.run(_args(plans_action="show", source_id="yt-aaa"))
         assert rc == 0
         out = capsys.readouterr().out
@@ -142,9 +162,11 @@ class TestPlansShow:
 
     def test_unknown_id_returns_1(
         self,
-        tmp_home: Path,  # noqa: ARG002
+        tmp_home: Path,
+        tmp_wiki: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
+        _write_config(tmp_home, tmp_wiki)
         rc = plans_cmd.run(_args(plans_action="show", source_id="yt-missing"))
         assert rc == 1
         out = capsys.readouterr().out

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -249,7 +249,9 @@ class TestGenerateReading:
         out = capsys.readouterr().out
         assert "Draft reading" in out
 
-        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        pending = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "reading"
+        )
         assert (pending / "structure.yaml").exists()
         assert (pending / "bullets.yaml").exists()
         assert (pending / "reading.yaml").exists()
@@ -305,7 +307,9 @@ class TestGenerateReadingSidecarSchema:
             rc = generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
         assert rc == 0
 
-        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        pending = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "reading"
+        )
         sidecar_data = yaml.safe_load((pending / "reading.yaml").read_text())
         assert sidecar_data["schema_version"] == 2
         # fixture has only "Intro" + "Founding of Aldara" — no low-yield matches
@@ -344,7 +348,9 @@ class TestGenerateReadingSidecarSchema:
 
         from auto_lorebook import reading_sidecar as sidecar_mod  # noqa: PLC0415
 
-        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        pending = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "reading"
+        )
         sc = sidecar_mod.read(pending / "reading.yaml")
         assert len(sc.gap_warnings) == 1
         assert sc.gap_warnings[0].start == pytest.approx(2050.0)
@@ -376,8 +382,12 @@ class TestApproveReading:
         assert "# Reading: Session 3" in approved.read_text(encoding="utf-8")
         assert "reading_status" not in approved.read_text(encoding="utf-8")
         # approve-reading must NOT cascade into plan/extract
-        assert not (tmp_home / "pending" / "yt-abc12345678" / "plan.yaml").exists()
-        assert not (tmp_home / "pending" / "yt-abc12345678" / "proposals").exists()
+        assert not (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "plan.yaml"
+        ).exists()
+        assert not (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "proposals"
+        ).exists()
         out = capsys.readouterr().out
         assert "Approved" in out
 
@@ -459,7 +469,9 @@ class TestApproveReadingInteractive:
         assert rc == 0
         approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
         assert not approved.exists()
-        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        pending = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "reading"
+        )
         assert (pending / "reading.yaml").exists()
         assert not (pending / "reading.md").exists()
         # segments still draft
@@ -489,7 +501,9 @@ class TestApproveReadingInteractive:
         assert rc == 0
         approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
         assert not approved.exists()
-        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        pending = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "reading"
+        )
         import yaml as _yaml  # noqa: PLC0415
 
         fm1 = _yaml.safe_load(
@@ -561,7 +575,9 @@ class TestApproveReadingInteractive:
         assert rc == 0
         approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
         assert approved.exists()
-        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        pending = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "reading"
+        )
         import yaml as _yaml  # noqa: PLC0415
 
         fm1 = _yaml.safe_load(
@@ -587,7 +603,9 @@ class TestApproveReadingInteractive:
         assert rc == 0
         approved = ingested_wiki / "sources" / "yt-abc12345678" / "reading.md"
         assert not approved.exists()
-        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        pending = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "reading"
+        )
         import yaml as _yaml  # noqa: PLC0415
 
         fm1 = _yaml.safe_load(
@@ -674,7 +692,9 @@ class TestApproveReadingInteractive:
         assert calls[0][0] == "my-fake-editor"
         assert calls[0][1].endswith("seg-001.md")
 
-        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        pending = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "reading"
+        )
         import yaml as _yaml  # noqa: PLC0415
 
         fm1 = _yaml.safe_load(
@@ -697,7 +717,9 @@ class TestApproveReadingInteractive:
         self._patch_inputs(monkeypatch, ["1", "e", "a", "2", "a", "q"])
         self._generate(monkeypatch)
 
-        pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+        pending = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "reading"
+        )
         seg001_path = pending / "segments" / "seg-001.md"
 
         def fake_run(cmd: list[str], **_kwargs: object) -> object:
@@ -844,7 +866,9 @@ class TestRegenerateReading:
             "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
-            pending = tmp_home / "pending" / "yt-abc12345678" / "reading"
+            pending = (
+                ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "reading"
+            )
             sidecar_before = (pending / "reading.yaml").read_bytes()
 
             regenerate_reading_cmd.run(
@@ -898,7 +922,9 @@ class TestPlan:
             rc = plan_cmd.run(_args(source_id="yt-abc12345678"))
 
         assert rc == 0
-        plan_path = tmp_home / "pending" / "yt-abc12345678" / "plan.yaml"
+        plan_path = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "plan.yaml"
+        )
         assert plan_path.exists()
         first_line = next(ln for ln in plan_path.read_text().splitlines() if ln.strip())
         assert first_line.startswith("schema_version:")
@@ -1022,7 +1048,9 @@ class TestExtract:
             rc = extract_cmd.run(_args(source_id="yt-abc12345678"))
 
         assert rc == 0
-        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        proposals_dir = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "proposals"
+        )
         assert proposals_dir.is_dir()
         files = sorted(proposals_dir.glob("*.yaml"))
         assert len(files) == 2

--- a/tests/test_reading_review.py
+++ b/tests/test_reading_review.py
@@ -95,16 +95,25 @@ def _write_pending() -> None:
         segment_file_mod.write(sf, segs_dir / f"{sf.frontmatter.segment_id}.md")
 
 
+def _write_config(home: Path, wiki: Path) -> None:
+    (home / "config.yaml").write_text(
+        "schema_version: 2\nactive_wiki: test\nwikis:\n"
+        f"- nickname: test\n  path: {wiki}\n",
+        encoding="utf-8",
+    )
+
+
 @pytest.fixture
 def env(
     tmp_path: Path,
     tmp_wiki: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> tuple[cfg_mod.Config, Path]:
-    """Write info.yaml and pending segment files; return (cfg, wiki)."""
+    """Write config + info.yaml + pending segment files; return (cfg, wiki)."""
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    _write_config(home, tmp_wiki)
     cfg = cfg_mod.Config(wikis=[WikiEntry("test", tmp_wiki)], active_wiki="test")
     _write_info(tmp_wiki)
     _write_pending()

--- a/tests/test_reject_ingest_cmd.py
+++ b/tests/test_reject_ingest_cmd.py
@@ -360,3 +360,62 @@ class TestRejectIngest:
                     assert f.get("created_by_ingest") != SOURCE_ID
                 for a in e.aliases:
                     assert a.added_by_ingest != SOURCE_ID
+
+
+class TestRejectIngestIsolation:
+    """Pending state for each wiki is isolated under its own .wiki-state/."""
+
+    def test_reject_ingest_isolated_per_wiki(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reject in wiki_a leaves wiki_b's pending artifacts intact."""
+        from auto_lorebook import wiki_bootstrap, wiki_state  # noqa: PLC0415
+        from auto_lorebook.config import Config  # noqa: PLC0415
+        from auto_lorebook.ingest_cleanup import reject_ingest  # noqa: PLC0415
+        from auto_lorebook.wiki_registry import WikiEntry  # noqa: PLC0415
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+
+        wiki_a = tmp_path / "wiki_a"
+        wiki_b = tmp_path / "wiki_b"
+        wiki_bootstrap.bootstrap(wiki_a)
+        wiki_bootstrap.bootstrap(wiki_b)
+
+        source_id = "yt-shared-sid"
+
+        # Write a plan.yaml under each wiki's .wiki-state/
+        import yaml as _yaml  # noqa: PLC0415
+
+        plan_stub = _yaml.safe_dump({
+            "schema_version": 1,
+            "source_id": source_id,
+            "planned_at": "2026-04-20T00:00:00Z",
+            "entity_resolutions": [],
+            "new_entities": [],
+            "planned_claims": [],
+            "unresolved": [],
+        })
+        plan_a = wiki_state.pending_plan_path(wiki_a, source_id)
+        plan_b = wiki_state.pending_plan_path(wiki_b, source_id)
+        plan_a.parent.mkdir(parents=True, exist_ok=True)
+        plan_b.parent.mkdir(parents=True, exist_ok=True)
+        plan_a.write_text(plan_stub, encoding="utf-8")
+        plan_b.write_text(plan_stub, encoding="utf-8")
+
+        # Config pointing at wiki_a; write config.yaml so load_config() works
+        (home / "config.yaml").write_text(
+            "schema_version: 2\nactive_wiki: a\nwikis:\n"
+            f"- nickname: a\n  path: {wiki_a}\n",
+            encoding="utf-8",
+        )
+        cfg_a = Config(wikis=[WikiEntry("a", wiki_a)], active_wiki="a")
+
+        reject_ingest(cfg_a, source_id)
+
+        # wiki_a's plan removed; wiki_b's plan untouched
+        assert not plan_a.exists(), "plan_a should have been removed"
+        assert plan_b.exists(), "plan_b must not be touched"

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -44,6 +44,11 @@ def cfg(
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+    (home / "config.yaml").write_text(
+        "schema_version: 2\nactive_wiki: test\nwikis:\n"
+        f"- nickname: test\n  path: {tmp_wiki}\n",
+        encoding="utf-8",
+    )
     return cfg_mod.Config(wikis=[WikiEntry("test", tmp_wiki)], active_wiki="test")
 
 

--- a/tests/test_review_cmd.py
+++ b/tests/test_review_cmd.py
@@ -363,7 +363,9 @@ class TestAutoApprove:
         assert len(e.facts) == 1
         assert e.facts[0]["id"] == "aldara-f001"
         # Proposals dir is empty
-        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        proposals_dir = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "proposals"
+        )
         assert list(proposals_dir.glob("*.yaml")) == []
         out = capsys.readouterr().out
         assert "approved=1" in out
@@ -485,7 +487,9 @@ class TestMultiTargetBundle:
             assert e.facts[0]["claim_group_id"] == "cg-001"
 
         # Proposals dir is empty — all three consumed.
-        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        proposals_dir = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "proposals"
+        )
         assert list(proposals_dir.glob("*.yaml")) == []
 
         # Count: approved=3 (one bundle, three routes).
@@ -534,7 +538,9 @@ class TestMultiTargetBundle:
         assert result.rejected == 1
 
         # All proposal files consumed.
-        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        proposals_dir = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "proposals"
+        )
         assert list(proposals_dir.glob("*.yaml")) == []
         capsys.readouterr()
 
@@ -573,7 +579,9 @@ class TestMultiTargetBundle:
         assert not (ingested_wiki / "locations" / "aldara.yaml").exists()
         assert not (ingested_wiki / "characters" / "theron.yaml").exists()
         assert not (ingested_wiki / "events" / "second-age.yaml").exists()
-        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        proposals_dir = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "proposals"
+        )
         assert list(proposals_dir.glob("*.yaml")) == []
         capsys.readouterr()
 
@@ -801,7 +809,9 @@ class TestInteractiveReviewerUndoIntegration:
             assert e.facts[0]["text_source"] is None
             assert e.facts[0]["edited_by_human"] is False
 
-        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        proposals_dir = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "proposals"
+        )
         assert list(proposals_dir.glob("*.yaml")) == []
         out = capsys.readouterr().out
         assert "approved=3" in out
@@ -851,7 +861,9 @@ class TestInteractiveReviewerUndoIntegration:
         ):
             assert not (ingested_wiki / cat / f"{slug}.yaml").exists()
 
-        proposals_dir = tmp_home / "pending" / "yt-abc12345678" / "proposals"
+        proposals_dir = (
+            ingested_wiki / ".wiki-state" / "pending" / "yt-abc12345678" / "proposals"
+        )
         assert list(proposals_dir.glob("*.yaml")) == []
         out = capsys.readouterr().out
         assert "rejected=3" in out

--- a/tests/test_seed_ingest_cmd.py
+++ b/tests/test_seed_ingest_cmd.py
@@ -105,8 +105,10 @@ class TestSeedIngestPerStage:
         sid = _seeded_sid_from(capsys.readouterr().out)
         assert sid.startswith("qa-")
 
+        from auto_lorebook import wiki_state  # noqa: PLC0415
+
         wiki_src = tmp_wiki / "sources" / sid
-        pending_reading = tmp_home / "pending" / sid / "reading"
+        pending_reading = wiki_state.pending_reading_dir(tmp_wiki, sid)
 
         assert {p.name for p in wiki_src.iterdir()} == expected_wiki
         if expected_pending:
@@ -134,14 +136,13 @@ class TestSeedIngestPerStage:
         info = info_yaml.read(tmp_wiki / "sources" / sid / "info.yaml")
         assert info.source_id == sid
 
-        struct = structure_mod.read(
-            tmp_home / "pending" / sid / "reading" / "structure.yaml"
-        )
+        from auto_lorebook import wiki_state  # noqa: PLC0415
+
+        pr = wiki_state.pending_reading_dir(tmp_wiki, sid)
+        struct = structure_mod.read(pr / "structure.yaml")
         assert struct.source_id == sid
 
-        bullets = stage1b.read_bullets(
-            tmp_home / "pending" / sid / "reading" / "bullets.yaml"
-        )
+        bullets = stage1b.read_bullets(pr / "bullets.yaml")
         assert bullets.source_id == sid
 
         approved_path = tmp_wiki / "sources" / sid / "reading.md"
@@ -149,19 +150,17 @@ class TestSeedIngestPerStage:
         assert fm["source_id"] == sid
         assert "reading_status" not in fm
 
-        sidecar = reading_sidecar_mod.read(
-            tmp_home / "pending" / sid / "reading" / "reading.yaml"
-        )
+        sidecar = reading_sidecar_mod.read(pr / "reading.yaml")
         assert sidecar.default_speaker == "DM"
 
         # placeholder must not survive anywhere on disk
         for path in (
             tmp_wiki / "sources" / sid / "info.yaml",
-            tmp_home / "pending" / sid / "reading" / "structure.yaml",
-            tmp_home / "pending" / sid / "reading" / "bullets.yaml",
-            tmp_home / "pending" / sid / "reading" / "reading.yaml",
-            tmp_home / "pending" / sid / "reading" / "segments" / "seg-001.md",
-            tmp_home / "pending" / sid / "reading" / "segments" / "seg-002.md",
+            pr / "structure.yaml",
+            pr / "bullets.yaml",
+            pr / "reading.yaml",
+            pr / "segments" / "seg-001.md",
+            pr / "segments" / "seg-002.md",
             approved_path,
         ):
             assert "__QA_SOURCE_ID__" not in path.read_text(encoding="utf-8")
@@ -179,13 +178,12 @@ class TestSeedIngestPerStage:
         assert rc == 0
         sid = _seeded_sid_from(capsys.readouterr().out)
 
-        seg001 = segment_file_mod.read(
-            tmp_home / "pending" / sid / "reading" / "segments" / "seg-001.md"
-        )
+        from auto_lorebook import wiki_state  # noqa: PLC0415
+
+        pr = wiki_state.pending_reading_dir(tmp_wiki, sid)
+        seg001 = segment_file_mod.read(pr / "segments" / "seg-001.md")
         assert seg001.frontmatter.segment_status == "draft"
-        seg002 = segment_file_mod.read(
-            tmp_home / "pending" / sid / "reading" / "segments" / "seg-002.md"
-        )
+        seg002 = segment_file_mod.read(pr / "segments" / "seg-002.md")
         assert seg002.frontmatter.segment_status == "draft"
 
     def test_explicit_source_id_used_verbatim(

--- a/tests/test_wiki_bootstrap.py
+++ b/tests/test_wiki_bootstrap.py
@@ -1,0 +1,84 @@
+"""Tests for wiki_bootstrap idempotent skeleton creation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from auto_lorebook import wiki_bootstrap, wiki_state
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_first_run_creates_entity_dirs(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki_bootstrap.bootstrap(wiki)
+    for sub in wiki_bootstrap.WIKI_SUBDIRS:
+        assert (wiki / sub).is_dir(), f"missing {sub}/"
+
+
+def test_first_run_creates_dotted_yaml_stubs(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki_bootstrap.bootstrap(wiki)
+    for fname in wiki_bootstrap.DOTTED_YAML_STUBS:
+        path = wiki / fname
+        assert path.exists(), f"missing {fname}"
+        assert path.read_text(encoding="utf-8") == wiki_bootstrap.STUB_BODY
+
+
+def test_first_run_creates_wiki_state_dir(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki_bootstrap.bootstrap(wiki)
+    assert wiki_state.wiki_state_dir(wiki).is_dir()
+
+
+def test_first_run_writes_gitignore(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki_bootstrap.bootstrap(wiki)
+    gi = wiki_state.gitignore_path(wiki)
+    assert gi.exists()
+    assert "pending/" in gi.read_text(encoding="utf-8")
+
+
+def test_second_run_is_noop(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki_bootstrap.bootstrap(wiki)
+
+    gi = wiki_state.gitignore_path(wiki)
+    stub = wiki / ".wiki-context.yaml"
+    mtime_gi = gi.stat().st_mtime
+    mtime_stub = stub.stat().st_mtime
+    content_gi = gi.read_text(encoding="utf-8")
+    content_stub = stub.read_text(encoding="utf-8")
+
+    wiki_bootstrap.bootstrap(wiki)
+
+    assert gi.stat().st_mtime == mtime_gi
+    assert stub.stat().st_mtime == mtime_stub
+    assert gi.read_text(encoding="utf-8") == content_gi
+    assert stub.read_text(encoding="utf-8") == content_stub
+
+
+def test_preserves_existing_wiki_context_yaml(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    custom = "schema_version: 1\nsetting:\n  name: Aether\n"
+    (wiki / ".wiki-context.yaml").write_text(custom, encoding="utf-8")
+
+    wiki_bootstrap.bootstrap(wiki)
+
+    assert (wiki / ".wiki-context.yaml").read_text(encoding="utf-8") == custom
+
+
+def test_preserves_existing_gitignore(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    state_dir = wiki_state.wiki_state_dir(wiki)
+    state_dir.mkdir(parents=True)
+    gi = wiki_state.gitignore_path(wiki)
+    custom = "*.pyc\npending/\n"
+    gi.write_text(custom, encoding="utf-8")
+
+    wiki_bootstrap.bootstrap(wiki)
+
+    assert gi.read_text(encoding="utf-8") == custom

--- a/tests/test_wiki_state.py
+++ b/tests/test_wiki_state.py
@@ -1,0 +1,80 @@
+"""Tests for wiki_state pure path arithmetic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from auto_lorebook import wiki_state
+
+
+def test_wiki_state_dir_shape() -> None:
+    p = wiki_state.wiki_state_dir(Path("/w"))
+    assert p == Path("/w/.wiki-state")
+
+
+def test_pending_dir_shape() -> None:
+    p = wiki_state.pending_dir(Path("/w"))
+    assert p == Path("/w/.wiki-state/pending")
+
+
+def test_pending_reading_dir_shape() -> None:
+    p = wiki_state.pending_reading_dir(Path("/w"), "src-001")
+    assert p == Path("/w/.wiki-state/pending/src-001/reading")
+
+
+def test_pending_plan_path_shape() -> None:
+    p = wiki_state.pending_plan_path(Path("/w"), "src-001")
+    assert p == Path("/w/.wiki-state/pending/src-001/plan.yaml")
+    assert p.name == "plan.yaml"
+
+
+def test_pending_proposals_dir_shape() -> None:
+    p = wiki_state.pending_proposals_dir(Path("/w"), "src-001")
+    assert p == Path("/w/.wiki-state/pending/src-001/proposals")
+
+
+def test_pending_proposal_path_shape() -> None:
+    p = wiki_state.pending_proposal_path(Path("/w"), "src-001", "prop-42")
+    assert p == Path("/w/.wiki-state/pending/src-001/proposals/prop-42.yaml")
+    assert p.name == "prop-42.yaml"
+
+
+def test_last_context_path_shape() -> None:
+    p = wiki_state.last_context_path(Path("/w"))
+    assert p == Path("/w/.wiki-state/last-context.yaml")
+
+
+def test_gitignore_path_shape() -> None:
+    p = wiki_state.gitignore_path(Path("/w"))
+    assert p == Path("/w/.wiki-state/.gitignore")
+
+
+def test_purity_no_filesystem_io() -> None:
+    """All functions must be pure — no I/O on nonexistent paths."""
+    root = Path("/nonexistent/wiki/that/does/not/exist")
+    wiki_state.wiki_state_dir(root)
+    wiki_state.pending_dir(root)
+    wiki_state.pending_reading_dir(root, "sid")
+    wiki_state.pending_plan_path(root, "sid")
+    wiki_state.pending_proposals_dir(root, "sid")
+    wiki_state.pending_proposal_path(root, "sid", "pid")
+    wiki_state.last_context_path(root)
+    wiki_state.gitignore_path(root)
+    # nothing created
+    assert not root.exists()
+
+
+@pytest.mark.parametrize(
+    ("source_id", "proposal_id"),
+    [
+        ("yt-abc123", "char-aldara"),
+        ("qa-deadbeef", "loc-ember-vale"),
+    ],
+)
+def test_pending_proposal_path_various_ids(source_id: str, proposal_id: str) -> None:
+    p = wiki_state.pending_proposal_path(Path("/w"), source_id, proposal_id)
+    assert p.suffix == ".yaml"
+    assert p.parent.name == "proposals"
+    assert p.parent.parent.name == source_id


### PR DESCRIPTION
### What this fixes

Wiki-scoped tool state previously lived in a single shared namespace at `~/.auto-lorebook/pending/<source_id>/...` and `~/.auto-lorebook/last-context.yaml`, so two wikis with the same `source_id` collided, moving a wiki to another machine stranded its in-flight work, and `reject-ingest` operated on a shared tree rather than being wiki-scoped. This branch relocates that state into `<wiki>/.wiki-state/` so each wiki is self-contained.

Two new deep modules carry the change:

- `auto_lorebook.wiki_state` — pure path arithmetic (no IO). Exposes the eight helpers named in the AC (`wiki_state_dir`, `pending_dir`, `pending_reading_dir`, `pending_plan_path`, `pending_proposals_dir`, `pending_proposal_path`, `last_context_path`, `gitignore_path`) plus a `pending_source_dir` convenience.
- `auto_lorebook.wiki_bootstrap.bootstrap(wiki_root)` — idempotent skeleton creation. Replaces the inline `_bootstrap_wiki` helper in `config.py`. Creates entity category dirs, `.wiki-context.yaml` + `.transcription-corrections.yaml` stubs, `.wiki-state/`, and `.wiki-state/.gitignore` containing `pending/`. Preserves any pre-existing user content (stubs and `.gitignore` are write-only-if-missing).

Call-site updates route every pending lookup and last-context I/O through the new modules:

- `reading_pipeline.py` keeps its `pending_*` helper signatures stable; each now resolves the active wiki internally (`_active_wiki_root()`) and composes the path via `wiki_state`.
- `commands/plans.py` and `commands/seed_ingest.py` reach for `wiki_state` directly.
- `config.load_last_context(wiki_root)` / `save_last_context(last, wiki_root)` now target `<wiki>/.wiki-state/last-context.yaml`; the old `~/.auto-lorebook/last-context.yaml` is no longer read or written. `commands/_shared.py` passes the resolved active wiki to both.
- `reject-ingest` becomes wiki-scoped automatically since its pending lookup flows through `reading_pipeline.pending_*`.

No migration of legacy `~/.auto-lorebook/pending/` data — confirmed acceptable per PRD #51.

### QA steps for the human

None — fully covered by the integration smoke. The Opus smoke run bootstrapped two fresh wikis under an isolated `AUTO_LOREBOOK_HOME`, drove `seed-ingest --at plan` + `reject-ingest --yes` end-to-end, asserted pending/last-context/`.gitignore` live under `<wiki>/.wiki-state/` (and nothing under `<home>/pending/`), confirmed idempotent re-bootstrap leaves files byte-identical, and verified two-wiki `last-context` isolation.

### Automated coverage

`uv run ruff check && uv run ruff format --check && uv run ty check && uv run pytest && uv run mkdocs build --strict` — all green (605 passed, 4 skipped live-integration tests).

Closes #55

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8zVrFF4Qz1UeytS5revaU)_