### PR TITLE
`auto-lorebook run` umbrella command (#59 slices 1-5)

### DIFF
--- a/docs/getting-started/first-ingest.md
+++ b/docs/getting-started/first-ingest.md
@@ -37,8 +37,6 @@ Setting [Aether Chronicles]:
 Any notes? (one line, or Enter to skip): Picks up mid-session after a long rest.
 
 Context saved to sources/yt-abc123/info.yaml.
-
-Generate reading now? [Y/n]: y
 ```
 
 Context fields are optional — blank is allowed. Unfilled fields reduce

--- a/docs/getting-started/first-ingest.md
+++ b/docs/getting-started/first-ingest.md
@@ -3,57 +3,42 @@
 This walkthrough takes a YouTube URL from raw source to approved entity
 facts.
 
-## 1. Ingest the source
+## Quickstart: single command
 
 ```bash
-auto-lorebook ingest https://youtube.com/watch?v=abc123
+auto-lorebook run https://youtube.com/watch?v=abc123
 ```
 
-The tool fetches the transcript via `yt-dlp`, stores it under
-`sources/yt-abc123/`, and prints what it captured:
+`run` detects where the source is in the pipeline and drives it forward
+to completion — ingest, reading generation, reading approval, planning,
+extraction, and fact review — stopping at each human gate.
 
-```
-✓ Manual subtitles available (English)
-Source stored as yt-abc123.
-  Title: Aether Chronicles S3E14
-  Duration: 2:20:32
-  Captions: manual (English)
-```
-
-If only auto-generated captions are available, the tool warns that
-proper-noun mishearings are likely and suggests adding name corrections
-during reading review.
-
-## 2. Fill in context
-
-The tool prompts interactively. Every field is skippable; defaults come
-from flags, then `.wiki-context.yaml`, then your last ingest.
-
-```
-Session date (YYYY-MM-DD): 2026-01-15
-Perspective (e.g. "Cor playing Kiki"): Cor playing Kiki in Aether Chronicles
-Source nature [actual-play/dm-lore/worldbuilding-video/interview/notes/other]: actual-play
-Setting [Aether Chronicles]:
-Any notes? (one line, or Enter to skip): Picks up mid-session after a long rest.
-
-Context saved to sources/yt-abc123/info.yaml.
-```
-
-Context fields are optional — blank is allowed. Unfilled fields reduce
-LLM quality but don't block the pipeline. See
-[context pipeline](../pipeline/context.md) for schema details.
-
-## 3. Review the reading
-
-After Stage 1a (structure) and Stage 1b (summarize) run, you get a
-draft: sidecar at `pending/yt-abc123/reading/reading.yaml` and one
-`segments/seg-NNN.md` per segment. Open the interactive review:
+For unattended or CI runs, pass both gate flags to skip the interactive
+prompts:
 
 ```bash
-auto-lorebook approve-reading yt-abc123
+auto-lorebook run https://youtube.com/watch?v=abc123 --yes --auto-approve
 ```
 
-The session prints the draft and prompts:
+`--yes` auto-approves the reading review; `--auto-approve` auto-approves
+all fact proposals. In a non-interactive shell, `run` refuses to proceed
+past a gate unless the matching flag is supplied.
+
+You can also resume a partially completed ingest by passing the source ID
+instead of the URL:
+
+```bash
+auto-lorebook run yt-abc123
+```
+
+`run` skips any stages already complete and continues from where it left off.
+
+## What happens at each gate
+
+### Reading review (Stage 1 output)
+
+After Stage 1a (structure) and Stage 1b (summarize) run, `run` opens the
+interactive reading review. The session prints the draft and prompts:
 
 - `a` — approve (flips status, copies to wiki).
 - `e` — preview assembled draft in `$EDITOR` (read-only; edits are
@@ -64,34 +49,12 @@ The session prints the draft and prompts:
 - `q` — quit; commits a queued reject (after a `y/N` confirm) or
   exits cleanly.
 
-Pass `--yes` to skip the loop and auto-approve (required for
-scripted/CI runs). See [reading stage](../pipeline/reading.md) for
-deeper treatment.
+Pass `--yes` to skip this loop and auto-approve. See
+[reading stage](../pipeline/reading.md) for deeper treatment.
 
-## 4. Plan and extract
+### Fact review (Stage 3 output)
 
-After approving the reading, run Stage 2 (planner) and Stage 3
-(extractor) explicitly:
-
-```bash
-auto-lorebook plan yt-abc123
-auto-lorebook extract yt-abc123
-```
-
-`plan` routes claim bullets to entities and writes
-`pending/yt-abc123/plan.yaml`; it refuses if the wiki-side `reading.md`
-is missing. `extract` locates verbatim transcript spans for each
-planned claim and writes proposal YAMLs under
-`pending/yt-abc123/proposals/`; it refuses if `plan.yaml` is missing.
-
-## 5. Review facts
-
-To walk through proposed facts:
-
-```bash
-auto-lorebook review ingest-2026-04-20-a
-```
-
+After the planner and extractor run, `run` opens the fact review loop.
 Each proposal shows the claim text, the raw transcript span it came
 from, corrections applied, source locator, and routing rationale.
 Decide per proposal: **approve**, **edit**, **reject**, or **play**
@@ -103,7 +66,9 @@ stub atomically. If review reveals systematic routing errors, bail out
 with `auto-lorebook replan <ingest_id>` instead of fighting proposal by
 proposal. See [fact review](../pipeline/review.md).
 
-## 6. View the wiki
+Pass `--auto-approve` to skip this loop and approve all proposals.
+
+## View the wiki
 
 Approved facts land in `<category>/<slug>.yaml`; the summarizer
 regenerates `<category>/<slug>.md` with citation-backed prose. Browse
@@ -116,3 +81,55 @@ auto-lorebook wiki list --category locations
 
 See [summarizer stage](../pipeline/summarizer.md) for how YAML facts
 become readable prose.
+
+## Running stages individually
+
+If you need fine-grained control, you can run each stage as a separate
+command. This is useful when resuming after an error, inspecting
+intermediate artifacts, or running only part of the pipeline.
+
+### 1. Ingest the source
+
+```bash
+auto-lorebook ingest https://youtube.com/watch?v=abc123
+```
+
+Fetches the transcript via `yt-dlp`, stores it under
+`sources/yt-abc123/`, and prints what it captured. Then prompts for
+context (session date, perspective, source nature, setting, notes) —
+every field is skippable.
+
+If only auto-generated captions are available, the tool warns that
+proper-noun mishearings are likely and suggests adding name corrections
+during reading review.
+
+### 2. Generate and review the reading
+
+```bash
+auto-lorebook generate-reading yt-abc123
+auto-lorebook approve-reading yt-abc123
+```
+
+`generate-reading` runs Stage 1a → 1b and writes a draft reading.
+`approve-reading` opens the interactive review loop described above.
+
+### 3. Plan and extract
+
+```bash
+auto-lorebook plan yt-abc123
+auto-lorebook extract yt-abc123
+```
+
+`plan` routes claim bullets to entities and writes
+`pending/yt-abc123/plan.yaml`; it refuses if the wiki-side `reading.md`
+is missing. `extract` locates verbatim transcript spans for each
+planned claim and writes proposal YAMLs under
+`pending/yt-abc123/proposals/`; it refuses if `plan.yaml` is missing.
+
+### 4. Review facts
+
+```bash
+auto-lorebook review ingest-2026-04-20-a
+```
+
+Opens the fact review loop described above.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -105,4 +105,10 @@ the registry.
 
 ## Next
 
-Run your first ingest: [first ingest walkthrough](first-ingest.md).
+Run your first ingest with the primary entry point:
+
+```bash
+auto-lorebook run https://youtube.com/watch?v=abc123
+```
+
+Full walkthrough: [first ingest](first-ingest.md).

--- a/docs/pipeline/context.md
+++ b/docs/pipeline/context.md
@@ -224,9 +224,6 @@ Setting [Aether Chronicles]:
 Any notes? (one line, or Enter to skip): Picks up mid-session after a long rest.
 
 Context saved to sources/yt-abc123/info.yaml.
-
-Generate reading now? [Y/n]: y
-Generating reading (segment → attribute → summarize)...
 ```
 
 Speakers are not prompted for at ingest time. They're defined once in
@@ -234,10 +231,8 @@ Speakers are not prompted for at ingest time. They're defined once in
 sources. Per-source speaker variation (guest players, one-off NPCs)
 can be added to `info.yaml` manually if needed.
 
-After context is captured, the tool offers to run the reading pipeline
-immediately. Declining leaves the source at "context captured, reading
-not yet generated"; the user runs `auto-lorebook generate-reading
-<source_id>` manually later.
+After context is captured, run the reading pipeline with
+`auto-lorebook generate-reading <source_id>`.
 
 ## Flags and non-interactive mode
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,6 +3,23 @@
 All commands are invoked as `auto-lorebook <command>`. Each command
 links to the page that explains its semantics.
 
+## Run (primary entry point)
+
+```bash
+auto-lorebook run <url-or-source-id> \
+  [--yes] \
+  [--auto-approve]
+```
+
+Drive a source through the full pipeline from its current state to
+completion. Skips stages already done; stops at each human gate. Accepts
+a YouTube URL (ingest included if not done) or an existing source ID.
+
+`--yes` forwards to the reading-review gate (auto-approves all reading
+segments). `--auto-approve` forwards to the fact-review gate
+(auto-approves all proposals). Both flags are required in a
+non-interactive shell. See [first ingest](../getting-started/first-ingest.md).
+
 ## Ingest
 
 ```bash

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -21,11 +21,12 @@ implementation status.
     `entities rebuild-index` is a placeholder until a disk cache
     materialises.
 
-    Phase 3 (planner) landed: Stage 2 LLM planner runs automatically
-    after `approve-reading`, writes `pending/<source_id>/plan.yaml`
-    with no filesystem side effects (new entities and aliases are
-    proposals only), supports multi-target routing per claim, and
-    exposes `plans list` / `plans show` for inspection.
+    Phase 3 (planner) landed: Stage 2 LLM planner (`auto-lorebook plan
+    <id>`) writes `pending/<source_id>/plan.yaml` with no filesystem
+    side effects (new entities and aliases are proposals only), supports
+    multi-target routing per claim, and exposes `plans list` /
+    `plans show` for inspection. Automatic chaining after
+    `approve-reading` is a planned ergonomics improvement (see #59).
 
     Phase 4 extractor landed: Stage 3 runs automatically after the
     planner, parallelised per `PlannedClaim`, with reduced preamble,
@@ -155,11 +156,11 @@ this phase but are deferred — `rename` to whenever a real need surfaces,
   per-target section and rationale.
 - `plans list` and `plans show` inspection commands.
 
-**Exit criterion** — ingest a source, review reading, planner runs
-automatically and produces a plan. New entities are _proposals on the
-plan_, not files in the wiki. Aliases are proposed, not yet written.
-At least one planned claim in a representative session routes to
-multiple targets. ✓
+**Exit criterion** — ingest a source, review reading, run
+`auto-lorebook plan <id>`, and confirm a plan is produced. New entities
+are _proposals on the plan_, not files in the wiki. Aliases are
+proposed, not yet written. At least one planned claim in a
+representative session routes to multiple targets. ✓
 
 `replan` was spec'd alongside this phase but landed in Phase 4
 once the extractor + review loop gave it something to discard.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -25,8 +25,7 @@ implementation status.
     <id>`) writes `pending/<source_id>/plan.yaml` with no filesystem
     side effects (new entities and aliases are proposals only), supports
     multi-target routing per claim, and exposes `plans list` /
-    `plans show` for inspection. Automatic chaining after
-    `approve-reading` is a planned ergonomics improvement (see #59).
+    `plans show` for inspection.
 
     Phase 4 extractor landed: Stage 3 runs automatically after the
     planner, parallelised per `PlannedClaim`, with reduced preamble,
@@ -68,6 +67,17 @@ implementation status.
     are left untouched so a follow-up `regenerate-reading` /
     `approve-reading` cleanly redoes the pipeline. **Phase 4 is
     fully landed.**
+
+    Pipeline ergonomics (#59) landed: `auto-lorebook run <URL-or-id>`
+    is the single entry point for the full pipeline. It detects which
+    stage is next, drives the source forward to completion, and stops
+    at each human gate (reading review, fact review). Stages already
+    complete are skipped with a notice. In a non-interactive shell,
+    `--yes` passes the reading gate and `--auto-approve` passes the
+    fact-review gate; without both flags, `run` refuses to proceed
+    past a gate unattended. The planner runs between the two gates
+    without its own gate; its failure modes surface during fact review,
+    with `replan` as the escape hatch.
 
 ## Phase 1: Reading stage
 

--- a/src/auto_lorebook/cli.py
+++ b/src/auto_lorebook/cli.py
@@ -23,6 +23,7 @@ from auto_lorebook.commands import (
     reject_ingest_cmd,
     replan_cmd,
     review_cmd,
+    run_cmd,
     seed_ingest_cmd,
     version_cmd,
     wiki_cmd,
@@ -123,6 +124,7 @@ def create_parser() -> argparse.ArgumentParser:
     entities_cmd.add_parser(subparsers, common_parser)
     plans_cmd.add_parser(subparsers, common_parser)
     review_cmd.add_parser(subparsers, common_parser)
+    run_cmd.add_parser(subparsers, common_parser)
     replan_cmd.add_parser(subparsers, common_parser)
     reject_ingest_cmd.add_parser(subparsers, common_parser)
     seed_ingest_cmd.add_parser(subparsers, common_parser)

--- a/src/auto_lorebook/commands/__init__.py
+++ b/src/auto_lorebook/commands/__init__.py
@@ -17,6 +17,7 @@ from auto_lorebook.commands import regenerate_reading as regenerate_reading_cmd
 from auto_lorebook.commands import reject_ingest as reject_ingest_cmd
 from auto_lorebook.commands import replan as replan_cmd
 from auto_lorebook.commands import review as review_cmd
+from auto_lorebook.commands import run as run_cmd
 from auto_lorebook.commands import seed_ingest as seed_ingest_cmd
 from auto_lorebook.commands import version as version_cmd
 from auto_lorebook.commands import wiki as wiki_cmd
@@ -34,6 +35,7 @@ __all__ = [
     "reject_ingest_cmd",
     "replan_cmd",
     "review_cmd",
+    "run_cmd",
     "seed_ingest_cmd",
     "version_cmd",
     "wiki_cmd",

--- a/src/auto_lorebook/commands/ingest.py
+++ b/src/auto_lorebook/commands/ingest.py
@@ -20,25 +20,8 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
-def add_parser(
-    subparsers: argparse._SubParsersAction,
-    common_parser: argparse.ArgumentParser,
-) -> argparse.ArgumentParser:
-    """Register the ingest subcommand."""
-    parser = subparsers.add_parser(
-        "ingest",
-        parents=[common_parser],
-        help="Ingest a source (local file or YouTube URL)",
-        description=(
-            "Fetch a source, gather context, and store it in the wiki. "
-            "Local files (.srt, .txt, .md) are supported. "
-            "YouTube URLs are fetched via yt-dlp (bundled)."
-        ),
-    )
-    parser.add_argument(
-        "url_or_path",
-        help="Local file path (.srt/.txt/.md) or YouTube URL",
-    )
+def add_ingest_args(parser: argparse.ArgumentParser) -> None:
+    """Add ingest-specific flags to parser (shared by ingest and run)."""
     parser.add_argument(
         "--source-url",
         dest="source_url",
@@ -103,6 +86,28 @@ def add_parser(
             "HTTP 429 rate limits."
         ),
     )
+
+
+def add_parser(
+    subparsers: argparse._SubParsersAction,
+    common_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Register the ingest subcommand."""
+    parser = subparsers.add_parser(
+        "ingest",
+        parents=[common_parser],
+        help="Ingest a source (local file or YouTube URL)",
+        description=(
+            "Fetch a source, gather context, and store it in the wiki. "
+            "Local files (.srt, .txt, .md) are supported. "
+            "YouTube URLs are fetched via yt-dlp (bundled)."
+        ),
+    )
+    parser.add_argument(
+        "url_or_path",
+        help="Local file path (.srt/.txt/.md) or YouTube URL",
+    )
+    add_ingest_args(parser)
     parser.set_defaults(func=run)
     return parser
 

--- a/src/auto_lorebook/commands/run.py
+++ b/src/auto_lorebook/commands/run.py
@@ -11,9 +11,11 @@ import logging
 from typing import TYPE_CHECKING
 
 from auto_lorebook import config as cfg_mod
+from auto_lorebook import source_id as sid_mod
 from auto_lorebook.commands import approve_reading as approve_reading_cmd
 from auto_lorebook.commands import extract as extract_cmd
 from auto_lorebook.commands import generate_reading as generate_reading_cmd
+from auto_lorebook.commands import ingest as ingest_cmd
 from auto_lorebook.commands import plan as plan_cmd
 from auto_lorebook.commands import review as review_cmd
 from auto_lorebook.pipeline_state import Stage, first_missing_stage
@@ -22,6 +24,18 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 _logger = logging.getLogger(__name__)
+
+# Ingest-only flags: warn when set on a source-id invocation.
+_INGEST_ONLY_ATTRS = (
+    "session_date",
+    "perspective",
+    "source_nature",
+    "setting",
+    "notes",
+    "source_url",
+    "no_interactive",
+    "cookies_from_browser",
+)
 
 # Extra Namespace fields each stage's run() requires beyond source_id/wiki.
 _STAGE_DEFAULTS: dict[Stage, dict[str, object]] = {
@@ -57,9 +71,26 @@ def add_parser(
             "review) defers to the interactive command as-is."
         ),
     )
-    parser.add_argument("source_id", help="Source ID (e.g. yt-abc12345678)")
+    parser.add_argument(
+        "url_or_sid",
+        help="Source ID (e.g. yt-abc12345678) or YouTube URL",
+    )
+    ingest_cmd.add_ingest_args(parser)
     parser.set_defaults(func=run)
     return parser
+
+
+def _is_url(value: str) -> bool:
+    """Check if value looks like a URL."""
+    return "://" in value or value.startswith("http")
+
+
+def _warn_ignored_ingest_flags(args: argparse.Namespace) -> None:
+    """Warn if any ingest-only flags are set on a source-id invocation."""
+    active = [attr for attr in _INGEST_ONLY_ATTRS if getattr(args, attr, None)]
+    if active:
+        flags = ", ".join(f"--{a.replace('_', '-')}" for a in active)
+        _logger.warning("ingest-only flags ignored for source-id invocation: %s", flags)
 
 
 def run(args: argparse.Namespace) -> int:
@@ -71,12 +102,55 @@ def run(args: argparse.Namespace) -> int:
         return 1
 
     wiki_override: str | None = getattr(args, "wiki", None)
-    source_id: str = args.source_id
+    # url_or_sid = real positional; source_id = --source-id flag override.
+    # When url_or_sid absent, treat source_id as positional (legacy test convention).
+    url_or_sid: str | None = getattr(args, "url_or_sid", None)
+    positional: str = url_or_sid if url_or_sid is not None else args.source_id
+    # sid_override only valid when positional came from url_or_sid slot.
+    sid_override: str | None = (
+        getattr(args, "source_id", None) if url_or_sid is not None else None
+    )
+
+    if _is_url(positional):
+        # Derive source_id from URL.
+        video_id = sid_mod.extract_video_id(positional)
+        if not video_id:
+            _logger.error(
+                "Only YouTube URLs are supported. Pass a source ID or a YouTube URL."
+            )
+            return 1
+        source_id = sid_override or f"yt-{video_id}"
+        # Check if source already ingested; if not, run ingest first.
+        stage = first_missing_stage(cfg, source_id, wiki_override=wiki_override)
+        if stage is Stage.INGEST:
+            ingest_args = argparse.Namespace(
+                url_or_path=positional,
+                wiki=wiki_override,
+                source_url=getattr(args, "source_url", None),
+                source_id=sid_override,
+                session_date=getattr(args, "session_date", None),
+                perspective=getattr(args, "perspective", None),
+                source_nature=getattr(args, "source_nature", None),
+                setting=getattr(args, "setting", None),
+                notes=getattr(args, "notes", None),
+                no_interactive=getattr(args, "no_interactive", True),
+                cookies_from_browser=getattr(args, "cookies_from_browser", None),
+            )
+            exit_code = ingest_cmd.run(ingest_args)
+            if exit_code != 0:
+                return exit_code
+    else:
+        source_id = positional
+        _warn_ignored_ingest_flags(args)
 
     while True:
         stage = first_missing_stage(cfg, source_id, wiki_override=wiki_override)
         if stage is None:
             return 0
+        if stage is Stage.INGEST:
+            # Should not happen after successful ingest, but guard anyway.
+            _logger.error("Source %s still missing after ingest.", source_id)
+            return 1
 
         stage_runner = STAGE_RUNNERS[stage]
         defaults = _STAGE_DEFAULTS[stage]

--- a/src/auto_lorebook/commands/run.py
+++ b/src/auto_lorebook/commands/run.py
@@ -112,6 +112,36 @@ _PIPELINE_ORDER = [
     Stage.REVIEW,
 ]
 
+# Display name (dashed, lowercase) for each stage.
+_STAGE_DISPLAY: dict[Stage, str] = {
+    Stage.INGEST: "ingest",
+    Stage.GENERATE_READING: "generate-reading",
+    Stage.APPROVE_READING: "approve-reading",
+    Stage.PLAN: "plan",
+    Stage.EXTRACT: "extract",
+    Stage.REVIEW: "review",
+}
+
+# Artifact that confirms the stage is done (used in skip notices).
+_STAGE_ARTIFACT: dict[Stage, str] = {
+    Stage.INGEST: "info.yaml",
+    Stage.GENERATE_READING: "reading sidecar",
+    Stage.APPROVE_READING: "reading.md",
+    Stage.PLAN: "plan.yaml",
+    Stage.EXTRACT: "proposals/",
+    Stage.REVIEW: "proposals empty",
+}
+
+
+def _print_stage_header(stage: Stage) -> None:
+    idx = _PIPELINE_ORDER.index(stage) + 1
+    total = len(_PIPELINE_ORDER)
+    print(f"── [{idx}/{total}] {_STAGE_DISPLAY[stage]} ──")  # noqa: T201
+
+
+def _print_skip_notice(stage: Stage) -> None:
+    print(f"✓ skipped {_STAGE_DISPLAY[stage]} ({_STAGE_ARTIFACT[stage]} exists)")  # noqa: T201
+
 
 def _reachable_gates(resume: Stage) -> list[Stage]:
     """Gates at-or-after resume point in pipeline order."""
@@ -215,6 +245,11 @@ def run(args: argparse.Namespace) -> int:
         )
         return 1
 
+    # Emit skip notices for all stages before the resume point.
+    resume_idx = _PIPELINE_ORDER.index(resume)
+    for skipped_stage in _PIPELINE_ORDER[:resume_idx]:
+        _print_skip_notice(skipped_stage)
+
     # Reuse resume from pre-flight as the first loop stage; avoids double call.
     stage: Stage | None = resume
     while stage is not None:
@@ -223,6 +258,7 @@ def run(args: argparse.Namespace) -> int:
             _logger.error("Source %s still missing after ingest.", source_id)
             return 1
 
+        _print_stage_header(stage)
         stage_runner = STAGE_RUNNERS[stage]
         stage_args = _build_stage_args(stage, source_id, wiki_override, args)
         exit_code = stage_runner(stage_args)

--- a/src/auto_lorebook/commands/run.py
+++ b/src/auto_lorebook/commands/run.py
@@ -18,6 +18,7 @@ from auto_lorebook.commands import generate_reading as generate_reading_cmd
 from auto_lorebook.commands import ingest as ingest_cmd
 from auto_lorebook.commands import plan as plan_cmd
 from auto_lorebook.commands import review as review_cmd
+from auto_lorebook.interactive import _is_interactive
 from auto_lorebook.pipeline_state import Stage, first_missing_stage
 
 if TYPE_CHECKING:
@@ -37,13 +38,10 @@ _INGEST_ONLY_ATTRS = (
     "cookies_from_browser",
 )
 
-# Extra Namespace fields each stage's run() requires beyond source_id/wiki.
-_STAGE_DEFAULTS: dict[Stage, dict[str, object]] = {
-    Stage.GENERATE_READING: {},
-    Stage.APPROVE_READING: {"yes": False},
-    Stage.PLAN: {},
-    Stage.EXTRACT: {},
-    Stage.REVIEW: {"auto_approve": False},
+# Stages that act as human gates and their required non-interactive flags.
+_GATE_FLAGS: dict[Stage, str] = {
+    Stage.APPROVE_READING: "--yes",
+    Stage.REVIEW: "--auto-approve",
 }
 
 # Maps Stage → command run() callable; exposed for patching in tests.
@@ -75,6 +73,18 @@ def add_parser(
         "url_or_sid",
         help="Source ID (e.g. yt-abc12345678) or YouTube URL",
     )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        default=False,
+        help="Forward to approve-reading gate (auto-approve reading segments).",
+    )
+    parser.add_argument(
+        "--auto-approve",
+        action="store_true",
+        default=False,
+        help="Forward to review gate (auto-approve all proposals).",
+    )
     ingest_cmd.add_ingest_args(parser)
     parser.set_defaults(func=run)
     return parser
@@ -91,6 +101,51 @@ def _warn_ignored_ingest_flags(args: argparse.Namespace) -> None:
     if active:
         flags = ", ".join(f"--{a.replace('_', '-')}" for a in active)
         _logger.warning("ingest-only flags ignored for source-id invocation: %s", flags)
+
+
+_PIPELINE_ORDER = [
+    Stage.INGEST,
+    Stage.GENERATE_READING,
+    Stage.APPROVE_READING,
+    Stage.PLAN,
+    Stage.EXTRACT,
+    Stage.REVIEW,
+]
+
+
+def _reachable_gates(resume: Stage) -> list[Stage]:
+    """Gates at-or-after resume point in pipeline order."""
+    resume_idx = _PIPELINE_ORDER.index(resume)
+    return [g for g in _GATE_FLAGS if _PIPELINE_ORDER.index(g) >= resume_idx]
+
+
+def _preflight_check(args: argparse.Namespace, resume: Stage) -> list[str]:
+    """Return list of missing required flags for non-interactive run; empty = ok."""
+    if _is_interactive():
+        return []
+    missing = []
+    for gate in _reachable_gates(resume):
+        flag = _GATE_FLAGS[gate]
+        # map flag string to attribute name: --yes → yes, --auto-approve → auto_approve
+        attr = flag.lstrip("-").replace("-", "_")
+        if not getattr(args, attr, False):
+            missing.append(flag)
+    return missing
+
+
+def _build_stage_args(
+    stage: Stage,
+    source_id: str,
+    wiki_override: str | None,
+    args: argparse.Namespace,
+) -> argparse.Namespace:
+    """Build Namespace for a stage, forwarding gate flags as appropriate."""
+    extra: dict[str, object] = {}
+    if stage is Stage.APPROVE_READING:
+        extra["yes"] = getattr(args, "yes", False)
+    elif stage is Stage.REVIEW:
+        extra["auto_approve"] = getattr(args, "auto_approve", False)
+    return argparse.Namespace(source_id=source_id, wiki=wiki_override, **extra)
 
 
 def run(args: argparse.Namespace) -> int:
@@ -143,22 +198,42 @@ def run(args: argparse.Namespace) -> int:
         source_id = positional
         _warn_ignored_ingest_flags(args)
 
-    while True:
-        stage = first_missing_stage(cfg, source_id, wiki_override=wiki_override)
-        if stage is None:
-            return 0
+    # Pre-flight: determine resume point and refuse early if non-TTY + gates reachable.
+    resume = first_missing_stage(cfg, source_id, wiki_override=wiki_override)
+    if resume is None:
+        return 0
+    if resume is Stage.INGEST:
+        _logger.error("Source %s still missing after ingest.", source_id)
+        return 1
+
+    missing_flags = _preflight_check(args, resume)
+    if missing_flags:
+        flags_str = " and ".join(missing_flags)
+        _logger.error(
+            "non-interactive shell: %s required to pass gate(s) unattended",
+            flags_str,
+        )
+        return 1
+
+    # Reuse resume from pre-flight as the first loop stage; avoids double call.
+    stage: Stage | None = resume
+    while stage is not None:
         if stage is Stage.INGEST:
             # Should not happen after successful ingest, but guard anyway.
             _logger.error("Source %s still missing after ingest.", source_id)
             return 1
 
         stage_runner = STAGE_RUNNERS[stage]
-        defaults = _STAGE_DEFAULTS[stage]
-        stage_args = argparse.Namespace(
-            source_id=source_id,
-            wiki=wiki_override,
-            **defaults,
-        )
+        stage_args = _build_stage_args(stage, source_id, wiki_override, args)
         exit_code = stage_runner(stage_args)
         if exit_code != 0:
             return exit_code
+
+        # Gate-decline check: if same stage still missing, user declined without error.
+        post_stage = first_missing_stage(cfg, source_id, wiki_override=wiki_override)
+        if post_stage is stage:
+            print(f"Stopped at stage {stage.value.replace('_', '-')}")  # noqa: T201
+            return 0
+        stage = post_stage
+
+    return 0

--- a/src/auto_lorebook/commands/run.py
+++ b/src/auto_lorebook/commands/run.py
@@ -208,6 +208,7 @@ def run(args: argparse.Namespace) -> int:
         # Check if source already ingested; if not, run ingest first.
         stage = first_missing_stage(cfg, source_id, wiki_override=wiki_override)
         if stage is Stage.INGEST:
+            _print_stage_header(Stage.INGEST)
             ingest_args = argparse.Namespace(
                 url_or_path=positional,
                 wiki=wiki_override,

--- a/src/auto_lorebook/commands/run.py
+++ b/src/auto_lorebook/commands/run.py
@@ -1,0 +1,90 @@
+"""auto-lorebook run umbrella subcommand.
+
+Walks a source through the pipeline from its current state to completion,
+delegating each stage to the matching command's run() function.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import TYPE_CHECKING
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook.commands import approve_reading as approve_reading_cmd
+from auto_lorebook.commands import extract as extract_cmd
+from auto_lorebook.commands import generate_reading as generate_reading_cmd
+from auto_lorebook.commands import plan as plan_cmd
+from auto_lorebook.commands import review as review_cmd
+from auto_lorebook.pipeline_state import Stage, first_missing_stage
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_logger = logging.getLogger(__name__)
+
+# Extra Namespace fields each stage's run() requires beyond source_id/wiki.
+_STAGE_DEFAULTS: dict[Stage, dict[str, object]] = {
+    Stage.GENERATE_READING: {},
+    Stage.APPROVE_READING: {"yes": False},
+    Stage.PLAN: {},
+    Stage.EXTRACT: {},
+    Stage.REVIEW: {"auto_approve": False},
+}
+
+# Maps Stage → command run() callable; exposed for patching in tests.
+STAGE_RUNNERS: dict[Stage, Callable[[argparse.Namespace], int]] = {
+    Stage.GENERATE_READING: generate_reading_cmd.run,
+    Stage.APPROVE_READING: approve_reading_cmd.run,
+    Stage.PLAN: plan_cmd.run,
+    Stage.EXTRACT: extract_cmd.run,
+    Stage.REVIEW: review_cmd.run,
+}
+
+
+def add_parser(
+    subparsers: argparse._SubParsersAction,
+    common_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Register the run subcommand."""
+    parser = subparsers.add_parser(
+        "run",
+        parents=[common_parser],
+        help="Walk a source through the pipeline from current state to completion",
+        description=(
+            "Detect which pipeline stage is next for a given source and run "
+            "through to completion. At human-gate stages (approve-reading, "
+            "review) defers to the interactive command as-is."
+        ),
+    )
+    parser.add_argument("source_id", help="Source ID (e.g. yt-abc12345678)")
+    parser.set_defaults(func=run)
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the run command: loop through stages until done."""
+    try:
+        cfg = cfg_mod.load_config()
+    except cfg_mod.ConfigError as e:
+        _logger.error("%s", e)
+        return 1
+
+    wiki_override: str | None = getattr(args, "wiki", None)
+    source_id: str = args.source_id
+
+    while True:
+        stage = first_missing_stage(cfg, source_id, wiki_override=wiki_override)
+        if stage is None:
+            return 0
+
+        stage_runner = STAGE_RUNNERS[stage]
+        defaults = _STAGE_DEFAULTS[stage]
+        stage_args = argparse.Namespace(
+            source_id=source_id,
+            wiki=wiki_override,
+            **defaults,
+        )
+        exit_code = stage_runner(stage_args)
+        if exit_code != 0:
+            return exit_code

--- a/src/auto_lorebook/pipeline_state.py
+++ b/src/auto_lorebook/pipeline_state.py
@@ -39,8 +39,9 @@ def first_missing_stage(
       GENERATE_READING : pending/<sid>/reading/reading.yaml exists
       APPROVE_READING  : <wiki>/sources/<sid>/reading.md exists
       PLAN          : pending/<sid>/plan.yaml exists
-      EXTRACT       : pending/<sid>/proposals/ exists and non-empty
-      REVIEW (done) : plan.yaml exists AND proposals dir empty or absent
+      EXTRACT       : pending/<sid>/proposals/ absent
+      REVIEW        : pending/<sid>/proposals/ exists and non-empty
+      done          : proposals dir exists and empty
     """
     wiki_root: Path = cfg.resolve_active_wiki(wiki_override)
 
@@ -62,13 +63,8 @@ def first_missing_stage(
         return Stage.PLAN
 
     proposals_dir = wiki_state.pending_proposals_dir(wiki_root, source_id)
-    if proposals_dir.exists():
-        if any(proposals_dir.iterdir()):
-            return Stage.REVIEW
-        # dir exists but empty → extract not yet populated
+    if not proposals_dir.exists():
         return Stage.EXTRACT
-    # proposals dir absent: use sidecar as proxy for pipeline completion
-    # sidecar exists → reading was generated normally → full pipeline ran → done
-    if sidecar.exists():
-        return None
-    return Stage.EXTRACT
+    if any(proposals_dir.iterdir()):
+        return Stage.REVIEW
+    return None

--- a/src/auto_lorebook/pipeline_state.py
+++ b/src/auto_lorebook/pipeline_state.py
@@ -1,0 +1,74 @@
+"""Pipeline state: detect next incomplete stage for a source."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from auto_lorebook import wiki_state
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from auto_lorebook.config import Config
+
+
+class Stage(Enum):
+    """Pipeline stages in execution order."""
+
+    INGEST = "ingest"
+    GENERATE_READING = "generate_reading"
+    APPROVE_READING = "approve_reading"
+    PLAN = "plan"
+    EXTRACT = "extract"
+    REVIEW = "review"
+
+
+def first_missing_stage(
+    cfg: Config,
+    source_id: str,
+    *,
+    wiki_override: str | None,
+) -> Stage | None:
+    """Return first incomplete stage, or None when all stages done.
+
+    Pure filesystem inspection — no I/O side effects.
+
+    Detector table:
+      INGEST        : <wiki>/sources/<sid>/info.yaml exists
+      GENERATE_READING : pending/<sid>/reading/reading.yaml exists
+      APPROVE_READING  : <wiki>/sources/<sid>/reading.md exists
+      PLAN          : pending/<sid>/plan.yaml exists
+      EXTRACT       : pending/<sid>/proposals/ exists and non-empty
+      REVIEW (done) : plan.yaml exists AND proposals dir empty or absent
+    """
+    wiki_root: Path = cfg.resolve_active_wiki(wiki_override)
+
+    info_yaml = wiki_root / "sources" / source_id / "info.yaml"
+    if not info_yaml.exists():
+        return Stage.INGEST
+
+    sidecar = wiki_state.pending_reading_dir(wiki_root, source_id) / "reading.yaml"
+    wiki_reading = wiki_root / "sources" / source_id / "reading.md"
+
+    # wiki-side reading.md implies GENERATE_READING + APPROVE_READING both done
+    if not wiki_reading.exists():
+        if not sidecar.exists():
+            return Stage.GENERATE_READING
+        return Stage.APPROVE_READING
+
+    plan_yaml = wiki_state.pending_plan_path(wiki_root, source_id)
+    if not plan_yaml.exists():
+        return Stage.PLAN
+
+    proposals_dir = wiki_state.pending_proposals_dir(wiki_root, source_id)
+    if proposals_dir.exists():
+        if any(proposals_dir.iterdir()):
+            return Stage.REVIEW
+        # dir exists but empty → extract not yet populated
+        return Stage.EXTRACT
+    # proposals dir absent: use sidecar as proxy for pipeline completion
+    # sidecar exists → reading was generated normally → full pipeline ran → done
+    if sidecar.exists():
+        return None
+    return Stage.EXTRACT

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -1,0 +1,176 @@
+"""Tests for pipeline_state.first_missing_stage."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from auto_lorebook.pipeline_state import Stage, first_missing_stage
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _cfg(wiki: Path) -> MagicMock:
+    cfg = MagicMock()
+    cfg.resolve_active_wiki.return_value = wiki
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Helpers to create detector artifacts
+# ---------------------------------------------------------------------------
+
+
+def _mk_info_yaml(wiki: Path, sid: str) -> None:
+    d = wiki / "sources" / sid
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "info.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+
+
+def _mk_reading_sidecar(wiki: Path, sid: str) -> None:
+    """Create pending/<sid>/reading/reading.yaml."""
+    d = wiki / ".wiki-state" / "pending" / sid / "reading"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "reading.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+
+
+def _mk_wiki_reading(wiki: Path, sid: str) -> None:
+    """Create wiki-side sources/<sid>/reading.md."""
+    d = wiki / "sources" / sid
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "reading.md").write_text("# reading\n", encoding="utf-8")
+
+
+def _mk_plan_yaml(wiki: Path, sid: str) -> None:
+    """Create pending/<sid>/plan.yaml."""
+    d = wiki / ".wiki-state" / "pending" / sid
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "plan.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+
+
+def _mk_proposal(wiki: Path, sid: str, name: str = "prop-001") -> None:
+    """Create a proposal file in pending/<sid>/proposals/."""
+    d = wiki / ".wiki-state" / "pending" / sid / "proposals"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{name}.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+
+
+def _mk_proposals_dir_empty(wiki: Path, sid: str) -> None:
+    """Create pending/<sid>/proposals/ (empty)."""
+    d = wiki / ".wiki-state" / "pending" / sid / "proposals"
+    d.mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Parameterised detector matrix
+# ---------------------------------------------------------------------------
+
+SID = "yt-abc12345678"
+
+
+@pytest.mark.parametrize(
+    ("setup_fns", "expected"),
+    [
+        # nothing present → INGEST
+        ([], Stage.INGEST),
+        # info.yaml only → GENERATE_READING
+        ([_mk_info_yaml], Stage.GENERATE_READING),
+        # info.yaml + reading sidecar → APPROVE_READING
+        ([_mk_info_yaml, _mk_reading_sidecar], Stage.APPROVE_READING),
+        # info.yaml + reading sidecar + wiki reading.md → PLAN
+        ([_mk_info_yaml, _mk_reading_sidecar, _mk_wiki_reading], Stage.PLAN),
+        # info.yaml + wiki reading.md + plan.yaml + absent proposals dir → EXTRACT
+        (
+            [_mk_info_yaml, _mk_wiki_reading, _mk_plan_yaml],
+            Stage.EXTRACT,
+        ),
+        # info.yaml + wiki reading.md + plan.yaml + empty proposals dir → EXTRACT
+        (
+            [_mk_info_yaml, _mk_wiki_reading, _mk_plan_yaml, _mk_proposals_dir_empty],
+            Stage.EXTRACT,
+        ),
+        # info.yaml + wiki reading.md + plan.yaml + non-empty proposals → REVIEW
+        (
+            [_mk_info_yaml, _mk_wiki_reading, _mk_plan_yaml, _mk_proposal],
+            Stage.REVIEW,
+        ),
+    ],
+    ids=[
+        "empty→INGEST",
+        "info.yaml→GENERATE_READING",
+        "sidecar→APPROVE_READING",
+        "wiki-reading→PLAN",
+        "plan+absent-proposals→EXTRACT",
+        "plan+empty-proposals→EXTRACT",
+        "plan+proposals→REVIEW",
+    ],
+)
+def test_first_missing_stage(
+    tmp_wiki: Path,
+    setup_fns: list,
+    expected: Stage,
+) -> None:
+    for fn in setup_fns:
+        fn(tmp_wiki, SID)
+    cfg = _cfg(tmp_wiki)
+    result = first_missing_stage(cfg, SID, wiki_override=None)
+    assert result == expected
+
+
+def test_all_done_returns_none(tmp_wiki: Path) -> None:
+    """plan.yaml + emptied proposals dir → None (pipeline complete)."""
+    _mk_info_yaml(tmp_wiki, SID)
+    _mk_reading_sidecar(tmp_wiki, SID)
+    _mk_wiki_reading(tmp_wiki, SID)
+    _mk_plan_yaml(tmp_wiki, SID)
+    _mk_proposals_dir_empty(tmp_wiki, SID)
+    # proposals dir exists but is empty — same as "completed review"
+    cfg = _cfg(tmp_wiki)
+    # EXTRACT would be returned… unless we mark it as already done by having
+    # a non-empty proposals dir that was subsequently emptied.
+    # Per spec: REVIEW done = plan.yaml exists AND proposals dir empty/absent.
+    # So with plan.yaml + empty proposals dir the result is EXTRACT, not None.
+    # None is only returned when ALL stages pass. We verify None is not returned
+    # prematurely by checking that the final state after review (proposals dir
+    # cleared) returns None.
+    # To reach None we need plan.yaml + proposals dir absent (treated as cleared).
+    # The issue spec says: "plan.yaml exists AND proposals dir empty (or absent)
+    # → returns None". So empty-proposals means DONE.
+    # BUT the EXTRACT detector says "absent or non-empty" → EXTRACT.
+    # Clarification from the spec table:
+    #   EXTRACT done: proposals dir exists and is non-empty
+    #   REVIEW done: plan.yaml exists AND proposals dir empty or absent → None
+    # So the EXTRACT detector passes when proposals dir is non-empty.
+    # If proposals dir is absent/empty AND plan.yaml exists → skip EXTRACT,
+    # skip REVIEW → return None.
+    # Re-run the test with consistent setup:
+    result = first_missing_stage(cfg, SID, wiki_override=None)
+    # With plan.yaml + empty proposals: EXTRACT stage detector is False
+    # (proposals dir exists but is empty → "non-empty" check fails → not done)
+    # → returns EXTRACT. That's correct per the spec.
+    assert result == Stage.EXTRACT
+
+
+def test_none_when_fully_complete(tmp_wiki: Path) -> None:
+    """After review completes (proposals cleared), pipeline returns None."""
+    _mk_info_yaml(tmp_wiki, SID)
+    _mk_reading_sidecar(tmp_wiki, SID)
+    _mk_wiki_reading(tmp_wiki, SID)
+    _mk_plan_yaml(tmp_wiki, SID)
+    # proposals dir absent — per spec REVIEW done = plan.yaml + empty/absent
+    cfg = _cfg(tmp_wiki)
+    result = first_missing_stage(cfg, SID, wiki_override=None)
+    assert result is None
+
+
+def test_wiki_override_forwarded(tmp_path: Path) -> None:
+    """wiki_override is passed to cfg.resolve_active_wiki."""
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    cfg = MagicMock()
+    cfg.resolve_active_wiki.return_value = wiki
+    first_missing_stage(cfg, SID, wiki_override="alt")
+    cfg.resolve_active_wiki.assert_called_once_with("alt")

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -87,15 +87,15 @@ SID = "yt-abc12345678"
             [_mk_info_yaml, _mk_wiki_reading, _mk_plan_yaml],
             Stage.EXTRACT,
         ),
-        # info.yaml + wiki reading.md + plan.yaml + empty proposals dir → EXTRACT
-        (
-            [_mk_info_yaml, _mk_wiki_reading, _mk_plan_yaml, _mk_proposals_dir_empty],
-            Stage.EXTRACT,
-        ),
         # info.yaml + wiki reading.md + plan.yaml + non-empty proposals → REVIEW
         (
             [_mk_info_yaml, _mk_wiki_reading, _mk_plan_yaml, _mk_proposal],
             Stage.REVIEW,
+        ),
+        # info.yaml + wiki reading.md + plan.yaml + empty proposals dir → None
+        (
+            [_mk_info_yaml, _mk_wiki_reading, _mk_plan_yaml, _mk_proposals_dir_empty],
+            None,
         ),
     ],
     ids=[
@@ -104,8 +104,8 @@ SID = "yt-abc12345678"
         "sidecar→APPROVE_READING",
         "wiki-reading→PLAN",
         "plan+absent-proposals→EXTRACT",
-        "plan+empty-proposals→EXTRACT",
         "plan+proposals→REVIEW",
+        "plan+empty-proposals→None",
     ],
 )
 def test_first_missing_stage(
@@ -121,46 +121,24 @@ def test_first_missing_stage(
 
 
 def test_all_done_returns_none(tmp_wiki: Path) -> None:
-    """plan.yaml + emptied proposals dir → None (pipeline complete)."""
+    """plan.yaml + empty proposals dir → None (review complete)."""
     _mk_info_yaml(tmp_wiki, SID)
     _mk_reading_sidecar(tmp_wiki, SID)
     _mk_wiki_reading(tmp_wiki, SID)
     _mk_plan_yaml(tmp_wiki, SID)
     _mk_proposals_dir_empty(tmp_wiki, SID)
-    # proposals dir exists but is empty — same as "completed review"
     cfg = _cfg(tmp_wiki)
-    # EXTRACT would be returned… unless we mark it as already done by having
-    # a non-empty proposals dir that was subsequently emptied.
-    # Per spec: REVIEW done = plan.yaml exists AND proposals dir empty/absent.
-    # So with plan.yaml + empty proposals dir the result is EXTRACT, not None.
-    # None is only returned when ALL stages pass. We verify None is not returned
-    # prematurely by checking that the final state after review (proposals dir
-    # cleared) returns None.
-    # To reach None we need plan.yaml + proposals dir absent (treated as cleared).
-    # The issue spec says: "plan.yaml exists AND proposals dir empty (or absent)
-    # → returns None". So empty-proposals means DONE.
-    # BUT the EXTRACT detector says "absent or non-empty" → EXTRACT.
-    # Clarification from the spec table:
-    #   EXTRACT done: proposals dir exists and is non-empty
-    #   REVIEW done: plan.yaml exists AND proposals dir empty or absent → None
-    # So the EXTRACT detector passes when proposals dir is non-empty.
-    # If proposals dir is absent/empty AND plan.yaml exists → skip EXTRACT,
-    # skip REVIEW → return None.
-    # Re-run the test with consistent setup:
     result = first_missing_stage(cfg, SID, wiki_override=None)
-    # With plan.yaml + empty proposals: EXTRACT stage detector is False
-    # (proposals dir exists but is empty → "non-empty" check fails → not done)
-    # → returns EXTRACT. That's correct per the spec.
-    assert result == Stage.EXTRACT
+    assert result is None
 
 
 def test_none_when_fully_complete(tmp_wiki: Path) -> None:
-    """After review completes (proposals cleared), pipeline returns None."""
+    """After review empties proposals dir, pipeline returns None."""
     _mk_info_yaml(tmp_wiki, SID)
     _mk_reading_sidecar(tmp_wiki, SID)
     _mk_wiki_reading(tmp_wiki, SID)
     _mk_plan_yaml(tmp_wiki, SID)
-    # proposals dir absent — per spec REVIEW done = plan.yaml + empty/absent
+    _mk_proposals_dir_empty(tmp_wiki, SID)
     cfg = _cfg(tmp_wiki)
     result = first_missing_stage(cfg, SID, wiki_override=None)
     assert result is None

--- a/tests/test_run_cmd.py
+++ b/tests/test_run_cmd.py
@@ -826,3 +826,147 @@ def test_add_parser_accepts_auto_approve_flag() -> None:
     parser = create_parser()
     args = parser.parse_args(["run", "--auto-approve", "yt-abc12345678"])
     assert args.auto_approve is True
+
+
+# ---------------------------------------------------------------------------
+# Stage headers and skip notices
+# ---------------------------------------------------------------------------
+
+
+def _all_stages_noop_runners() -> dict[Stage, Callable[[argparse.Namespace], int]]:
+    """Return STAGE_RUNNERS dict where every stage is a no-op returning 0."""
+    patched = dict(run_cmd.STAGE_RUNNERS)
+    for stage in list(patched):
+        patched[stage] = lambda _ns: 0
+    return patched
+
+
+def test_prints_six_headers_from_scratch(capsys: pytest.CaptureFixture[str]) -> None:
+    """Fresh run prints a stage header for all 6 pipeline stages."""
+    # source-id path; first fms → GENERATE_READING (resume), then each stage, then None.
+    fms_effects: list[Stage | None] = [
+        Stage.GENERATE_READING,  # resume (pre-flight)
+        Stage.APPROVE_READING,  # after GENERATE_READING
+        Stage.PLAN,  # after APPROVE_READING
+        Stage.EXTRACT,  # after PLAN
+        Stage.REVIEW,  # after EXTRACT
+        None,  # after REVIEW → done
+    ]
+    patched_runners = _all_stages_noop_runners()
+
+    args = argparse.Namespace(
+        url_or_sid="yt-abc12345678",
+        source_id=None,
+        wiki=None,
+        yes=True,
+        auto_approve=True,
+    )
+
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=fms_effects,
+        ),
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+        patch("auto_lorebook.commands.run.ingest_cmd.run", return_value=0),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(args)
+
+    assert result == 0
+    out = capsys.readouterr().out
+    # Headers for stages 2-6 (ingest handled pre-loop; source-id path starts at 2).
+    expected_pairs = [
+        ("[2/6]", "generate-reading"),
+        ("[3/6]", "approve-reading"),
+        ("[4/6]", "plan"),
+        ("[5/6]", "extract"),
+        ("[6/6]", "review"),
+    ]
+    for index_tag, stage_name in expected_pairs:
+        assert index_tag in out, f"missing {index_tag} in stdout"
+        assert stage_name in out, f"missing stage name '{stage_name}' in stdout"
+
+
+def test_resume_prints_skip_notices_and_remaining_headers(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Resume from PLAN: 3 skip notices + headers for plan/extract/review."""
+    fms_effects: list[Stage | None] = [
+        Stage.PLAN,  # resume (pre-flight)
+        Stage.EXTRACT,
+        Stage.REVIEW,
+        None,
+    ]
+    patched_runners = _all_stages_noop_runners()
+
+    args = argparse.Namespace(
+        url_or_sid="yt-abc12345678",
+        source_id=None,
+        wiki=None,
+        yes=True,
+        auto_approve=True,
+    )
+
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=fms_effects,
+        ),
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(args)
+
+    assert result == 0
+    out = capsys.readouterr().out
+    # Three skip notices for ingest, generate-reading, approve-reading
+    for skipped in ("ingest", "generate-reading", "approve-reading"):
+        assert skipped in out, f"missing skip notice for '{skipped}'"
+    # Three stage headers for plan, extract, review
+    for idx, stage_name in [
+        ("[4/6]", "plan"),
+        ("[5/6]", "extract"),
+        ("[6/6]", "review"),
+    ]:  # noqa: E501
+        assert idx in out, f"missing {idx} in stdout"
+        assert stage_name in out, f"missing stage header for '{stage_name}'"
+
+
+def test_skip_notice_mentions_artifact(capsys: pytest.CaptureFixture[str]) -> None:
+    """Skip notices include both the stage name and its artifact name."""
+    fms_effects: list[Stage | None] = [
+        Stage.PLAN,  # resume — ingest/generate-reading/approve-reading already done
+        None,
+    ]
+    patched_runners = _all_stages_noop_runners()
+
+    args = argparse.Namespace(
+        url_or_sid="yt-abc12345678",
+        source_id=None,
+        wiki=None,
+        yes=True,
+        auto_approve=True,
+    )
+
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=fms_effects,
+        ),
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+    ):
+        mock_cfg.return_value = MagicMock()
+        run_cmd.run(args)
+
+    out = capsys.readouterr().out
+    # Check ingest skip notice mentions its artifact
+    assert "info.yaml" in out
+    # Check approve-reading skip notice mentions its artifact
+    assert "reading.md" in out

--- a/tests/test_run_cmd.py
+++ b/tests/test_run_cmd.py
@@ -1,0 +1,267 @@
+"""Tests for the `run` umbrella command."""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+import pytest
+
+from auto_lorebook import config as cfg_mod
+from auto_lorebook.cli import create_parser
+from auto_lorebook.commands import run as run_cmd
+from auto_lorebook.pipeline_state import Stage
+
+
+def _args(
+    source_id: str = "yt-abc12345678",
+    wiki: str | None = None,
+) -> argparse.Namespace:
+    return argparse.Namespace(source_id=source_id, wiki=wiki)
+
+
+def _fake_runner(
+    exit_code: int = 0,
+) -> tuple[list[argparse.Namespace], Callable[[argparse.Namespace], int]]:
+    """Return (call_log, runner) pair for a fake stage run() function."""
+    call_log: list[argparse.Namespace] = []
+
+    def runner(args: argparse.Namespace) -> int:
+        call_log.append(args)
+        return exit_code
+
+    return call_log, runner
+
+
+# ---------------------------------------------------------------------------
+# No-op: nothing missing
+# ---------------------------------------------------------------------------
+
+
+def test_run_noop_when_nothing_missing() -> None:
+    """Nothing to do when first_missing_stage returns None immediately."""
+    with (
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage", return_value=None
+        ) as mock_fms,
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(_args())
+    assert result == 0
+    mock_fms.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Dispatch order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("stage", "extra_attr"),
+    [
+        (Stage.GENERATE_READING, None),
+        (Stage.APPROVE_READING, "yes"),
+        (Stage.PLAN, None),
+        (Stage.EXTRACT, None),
+        (Stage.REVIEW, "auto_approve"),
+    ],
+    ids=[
+        "GENERATE_READING",
+        "APPROVE_READING",
+        "PLAN",
+        "EXTRACT",
+        "REVIEW",
+    ],
+)
+def test_dispatches_to_stage(
+    stage: Stage,
+    extra_attr: str | None,
+) -> None:
+    """Each stage dispatches to its runner, then loops to None."""
+    call_log, fake_run = _fake_runner(0)
+
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    patched_runners[stage] = fake_run
+
+    with (
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=[stage, None],
+        ),
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch.object(
+            run_cmd,
+            "STAGE_RUNNERS",
+            patched_runners,
+        ),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(_args())
+
+    assert result == 0
+    assert len(call_log) == 1
+    ns = call_log[0]
+    assert ns.source_id == "yt-abc12345678"
+    if extra_attr:
+        assert hasattr(ns, extra_attr)
+
+
+# ---------------------------------------------------------------------------
+# Exit-code propagation
+# ---------------------------------------------------------------------------
+
+
+def test_propagates_nonzero_exit_code() -> None:
+    """Non-zero exit from a stage is propagated immediately."""
+    _, fake_run = _fake_runner(42)
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    patched_runners[Stage.PLAN] = fake_run
+
+    with (
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            return_value=Stage.PLAN,
+        ),
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch.object(
+            run_cmd,
+            "STAGE_RUNNERS",
+            patched_runners,
+        ),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(_args())
+
+    assert result == 42
+
+
+def test_stops_looping_on_nonzero_exit() -> None:
+    """Loop stops on first non-zero exit; first_missing_stage called once only."""
+    fms_calls: list[int] = []
+
+    def counting_fms(*_a: object, **_kw: object) -> Stage:
+        fms_calls.append(1)
+        return Stage.PLAN
+
+    _, fake_run = _fake_runner(1)
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    patched_runners[Stage.PLAN] = fake_run
+
+    with (
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=counting_fms,
+        ),
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch.object(
+            run_cmd,
+            "STAGE_RUNNERS",
+            patched_runners,
+        ),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(_args())
+
+    assert result == 1
+    assert len(fms_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# --wiki threading
+# ---------------------------------------------------------------------------
+
+
+def test_wiki_override_threaded_to_fms() -> None:
+    """Wiki kwarg from args flows to first_missing_stage."""
+    captured: list[str | None] = []
+
+    def spy_fms(
+        _cfg: object,
+        _source_id: str,
+        *,
+        wiki_override: str | None,
+    ) -> None:
+        captured.append(wiki_override)
+
+    with (
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=spy_fms,
+        ),
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+    ):
+        mock_cfg.return_value = MagicMock()
+        run_cmd.run(_args(wiki="alt"))
+
+    assert captured == ["alt"]
+
+
+def test_wiki_override_threaded_to_stage_namespace() -> None:
+    """Wiki attribute on dispatched Namespace matches args.wiki."""
+    captured_ns: list[argparse.Namespace] = []
+
+    def capture_run(args: argparse.Namespace) -> int:
+        captured_ns.append(args)
+        return 0
+
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    patched_runners[Stage.PLAN] = capture_run
+
+    with (
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=[Stage.PLAN, None],
+        ),
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch.object(
+            run_cmd,
+            "STAGE_RUNNERS",
+            patched_runners,
+        ),
+    ):
+        mock_cfg.return_value = MagicMock()
+        run_cmd.run(_args(wiki="alt"))
+
+    assert captured_ns[0].wiki == "alt"
+
+
+# ---------------------------------------------------------------------------
+# Config error
+# ---------------------------------------------------------------------------
+
+
+def test_config_error_returns_1() -> None:
+    """ConfigError during load_config returns exit code 1."""
+    with patch(
+        "auto_lorebook.commands.run.cfg_mod.load_config",
+        side_effect=cfg_mod.ConfigError("no config"),
+    ):
+        result = run_cmd.run(_args())
+
+    assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# Parser registration
+# ---------------------------------------------------------------------------
+
+
+def test_add_parser_registers_run_subcommand() -> None:
+    """Run subcommand appears in parser after add_parser call."""
+    parser = create_parser()
+    args = parser.parse_args(["run", "yt-abc12345678"])
+    assert args.source_id == "yt-abc12345678"
+    assert hasattr(args, "func")
+
+
+def test_add_parser_accepts_wiki_flag() -> None:
+    """Run subcommand accepts --wiki via global flag."""
+    parser = create_parser()
+    args = parser.parse_args(["--wiki", "alt", "run", "yt-abc12345678"])
+    assert args.wiki == "alt"
+    assert args.source_id == "yt-abc12345678"

--- a/tests/test_run_cmd.py
+++ b/tests/test_run_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -255,7 +256,7 @@ def test_add_parser_registers_run_subcommand() -> None:
     """Run subcommand appears in parser after add_parser call."""
     parser = create_parser()
     args = parser.parse_args(["run", "yt-abc12345678"])
-    assert args.source_id == "yt-abc12345678"
+    assert args.url_or_sid == "yt-abc12345678"
     assert hasattr(args, "func")
 
 
@@ -264,4 +265,217 @@ def test_add_parser_accepts_wiki_flag() -> None:
     parser = create_parser()
     args = parser.parse_args(["--wiki", "alt", "run", "yt-abc12345678"])
     assert args.wiki == "alt"
-    assert args.source_id == "yt-abc12345678"
+    assert args.url_or_sid == "yt-abc12345678"
+
+
+# ---------------------------------------------------------------------------
+# add_ingest_args parity
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_flag_parity() -> None:
+    """Run and ingest parsers accept the same ingest-specific flags."""
+    ingest_flags = [
+        "--session-date=2026-01-15",
+        "--perspective=x",
+        "--source-nature=actual-play",
+        "--setting=Foo",
+        "--notes=bar",
+        "--source-url=https://example.com",
+        "--source-id=yt-abc12345678",
+        "--no-interactive",
+        "--cookies-from-browser=chrome",
+    ]
+    full_parser = create_parser()
+    # ingest with all flags
+    ingest_args = full_parser.parse_args([
+        "ingest",
+        "https://youtube.com/watch?v=abc12345678",
+        *ingest_flags,
+    ])
+    assert ingest_args.session_date == "2026-01-15"
+    assert ingest_args.perspective == "x"
+    assert ingest_args.source_nature == "actual-play"
+    assert ingest_args.setting == "Foo"
+    assert ingest_args.notes == "bar"
+    assert ingest_args.source_url == "https://example.com"
+    assert ingest_args.source_id == "yt-abc12345678"
+    assert ingest_args.no_interactive is True
+    assert ingest_args.cookies_from_browser == "chrome"
+
+    # run with the same flags
+    run_args = full_parser.parse_args(["run", "yt-abc12345678", *ingest_flags])
+    assert run_args.session_date == "2026-01-15"
+    assert run_args.perspective == "x"
+    assert run_args.source_nature == "actual-play"
+    assert run_args.setting == "Foo"
+    assert run_args.notes == "bar"
+    assert run_args.source_url == "https://example.com"
+    assert run_args.source_id == "yt-abc12345678"
+    assert run_args.no_interactive is True
+    assert run_args.cookies_from_browser == "chrome"
+
+
+# ---------------------------------------------------------------------------
+# URL → new source: ingest called first, then chain continues
+# ---------------------------------------------------------------------------
+
+
+def test_url_new_source_calls_ingest_then_chain() -> None:
+    """URL positional with no existing source calls ingest, then pipeline stages."""
+    url = "https://youtube.com/watch?v=abc12345678"
+    expected_sid = "yt-abc12345678"
+
+    ingest_calls: list[argparse.Namespace] = []
+    stage_calls: list[tuple[Stage, argparse.Namespace]] = []
+
+    def fake_ingest(ns: argparse.Namespace) -> int:
+        ingest_calls.append(ns)
+        return 0
+
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    for stage in list(patched_runners):
+
+        def make_runner(s: Stage) -> Callable[[argparse.Namespace], int]:
+            def runner(ns: argparse.Namespace) -> int:
+                stage_calls.append((s, ns))
+                return 0
+
+            return runner
+
+        patched_runners[stage] = make_runner(stage)
+
+    # fms: INGEST (triggers ingest), GENERATE_READING (first loop stage), None (done)
+    fms_side_effects = [Stage.INGEST, Stage.GENERATE_READING, None]
+
+    args = argparse.Namespace(
+        url_or_sid=url,
+        source_id=None,
+        wiki=None,
+        session_date=None,
+        perspective=None,
+        source_nature=None,
+        setting=None,
+        notes=None,
+        source_url=None,
+        no_interactive=True,
+        cookies_from_browser=None,
+    )
+
+    fms_patch = patch(
+        "auto_lorebook.commands.run.first_missing_stage",
+        side_effect=fms_side_effects,
+    )
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        fms_patch,
+        patch("auto_lorebook.commands.run.ingest_cmd.run", fake_ingest),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(args)
+
+    assert result == 0
+    # ingest was called with the URL and all ingest flags forwarded
+    assert len(ingest_calls) == 1
+    assert ingest_calls[0].url_or_path == url
+    # pipeline stage called after ingest
+    assert len(stage_calls) == 1
+    assert stage_calls[0][0] == Stage.GENERATE_READING
+    # source_id on stage namespace is the derived sid
+    assert stage_calls[0][1].source_id == expected_sid
+
+
+# ---------------------------------------------------------------------------
+# URL → existing source: ingest skipped, chain continues from first missing
+# ---------------------------------------------------------------------------
+
+
+def test_url_existing_source_skips_ingest() -> None:
+    """URL positional with existing source skips ingest, runs remaining stages."""
+    url = "https://youtube.com/watch?v=abc12345678"
+
+    ingest_calls: list[argparse.Namespace] = []
+
+    def fake_ingest(ns: argparse.Namespace) -> int:
+        ingest_calls.append(ns)
+        return 0
+
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    stage_calls: list[Stage] = []
+    for stage in list(patched_runners):
+
+        def make_runner(s: Stage) -> Callable[[argparse.Namespace], int]:
+            def runner(_ns: argparse.Namespace) -> int:
+                stage_calls.append(s)
+                return 0
+
+            return runner
+
+        patched_runners[stage] = make_runner(stage)
+
+    # URL path: fms called once to check ingest need (non-INGEST), then twice in loop.
+    fms_side_effects = [Stage.GENERATE_READING, Stage.GENERATE_READING, None]
+
+    args = argparse.Namespace(
+        url_or_sid=url,
+        source_id=None,
+        wiki=None,
+        session_date=None,
+        perspective=None,
+        source_nature=None,
+        setting=None,
+        notes=None,
+        source_url=None,
+        no_interactive=True,
+        cookies_from_browser=None,
+    )
+
+    fms_patch = patch(
+        "auto_lorebook.commands.run.first_missing_stage",
+        side_effect=fms_side_effects,
+    )
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        fms_patch,
+        patch("auto_lorebook.commands.run.ingest_cmd.run", fake_ingest),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(args)
+
+    assert result == 0
+    assert ingest_calls == []  # ingest NOT called
+    assert Stage.GENERATE_READING in stage_calls
+
+
+# ---------------------------------------------------------------------------
+# Source-id positional + ingest-only flag → warning, proceeds normally
+# ---------------------------------------------------------------------------
+
+
+def test_source_id_with_ingest_flags_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """Source-id positional + ingest-only flags emits a warning log."""
+    args = argparse.Namespace(
+        source_id="yt-abc12345678",
+        wiki=None,
+        session_date="2026-01-15",  # ingest-only flag set
+        perspective=None,
+        source_nature=None,
+        setting=None,
+        notes=None,
+        source_url=None,
+        no_interactive=False,
+        cookies_from_browser=None,
+    )
+
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch("auto_lorebook.commands.run.first_missing_stage", return_value=None),
+        caplog.at_level(logging.WARNING, logger="auto_lorebook.commands.run"),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(args)
+
+    assert result == 0
+    assert any("ignored" in r.message.lower() for r in caplog.records)

--- a/tests/test_run_cmd.py
+++ b/tests/test_run_cmd.py
@@ -842,10 +842,12 @@ def _all_stages_noop_runners() -> dict[Stage, Callable[[argparse.Namespace], int
 
 
 def test_prints_six_headers_from_scratch(capsys: pytest.CaptureFixture[str]) -> None:
-    """Fresh run prints a stage header for all 6 pipeline stages."""
-    # source-id path; first fms → GENERATE_READING (resume), then each stage, then None.
+    """Fresh URL run prints all 6 stage headers in order."""
+    # URL path: first fms → INGEST (triggers ingest), then pre-flight fms →
+    # GENERATE_READING, then each remaining stage, then None.
     fms_effects: list[Stage | None] = [
-        Stage.GENERATE_READING,  # resume (pre-flight)
+        Stage.INGEST,  # URL pre-ingest check → triggers ingest_cmd.run
+        Stage.GENERATE_READING,  # pre-flight after ingest
         Stage.APPROVE_READING,  # after GENERATE_READING
         Stage.PLAN,  # after APPROVE_READING
         Stage.EXTRACT,  # after PLAN
@@ -855,7 +857,7 @@ def test_prints_six_headers_from_scratch(capsys: pytest.CaptureFixture[str]) -> 
     patched_runners = _all_stages_noop_runners()
 
     args = argparse.Namespace(
-        url_or_sid="yt-abc12345678",
+        url_or_sid="https://www.youtube.com/watch?v=abc12345678",
         source_id=None,
         wiki=None,
         yes=True,
@@ -877,17 +879,23 @@ def test_prints_six_headers_from_scratch(capsys: pytest.CaptureFixture[str]) -> 
 
     assert result == 0
     out = capsys.readouterr().out
-    # Headers for stages 2-6 (ingest handled pre-loop; source-id path starts at 2).
-    expected_pairs = [
-        ("[2/6]", "generate-reading"),
-        ("[3/6]", "approve-reading"),
-        ("[4/6]", "plan"),
-        ("[5/6]", "extract"),
-        ("[6/6]", "review"),
-    ]
-    for index_tag, stage_name in expected_pairs:
-        assert index_tag in out, f"missing {index_tag} in stdout"
-        assert stage_name in out, f"missing stage name '{stage_name}' in stdout"
+    # All six [N/6] tags must appear in strictly increasing output position.
+    tags = ["[1/6]", "[2/6]", "[3/6]", "[4/6]", "[5/6]", "[6/6]"]
+    positions = [out.index(tag) for tag in tags]
+    assert positions == sorted(positions), (
+        f"headers out of order: {list(zip(tags, positions, strict=True))}"
+    )
+    # Stage names also present.
+    stage_names = (
+        "ingest",
+        "generate-reading",
+        "approve-reading",
+        "plan",
+        "extract",
+        "review",
+    )
+    for name in stage_names:
+        assert name in out, f"missing stage name '{name}' in stdout"
 
 
 def test_resume_prints_skip_notices_and_remaining_headers(
@@ -932,7 +940,7 @@ def test_resume_prints_skip_notices_and_remaining_headers(
         ("[4/6]", "plan"),
         ("[5/6]", "extract"),
         ("[6/6]", "review"),
-    ]:  # noqa: E501
+    ]:
         assert idx in out, f"missing {idx} in stdout"
         assert stage_name in out, f"missing stage header for '{stage_name}'"
 

--- a/tests/test_run_cmd.py
+++ b/tests/test_run_cmd.py
@@ -21,8 +21,16 @@ from auto_lorebook.pipeline_state import Stage
 def _args(
     source_id: str = "yt-abc12345678",
     wiki: str | None = None,
+    *,
+    yes: bool = False,
+    auto_approve: bool = False,
 ) -> argparse.Namespace:
-    return argparse.Namespace(source_id=source_id, wiki=wiki)
+    return argparse.Namespace(
+        source_id=source_id,
+        wiki=wiki,
+        yes=yes,
+        auto_approve=auto_approve,
+    )
 
 
 def _fake_runner(
@@ -95,6 +103,7 @@ def test_dispatches_to_stage(
             side_effect=[stage, None],
         ),
         patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
         patch.object(
             run_cmd,
             "STAGE_RUNNERS",
@@ -129,6 +138,7 @@ def test_propagates_nonzero_exit_code() -> None:
             return_value=Stage.PLAN,
         ),
         patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
         patch.object(
             run_cmd,
             "STAGE_RUNNERS",
@@ -219,6 +229,7 @@ def test_wiki_override_threaded_to_stage_namespace() -> None:
             side_effect=[Stage.PLAN, None],
         ),
         patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
         patch.object(
             run_cmd,
             "STAGE_RUNNERS",
@@ -370,6 +381,7 @@ def test_url_new_source_calls_ingest_then_chain() -> None:
         patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
         fms_patch,
         patch("auto_lorebook.commands.run.ingest_cmd.run", fake_ingest),
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
         patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
     ):
         mock_cfg.return_value = MagicMock()
@@ -439,6 +451,7 @@ def test_url_existing_source_skips_ingest() -> None:
         patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
         fms_patch,
         patch("auto_lorebook.commands.run.ingest_cmd.run", fake_ingest),
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
         patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
     ):
         mock_cfg.return_value = MagicMock()
@@ -479,3 +492,337 @@ def test_source_id_with_ingest_flags_warns(caplog: pytest.LogCaptureFixture) -> 
 
     assert result == 0
     assert any("ignored" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight TTY refusal
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_refuses_when_non_tty_approve_reading_reachable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-TTY shell + approve-reading gate reachable → non-zero exit, names --yes."""
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            return_value=Stage.APPROVE_READING,
+        ),
+        patch(
+            "auto_lorebook.commands.run._is_interactive",
+            return_value=False,
+        ),
+        caplog.at_level(logging.ERROR, logger="auto_lorebook.commands.run"),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(_args())
+
+    assert result != 0
+    assert any("--yes" in r.message for r in caplog.records)
+
+
+def test_preflight_refuses_when_non_tty_review_reachable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-TTY shell + review gate reachable → non-zero exit, names --auto-approve."""
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            return_value=Stage.REVIEW,
+        ),
+        patch(
+            "auto_lorebook.commands.run._is_interactive",
+            return_value=False,
+        ),
+        caplog.at_level(logging.ERROR, logger="auto_lorebook.commands.run"),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(_args())
+
+    assert result != 0
+    assert any("--auto-approve" in r.message for r in caplog.records)
+
+
+def test_preflight_refuses_both_flags_when_both_reachable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-TTY + both gates reachable + neither flag → message names both."""
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            return_value=Stage.GENERATE_READING,
+        ),
+        patch(
+            "auto_lorebook.commands.run._is_interactive",
+            return_value=False,
+        ),
+        caplog.at_level(logging.ERROR, logger="auto_lorebook.commands.run"),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(_args())
+
+    assert result != 0
+    combined = " ".join(r.message for r in caplog.records)
+    assert "--yes" in combined
+    assert "--auto-approve" in combined
+
+
+def test_preflight_ok_when_approve_reading_not_reachable() -> None:
+    """Reading already approved (PLAN is first missing) → --yes not demanded.
+
+    REVIEW gate is still reachable, so --auto-approve is passed to satisfy it.
+    Verifies that --yes (approve-reading gate) is NOT required.
+    """
+    _, fake_plan = _fake_runner(0)
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    patched_runners[Stage.PLAN] = fake_plan
+
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=[Stage.PLAN, None],
+        ),
+        patch(
+            "auto_lorebook.commands.run._is_interactive",
+            return_value=False,
+        ),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+    ):
+        mock_cfg.return_value = MagicMock()
+        # --auto-approve satisfies REVIEW gate; --yes should NOT be needed
+        result = run_cmd.run(_args(auto_approve=True))
+
+    assert result == 0
+
+
+def test_preflight_ok_when_approve_reading_not_reachable_only_review_ahead() -> None:
+    """Resume at REVIEW: --yes not demanded, only --auto-approve needed."""
+    _, fake_review = _fake_runner(0)
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    patched_runners[Stage.REVIEW] = fake_review
+
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=[Stage.REVIEW, None],
+        ),
+        patch(
+            "auto_lorebook.commands.run._is_interactive",
+            return_value=False,
+        ),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+    ):
+        mock_cfg.return_value = MagicMock()
+        # Only REVIEW gate reachable; --yes (approve-reading) should NOT be needed
+        result = run_cmd.run(_args(auto_approve=True))
+
+    assert result == 0
+
+
+def test_preflight_passes_when_flags_provided() -> None:
+    """--yes + --auto-approve supplied → pre-flight allows through."""
+    _, fake_run = _fake_runner(0)
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    patched_runners[Stage.GENERATE_READING] = fake_run
+
+    args = argparse.Namespace(
+        source_id="yt-abc12345678",
+        wiki=None,
+        yes=True,
+        auto_approve=True,
+    )
+
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=[Stage.GENERATE_READING, None],
+        ),
+        patch(
+            "auto_lorebook.commands.run._is_interactive",
+            return_value=False,
+        ),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(args)
+
+    assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# Flag forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_yes_flag_forwarded_to_approve_reading() -> None:
+    """--yes is forwarded to approve-reading stage namespace."""
+    call_log, fake_run = _fake_runner(0)
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    patched_runners[Stage.APPROVE_READING] = fake_run
+
+    args = argparse.Namespace(
+        source_id="yt-abc12345678",
+        wiki=None,
+        yes=True,
+        auto_approve=False,
+    )
+
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=[Stage.APPROVE_READING, None],
+        ),
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+    ):
+        mock_cfg.return_value = MagicMock()
+        run_cmd.run(args)
+
+    assert len(call_log) == 1
+    assert call_log[0].yes is True
+
+
+def test_auto_approve_flag_forwarded_to_review() -> None:
+    """--auto-approve is forwarded to review stage namespace."""
+    call_log, fake_run = _fake_runner(0)
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    patched_runners[Stage.REVIEW] = fake_run
+
+    args = argparse.Namespace(
+        source_id="yt-abc12345678",
+        wiki=None,
+        yes=False,
+        auto_approve=True,
+    )
+
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=[Stage.REVIEW, None],
+        ),
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+    ):
+        mock_cfg.return_value = MagicMock()
+        run_cmd.run(args)
+
+    assert len(call_log) == 1
+    assert call_log[0].auto_approve is True
+
+
+def test_yes_not_forwarded_to_other_stages() -> None:
+    """--yes flag does not appear with a truthy value in non-gate stages."""
+    call_log, fake_run = _fake_runner(0)
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    patched_runners[Stage.PLAN] = fake_run
+
+    args = argparse.Namespace(
+        source_id="yt-abc12345678",
+        wiki=None,
+        yes=True,
+        auto_approve=True,
+    )
+
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=[Stage.PLAN, None],
+        ),
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+    ):
+        mock_cfg.return_value = MagicMock()
+        run_cmd.run(args)
+
+    assert len(call_log) == 1
+    # PLAN stage namespace should NOT have yes attribute from flag forwarding
+    assert not getattr(call_log[0], "yes", False)
+
+
+# ---------------------------------------------------------------------------
+# Gate-decline handling
+# ---------------------------------------------------------------------------
+
+
+def test_gate_decline_at_approve_reading(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Stage returns 0 but approve-reading still missing → stopped message, exit 0."""
+    # Stage runner returns 0 but first_missing_stage still returns APPROVE_READING
+    # (user quit without approving)
+    _, fake_run = _fake_runner(0)
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    patched_runners[Stage.APPROVE_READING] = fake_run
+
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            # first call: preflight + stage dispatch → APPROVE_READING
+            # second call: post-stage re-check → still APPROVE_READING (gate declined)
+            side_effect=[Stage.APPROVE_READING, Stage.APPROVE_READING],
+        ),
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(_args())
+
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "approve-reading" in (captured.out + captured.err).lower()
+    assert "stopped" in (captured.out + captured.err).lower()
+
+
+def test_gate_decline_at_review(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Review stage returns 0 but still has proposals → stopped message, exit 0."""
+    _, fake_run = _fake_runner(0)
+    patched_runners = dict(run_cmd.STAGE_RUNNERS)
+    patched_runners[Stage.REVIEW] = fake_run
+
+    with (
+        patch("auto_lorebook.commands.run.cfg_mod.load_config") as mock_cfg,
+        patch(
+            "auto_lorebook.commands.run.first_missing_stage",
+            side_effect=[Stage.REVIEW, Stage.REVIEW],
+        ),
+        patch("auto_lorebook.commands.run._is_interactive", return_value=True),
+        patch.object(run_cmd, "STAGE_RUNNERS", patched_runners),
+    ):
+        mock_cfg.return_value = MagicMock()
+        result = run_cmd.run(_args())
+
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "review" in (captured.out + captured.err).lower()
+    assert "stopped" in (captured.out + captured.err).lower()
+
+
+# ---------------------------------------------------------------------------
+# Parser: --yes and --auto-approve flags
+# ---------------------------------------------------------------------------
+
+
+def test_add_parser_accepts_yes_flag() -> None:
+    """Run subcommand parser accepts --yes."""
+    parser = create_parser()
+    args = parser.parse_args(["run", "--yes", "yt-abc12345678"])
+    assert args.yes is True
+
+
+def test_add_parser_accepts_auto_approve_flag() -> None:
+    """Run subcommand parser accepts --auto-approve."""
+    parser = create_parser()
+    args = parser.parse_args(["run", "--auto-approve", "yt-abc12345678"])
+    assert args.auto_approve is True


### PR DESCRIPTION
Lands all five tracer-bullet slices of #59 plus the doc-drift reconciliation that the PRD called out as pre-existing. Each slice was driven through plan → implement → review (Sonnet) loop on this single branch; the reviewer also handled the live smoke per the user's instruction.

## What's in this PR

| Issue | Slice | Commit |
|---|---|---|
| #60 | Reconcile pre-existing doc drift (no code) | `df6b770` |
| #61 | `pipeline_state` module + minimal `run` (sid-only) | `f32106c` → `b673f4a` (fix) |
| #62 | URL support + full ingest flag surface on `run` | `10b6927` |
| #63 | TTY pre-flight, `--yes`/`--auto-approve` forwarding, gate-decline | `1811c54` |
| #64 | Stage headers + skip notices | `85be939` → `debba7f` (test tightening) |
| #65 | Promote `run` as the primary documented path | `670ff2c` |

## How it composes

1. **`auto_lorebook.pipeline_state`** — pure deep module. `first_missing_stage(cfg, source_id, *, wiki_override) -> Stage | None` walks the detector table (`info.yaml`, reading sidecar, `reading.md`, `plan.yaml`, proposals dir state) top-to-bottom. The proposals-dir lifecycle is: absent after `plan`, populated after `extract`, empty after `review` (review deletes individual YAMLs via `unlink` but never removes the dir). #61 initially inverted that distinction; `b673f4a` corrects it.
2. **`auto_lorebook.commands.run`** — shallow CLI wrapper. Accepts a URL or source_id, derives the sid, pre-flights for TTY + gate flag reachability, prints stage headers / skip notices, dispatches to each stage's existing `run()` via a built `Namespace`, propagates non-zero exits, detects user gate-decline (stage returns 0 but its artifact is still missing).
3. **`add_ingest_args(parser)`** — extracted helper, called by both `ingest_cmd.add_parser` and `run_cmd.add_parser`. `ingest` behaviour unchanged.
4. **Docs** — `getting-started/first-ingest.md` now leads with `auto-lorebook run <URL>`; the six-stage manual flow moves to a "Running stages individually" subsection. Roadmap gets a "Pipeline ergonomics" note. The misleading `Generate reading now? [Y/n]:` prompts and "planner runs automatically after `approve-reading`" wording are gone (or qualified as library-level vs CLI-level).

## Test coverage

- `tests/test_pipeline_state.py` — parameterised over the full detector matrix, including the proposals-dir absent/empty/non-empty trichotomy.
- `tests/test_run_cmd.py` — dispatch order, exit-code propagation, `--wiki` threading, URL vs sid disambiguation, ingest-flag-on-sid warning, pre-flight refusal per gate, gate-decline per gate, "gate not reachable so flag not required", stage headers (six in order, URL path), skip notices on resume, artifact names in skip notices.
- All existing suites untouched. Final run: **698 passed, 4 skipped (live)**.

## Verifications run on the branch

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run ty check` — clean
- `uv run pytest` — 698 / 4
- `uv run mkdocs build --strict` — clean
- `uv run pytest tests/test_docs.py` — clean

## Inconsistencies surfaced (not addressed here)

- `AGENTS.md` references `docs/hooks/cli_reference.py` as if it auto-inlines CLI flags from `bot.py` / `cli.py`. The file does not exist and the hook is not wired into `mkdocs.yml`. #65's docs were edited manually as a result. Worth a follow-up issue to either land the hook or correct `AGENTS.md`.

Closes #60
Closes #61
Closes #62
Closes #63
Closes #64
Closes #65

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjPXybj89GEHR3m8HJVK8m)_