### PR TITLE
Stage 4 slice 3: cross-reference citations and entity cross-links

### DIFF
--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -27,34 +27,36 @@ Entity markdown file, overwritten in full on each regeneration:
 ## Summary
 
 Aldara is a kingdom founded in the Second Age by the grandfather of King
-Theron. Its ruling bloodline has remained unbroken since its founding.
-Some tavern rumors suggest the founding king was cursed by an elven
-sorceress, though this is unconfirmed.
+[Theron](../characters/theron.md). Its ruling bloodline has remained unbroken
+since its founding.[^f-n01] Some tavern rumors suggest the founding king was
+cursed by an elven sorceress, though this is unconfirmed.
 
 ## Facts
 
 ### Authoritative
 
-[^1]: "Theron's grandfather founded Aldara in the Second Age."
-[^2]: "Aldara's kings have always come from the Theron bloodline."
+[^fact-001]: "Theron's grandfather founded Aldara in the Second Age."
+[^fact-002]: "Aldara's kings have always come from the Theron bloodline."
 
 ### Hearsay
 
-[^3]: "The founding king was cursed by an elven sorceress."
+[^fact-003]: "The founding king was cursed by an elven sorceress."
 
 ### Disproven
 
-[^4]: ~~The founding king was mortal.~~ — Later shown to be half-fae.
+[^fact-004]: ~~The founding king was mortal.~~ — Later shown to be half-fae.
 
 ## References
 
 1. Worldbuilding Session 3 — https://youtube.com/watch?v=abc123
 
-[^1]: "Theron's grandfather founded Aldara in the Second Age."  — DM, [0:04:32-0:04:41](https://youtube.com/watch?v=abc123&t=272) (session: 2026-01-15)
-[^2]: "Aldara's kings have always come from the Theron bloodline."  — DM, 0:06:02 (session: 2026-01-20)
-[^3]: "The founding king was cursed by an elven sorceress."  — Innkeeper NPC, [1:23:40-1:24:15](https://youtube.com/watch?v=abc123&t=5020) (session: 2026-02-03)
-[^4]: "The founding king was mortal."  — DM, 0:08:00 (session: 2026-02-03)
+[^fact-001]: "Theron's grandfather founded Aldara in the Second Age."  — DM, [0:04:32-0:04:41](https://youtube.com/watch?v=abc123&t=272) (session: 2026-01-15)
+[^fact-002]: "Aldara's kings have always come from the Theron bloodline."  — DM, 0:06:02 (session: 2026-01-20)
+[^fact-003]: "The founding king was cursed by an elven sorceress."  — Innkeeper NPC, [1:23:40-1:24:15](https://youtube.com/watch?v=abc123&t=5020) (session: 2026-02-03)
+[^fact-004]: "The founding king was mortal."  — DM, 0:08:00 (session: 2026-02-03)
   *Later shown to be half-fae.*
+
+[^f-n01]: "Theron's bloodline has remained unbroken." — [Theron](../characters/theron.md#fn:f-n01)
 ```
 
 ## Summarizer rules
@@ -71,7 +73,8 @@ sorceress, though this is unconfirmed.
 - **Disproven facts** excluded from summary by default; rendered
   struck-through in their own section with the reason.
 - Every summary sentence cites fact IDs; citation labels in the
-  rendered view are footnote numbers.
+  rendered view are stable anchors derived from the fact's ID
+  (e.g. `[^fact-001]`), not positional counters.
 
 ## Model slot
 
@@ -105,6 +108,34 @@ facts of its one-hop linked entities (grouped by epistemic status). The LLM may
 synthesize a claim drawn from a linked entity's fact, applying the same epistemic-status
 hedging rules as for the entity's own facts. The rendered `## Facts` section on the
 page lists only the entity's own facts.
+
+## Cross-references and entity links
+
+The LLM may embed two kinds of inline markers in its prose output, which
+the renderer resolves before writing the page.
+
+**Entity links** — `[[category/slug]]` markers become clickable markdown
+links using the entity's canonical name. Same-category links resolve to a
+bare `slug.md` path; cross-category links resolve to `../category/slug.md`.
+If a marker cannot be found in the entity index, the renderer degrades it
+to plain `category/slug` text and logs a warning — the page is always
+written.
+
+**Cross-reference citations** — `[[fact:<id>]]` markers indicate that the
+preceding prose sentence draws on a linked entity's fact. The renderer
+replaces each marker with a footnote reference `[^<id>]` and appends a
+cross-reference footnote definition that quotes the source fact text and
+links to the linked entity's page anchored at `#fn:<id>` (Python-Markdown
+footnote convention). Only facts actually cited in prose generate crossref
+footnotes; the full linked-entity fact set is available to the LLM for
+context but does not appear unless cited. Unresolvable markers degrade to
+plain text and log a warning.
+
+Example crossref footnote in rendered output:
+
+```markdown
+[^f-n01]: "Theron's bloodline has remained unbroken." — [Theron](../characters/theron.md#fn:f-n01)
+```
 
 ## Rebuild
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
     "S101", # Allow assert in tests
+    "PLC2701", # Allow private-name imports from internal modules
 ]
 
 [tool.ruff.format]

--- a/src/auto_lorebook/stage4.py
+++ b/src/auto_lorebook/stage4.py
@@ -13,6 +13,7 @@ Public API:
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -50,6 +51,8 @@ Rules:
 - Linked-entity facts (below): you MAY synthesize a claim drawn from a
   linked entity's fact, with the same epistemic-status hedging as above.
   Do not fabricate beyond what is listed.
+- Markers: use [[category/slug]] to link an entity by name (e.g. [[locations/aldara]]);
+  use [[fact:<fact_id>]] to cite a linked entity's fact (e.g. [[fact:f-n01]]).
 
 Emit a single JSON object:
 {
@@ -198,6 +201,69 @@ def run(
     return parse_response(payload)
 
 
+_ENTITY_LINK_RE = re.compile(r"\[\[([a-z0-9-]+)/([a-z0-9-]+)\]\]")
+_FACT_REF_RE = re.compile(r"\[\[fact:([^\]]+)\]\]")
+
+
+def _resolve_entity_links(
+    prose: str,
+    entity_lookup: dict[tuple[str, str], EntityRow],
+    *,
+    from_category: str,
+) -> str:
+    """Scan [[category/slug]] markers; resolve to markdown links or plain text.
+
+    Same-category: bare ``slug.md``; cross-category: ``../category/slug.md``.
+    Unresolvable: raw ``category/slug`` text + logged warning.  Never raises.
+    """
+
+    def _replace(m: re.Match[str]) -> str:
+        cat, slug = m.group(1), m.group(2)
+        entity = entity_lookup.get((cat, slug))
+        if entity is None:
+            _logger.warning("unresolvable entity marker: %s/%s", cat, slug)
+            return f"{cat}/{slug}"
+        path = f"{slug}.md" if cat == from_category else f"../{cat}/{slug}.md"
+        return f"[{entity.canonical_name}]({path})"
+
+    return _ENTITY_LINK_RE.sub(_replace, prose)
+
+
+def _resolve_crossref_markers(
+    prose: str,
+    linked_fact_index: dict[str, tuple[EntityRow, FactRow]],
+    *,
+    from_category: str,
+) -> tuple[str, list[str]]:
+    """Scan [[fact:<id>]] markers; resolve to footnote refs + footnote defs.
+
+    Resolvable: inline marker → ``[^<id>]``; footnote def quotes linked fact
+    text and links to linked entity's page anchored at ``#fn:<id>``.
+    Unresolvable: plain text + logged warning.  Never raises.
+    Returns (rewritten_prose, footnote_def_lines).
+    """
+    footnote_defs: list[str] = []
+
+    def _replace(m: re.Match[str]) -> str:
+        fact_id = m.group(1)
+        entry = linked_fact_index.get(fact_id)
+        if entry is None:
+            _logger.warning("unresolvable fact marker: %s", fact_id)
+            return fact_id
+        linked_ent, linked_fact = entry
+        cat = linked_ent.category
+        slug = linked_ent.slug
+        path = f"{slug}.md" if cat == from_category else f"../{cat}/{slug}.md"
+        anchor = f"#fn:{fact_id}"
+        quote = f'"{linked_fact.text}"'
+        link = f"[{linked_ent.canonical_name}]({path}{anchor})"
+        footnote_defs.append(f"[^{fact_id}]: {quote} — {link}")
+        return f"[^{fact_id}]"
+
+    rewritten = _FACT_REF_RE.sub(_replace, prose)
+    return rewritten, footnote_defs
+
+
 def _source_url_with_ts(source_url: str | None, locator: str) -> str | None:
     """Append timestamp query param to YouTube URLs."""
     if not source_url:
@@ -244,11 +310,15 @@ def render_entity_page(
     facts: list[FactRow],
     prose: str | None,
     conn: sqlite3.Connection | None,
+    entity_lookup: dict[tuple[str, str], EntityRow] | None = None,
+    linked_facts: list[tuple[EntityRow, list[FactRow]]] | None = None,
 ) -> str:
     """Render full Markdown page for entity.
 
     Zero-fact entities (prose=None): mechanical stub, no ``## Summary``.
     Entities with facts: ``## Summary`` + prose + status-grouped facts + references.
+    entity_lookup: index for [[category/slug]] marker resolution.
+    linked_facts: linked-entity pairs for [[fact:<id>]] crossref resolution.
     """
     lines: list[str] = [f"# {entity.canonical_name}", ""]
 
@@ -259,22 +329,31 @@ def render_entity_page(
     if not facts or prose is None:
         return "\n".join(lines)
 
-    # prose summary section
-    lines.extend(["## Summary", "", prose.strip(), ""])
+    # resolve entity-link and crossref markers in prose
+    resolved_prose = prose.strip()
+    crossref_footnote_defs: list[str] = []
+    if entity_lookup is not None:
+        resolved_prose = _resolve_entity_links(
+            resolved_prose, entity_lookup, from_category=entity.category
+        )
+    if linked_facts is not None:
+        # build flat index: fact_id → (entity, fact)
+        linked_fact_index: dict[str, tuple[EntityRow, FactRow]] = {}
+        for linked_ent, linked_fact_rows in linked_facts:
+            for lf in linked_fact_rows:
+                linked_fact_index[lf.id] = (linked_ent, lf)
+        resolved_prose, crossref_footnote_defs = _resolve_crossref_markers(
+            resolved_prose, linked_fact_index, from_category=entity.category
+        )
 
-    # group facts by status; assign footnote numbers
+    # prose summary section
+    lines.extend(["## Summary", "", resolved_prose, ""])
+
+    # group facts by status; use fact.id as stable anchor label
     by_status: dict[str, list[FactRow]] = {s: [] for s in _STATUS_ORDER}
     for fact in facts:
         bucket = fact.status if fact.status in by_status else "hearsay"
         by_status[bucket].append(fact)
-
-    # build footnote index: fact_id → footnote number
-    fn_counter = 0
-    fact_footnote: dict[str, int] = {}
-    for status in _STATUS_ORDER:
-        for fact in by_status[status]:
-            fn_counter += 1
-            fact_footnote[fact.id] = fn_counter
 
     # ## Facts section
     lines.extend(["## Facts", ""])
@@ -284,13 +363,12 @@ def render_entity_page(
             continue
         lines.extend((f"### {status.capitalize()}", ""))
         for fact in bucket:
-            fn = fact_footnote[fact.id]
             if status == "disproven":
                 text_part = f"~~{fact.text}~~"
                 reason_part = f" — {fact.status_reason}" if fact.status_reason else ""
-                lines.append(f"[^{fn}]: {text_part}{reason_part}")
+                lines.append(f"[^{fact.id}]: {text_part}{reason_part}")
             else:
-                lines.append(f"[^{fn}]: {fact.text}")
+                lines.append(f"[^{fact.id}]: {fact.text}")
         lines.append("")
 
     # ## References section
@@ -326,7 +404,6 @@ def render_entity_page(
     lines.append("")
     for status in _STATUS_ORDER:
         for fact in by_status[status]:
-            fn = fact_footnote[fact.id]
             src_url = _resolve_source_url(conn, fact.source_id, fact.locator)
             link = f"[{fact.locator}]({src_url})" if src_url else fact.locator
             speaker = f"— {fact.speaker}, " if fact.speaker else ""
@@ -334,9 +411,14 @@ def render_entity_page(
             quote = f'"{fact.text}"'
             if status == "disproven":
                 reason = f"\n  *{fact.status_reason}*" if fact.status_reason else ""
-                lines.append(f"[^{fn}]: {quote}  {speaker}{link}{session}{reason}")
+                lines.append(f"[^{fact.id}]: {quote}  {speaker}{link}{session}{reason}")
             else:
-                lines.append(f"[^{fn}]: {quote}  {speaker}{link}{session}")
+                lines.append(f"[^{fact.id}]: {quote}  {speaker}{link}{session}")
+
+    # crossref footnote defs (linked-entity citations)
+    if crossref_footnote_defs:
+        lines.append("")
+        lines.extend(crossref_footnote_defs)
 
     return "\n".join(lines)
 
@@ -370,6 +452,12 @@ def summarize_entity(
     aliases = entities_mod.list_aliases(conn, category, slug)
     fact_rows = facts_mod.list_facts_by_entity(conn, category, slug)
 
+    # build entity lookup for [[category/slug]] marker resolution
+    all_entities = entities_mod.list_entities(conn)
+    entity_lookup: dict[tuple[str, str], EntityRow] = {
+        (e.category, e.slug): e for e in all_entities
+    }
+
     prose: str | None = None
     if fact_rows:
         result = run(
@@ -390,6 +478,8 @@ def summarize_entity(
         facts=fact_rows,
         prose=prose,
         conn=conn,
+        entity_lookup=entity_lookup,
+        linked_facts=linked_facts,
     )
     path = _summary_path(wiki_repo, category, slug)
     atomic_write_text(path, text)

--- a/src/auto_lorebook/stage4.py
+++ b/src/auto_lorebook/stage4.py
@@ -243,6 +243,7 @@ def _resolve_crossref_markers(
     Returns (rewritten_prose, footnote_def_lines).
     """
     footnote_defs: list[str] = []
+    seen_fact_ids: set[str] = set()
 
     def _replace(m: re.Match[str]) -> str:
         fact_id = m.group(1)
@@ -257,7 +258,9 @@ def _resolve_crossref_markers(
         anchor = f"#fn:{fact_id}"
         quote = f'"{linked_fact.text}"'
         link = f"[{linked_ent.canonical_name}]({path}{anchor})"
-        footnote_defs.append(f"[^{fact_id}]: {quote} — {link}")
+        if fact_id not in seen_fact_ids:
+            seen_fact_ids.add(fact_id)
+            footnote_defs.append(f"[^{fact_id}]: {quote} — {link}")
         return f"[^{fact_id}]"
 
     rewritten = _FACT_REF_RE.sub(_replace, prose)

--- a/tests/test_db_migrations.py
+++ b/tests/test_db_migrations.py
@@ -198,7 +198,7 @@ def test_migration_002_preserves_existing_rows(tmp_path: Path) -> None:
 
     # Create a v1 DB (only migration 001)
     from auto_lorebook.db.migrations import (  # noqa: PLC0415
-        _migration_001_initial,  # noqa: PLC2701
+        _migration_001_initial,
     )
 
     raw = sqlite3.connect(str(db_path))
@@ -263,8 +263,8 @@ def test_migration_003_preserves_existing_rows(tmp_path: Path) -> None:
     db_path = tmp_path / "wiki.db"
 
     from auto_lorebook.db.migrations import (  # noqa: PLC0415
-        _migration_001_initial,  # noqa: PLC2701
-        _migration_002_widen_source_type,  # noqa: PLC2701
+        _migration_001_initial,
+        _migration_002_widen_source_type,
     )
 
     raw = sqlite3.connect(str(db_path))
@@ -371,10 +371,10 @@ def test_migration_005_drops_per_target_columns_from_proposals() -> None:
 def test_migration_005_preserves_existing_rows(tmp_path: Path) -> None:
     """Rows from v4 survive migration 005; proposal_targets populated from proposals."""
     from auto_lorebook.db.migrations import (  # noqa: PLC0415
-        _migration_001_initial,  # noqa: PLC2701
-        _migration_002_widen_source_type,  # noqa: PLC2701
-        _migration_003_fix_segment_status_and_add_flags_json,  # noqa: PLC2701
-        _migration_004_plan_metadata_and_flag_reason,  # noqa: PLC2701
+        _migration_001_initial,
+        _migration_002_widen_source_type,
+        _migration_003_fix_segment_status_and_add_flags_json,
+        _migration_004_plan_metadata_and_flag_reason,
     )
 
     db_path = tmp_path / "wiki.db"
@@ -437,9 +437,9 @@ def test_migration_005_preserves_existing_rows(tmp_path: Path) -> None:
 def test_migration_004_preserves_existing_rows(tmp_path: Path) -> None:
     """Rows from v3 survive migration 004; flag_reason is NULL on legacy proposals."""
     from auto_lorebook.db.migrations import (  # noqa: PLC0415
-        _migration_001_initial,  # noqa: PLC2701
-        _migration_002_widen_source_type,  # noqa: PLC2701
-        _migration_003_fix_segment_status_and_add_flags_json,  # noqa: PLC2701
+        _migration_001_initial,
+        _migration_002_widen_source_type,
+        _migration_003_fix_segment_status_and_add_flags_json,
     )
 
     db_path = tmp_path / "wiki.db"

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -918,7 +918,7 @@ class TestRenderOuterGapWarnings:
 
     def _make_summaries(self) -> list:
         from auto_lorebook.commands.approve_reading import (  # noqa: PLC0415
-            _SegSummary,  # noqa: PLC2701
+            _SegSummary,
         )
 
         return [
@@ -936,7 +936,7 @@ class TestRenderOuterGapWarnings:
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         from auto_lorebook.commands.approve_reading import (  # noqa: PLC0415
-            _render_outer,  # noqa: PLC2701
+            _render_outer,
         )
 
         summaries = self._make_summaries()
@@ -950,7 +950,7 @@ class TestRenderOuterGapWarnings:
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         from auto_lorebook.commands.approve_reading import (  # noqa: PLC0415
-            _render_outer,  # noqa: PLC2701
+            _render_outer,
         )
         from auto_lorebook.gap_check import GapWarning  # noqa: PLC0415
 

--- a/tests/test_stage4.py
+++ b/tests/test_stage4.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -17,6 +18,8 @@ from auto_lorebook.facts import (
 from auto_lorebook.page_step import run_page_step
 from auto_lorebook.stage4 import (
     Stage4Error,
+    _resolve_crossref_markers,
+    _resolve_entity_links,
     build_prompt,
     parse_response,
     render_entity_page,
@@ -698,3 +701,195 @@ class TestBuildPromptLinkedFacts:
         user_content = " ".join(m["content"] for m in messages if m["role"] == "user")
         assert "Aldara is an ancient city." in user_content
         assert result.prose == "Theron founded Aldara."
+
+
+# ---------------------------------------------------------------------------
+# TestPerFactAnchors — fact.id-derived stable anchors
+# ---------------------------------------------------------------------------
+
+
+class TestPerFactAnchors:
+    def test_anchor_derived_from_fact_id(self) -> None:
+        """Footnote label uses fact.id, not a counter."""
+        entity = _make_entity_row()
+        fact = _make_fact_row(fact_id="f-001")
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=[fact],
+            prose="Some prose.",
+            conn=None,
+        )
+        assert "[^f-001]:" in result
+
+    def test_anchor_stable_across_fact_set_change(self) -> None:
+        """Adding a second fact does not change the anchor of the first."""
+        entity = _make_entity_row()
+        fact1 = _make_fact_row(fact_id="f-001", text="First fact.")
+        fact2 = _make_fact_row(fact_id="f-002", text="Second fact.", source_id="src-001")
+
+        result_one = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=[fact1],
+            prose="Some prose.",
+            conn=None,
+        )
+        result_two = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=[fact1, fact2],
+            prose="Some prose.",
+            conn=None,
+        )
+        # f-001 anchor must be present in both; not changed by adding f-002
+        assert "[^f-001]:" in result_one
+        assert "[^f-001]:" in result_two
+
+
+# ---------------------------------------------------------------------------
+# TestEntityMarkerResolution — [[category/slug]] → markdown link
+# ---------------------------------------------------------------------------
+
+
+class TestEntityMarkerResolution:
+    def _make_linked_entity(
+        self, name: str, category: str, slug: str
+    ) -> EntityRow:
+        return _make_entity_row(name, category, slug)
+
+    def test_marker_resolves_to_link(self) -> None:
+        """[[characters/aldara]] → [Aldara](../characters/aldara.md) (cross-cat)."""
+        entity = self._make_linked_entity("Aldara", "characters", "aldara")
+        lookup = {("characters", "aldara"): entity}
+        prose = "See [[characters/aldara]] for details."
+        result = _resolve_entity_links(prose, lookup, from_category="locations")
+        assert "[Aldara](../characters/aldara.md)" in result
+        assert "[[characters/aldara]]" not in result
+
+    def test_same_category_bare_path(self) -> None:
+        """Same category → relative path without parent component."""
+        entity = self._make_linked_entity("Aldara", "locations", "aldara")
+        lookup = {("locations", "aldara"): entity}
+        prose = "See [[locations/aldara]] here."
+        result = _resolve_entity_links(prose, lookup, from_category="locations")
+        assert "[Aldara](aldara.md)" in result
+
+    def test_unresolvable_marker_becomes_plain_text(self) -> None:
+        """Unknown marker degrades to raw 'category/slug' text."""
+        lookup: dict[tuple[str, str], EntityRow] = {}
+        prose = "See [[mystery/unknown]] here."
+        result = _resolve_entity_links(prose, lookup, from_category="characters")
+        assert "[[mystery/unknown]]" not in result
+        assert "mystery/unknown" in result
+
+    def test_unresolvable_marker_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Unresolvable marker emits a logged warning."""
+        lookup: dict[tuple[str, str], EntityRow] = {}
+        prose = "See [[mystery/unknown]] here."
+        with caplog.at_level(logging.WARNING, logger="auto_lorebook.stage4"):
+            _resolve_entity_links(prose, lookup, from_category="characters")
+        assert any("mystery/unknown" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# TestCrossReferenceFootnotes — [[fact:<id>]] → footnote + crossref
+# ---------------------------------------------------------------------------
+
+
+class TestCrossReferenceFootnotes:
+    def _make_linked(
+        self, name: str = "Aldara", cat: str = "locations", slug: str = "aldara"
+    ) -> EntityRow:
+        return _make_entity_row(name, cat, slug)
+
+    def test_crossref_marker_emits_footnote(self) -> None:
+        """[[fact:f-n01]] replaced with [^f-n01] ref; footnote def added."""
+        linked_ent = self._make_linked()
+        linked_fact = _make_fact_row(
+            fact_id="f-n01", text="Aldara was built in the Second Age."
+        )
+        linked_fact_index = {"f-n01": (linked_ent, linked_fact)}
+        prose = "Theron lived near [[fact:f-n01]]."
+        new_prose, footnote_defs = _resolve_crossref_markers(
+            prose, linked_fact_index, from_category="characters"
+        )
+        assert "[^f-n01]" in new_prose
+        assert "[[fact:f-n01]]" not in new_prose
+        assert any("f-n01" in d for d in footnote_defs)
+
+    def test_crossref_footnote_quotes_linked_fact(self) -> None:
+        """Footnote def includes the linked fact's text as a quote."""
+        linked_ent = self._make_linked()
+        linked_fact = _make_fact_row(
+            fact_id="f-n01", text="Aldara was built in the Second Age."
+        )
+        linked_fact_index = {"f-n01": (linked_ent, linked_fact)}
+        prose = "Background: [[fact:f-n01]]."
+        _, footnote_defs = _resolve_crossref_markers(
+            prose, linked_fact_index, from_category="characters"
+        )
+        combined = "\n".join(footnote_defs)
+        assert "Aldara was built in the Second Age." in combined
+
+    def test_crossref_footnote_links_to_entity_page(self) -> None:
+        """Footnote def contains link to linked entity's page anchored at fact."""
+        linked_ent = self._make_linked(cat="locations", slug="aldara")
+        linked_fact = _make_fact_row(fact_id="f-n01", text="Some claim.")
+        linked_fact_index = {"f-n01": (linked_ent, linked_fact)}
+        prose = "See [[fact:f-n01]]."
+        _, footnote_defs = _resolve_crossref_markers(
+            prose, linked_fact_index, from_category="characters"
+        )
+        combined = "\n".join(footnote_defs)
+        # link to ../locations/aldara.md#fn:f-n01
+        assert "locations/aldara.md" in combined
+        assert "#fn:f-n01" in combined
+
+    def test_unresolvable_crossref_degrades_to_plain_text(self) -> None:
+        """[[fact:unknown]] → plain text (marker removed), no exception."""
+        linked_fact_index: dict[str, tuple[EntityRow, FactRow]] = {}
+        prose = "See [[fact:unknown]]."
+        new_prose, footnote_defs = _resolve_crossref_markers(
+            prose, linked_fact_index, from_category="characters"
+        )
+        assert "[[fact:unknown]]" not in new_prose
+        assert not footnote_defs
+
+    def test_crossref_only_for_cited_linked_facts(self) -> None:
+        """Only [[fact:…]] markers that appear in prose generate footnotes."""
+        linked_ent = self._make_linked()
+        fact_cited = _make_fact_row(fact_id="f-n01", text="Cited fact.")
+        fact_uncited = _make_fact_row(fact_id="f-n02", text="Uncited fact.")
+        linked_fact_index = {
+            "f-n01": (linked_ent, fact_cited),
+            "f-n02": (linked_ent, fact_uncited),
+        }
+        prose = "Only [[fact:f-n01]] is mentioned."
+        _, footnote_defs = _resolve_crossref_markers(
+            prose, linked_fact_index, from_category="characters"
+        )
+        combined = "\n".join(footnote_defs)
+        assert "f-n01" in combined
+        assert "f-n02" not in combined
+
+    def test_render_entity_page_with_crossref(self) -> None:
+        """render_entity_page passes crossref footnotes through to output."""
+        entity = _make_entity_row()
+        own_fact = _make_fact_row(fact_id="f-001", text="Theron ruled.")
+        linked_ent = _make_entity_row("Aldara", "locations", "aldara")
+        linked_fact = _make_fact_row(fact_id="f-n01", text="Aldara was founded here.")
+        entity_lookup = {("locations", "aldara"): linked_ent}
+        linked_facts = [(linked_ent, [linked_fact])]
+        prose = "Theron ruled. See [[fact:f-n01]]."
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=[own_fact],
+            prose=prose,
+            conn=None,
+            entity_lookup=entity_lookup,
+            linked_facts=linked_facts,
+        )
+        assert "[^f-n01]" in result
+        assert "Aldara was founded here." in result

--- a/tests/test_stage4.py
+++ b/tests/test_stage4.py
@@ -726,7 +726,9 @@ class TestPerFactAnchors:
         """Adding a second fact does not change the anchor of the first."""
         entity = _make_entity_row()
         fact1 = _make_fact_row(fact_id="f-001", text="First fact.")
-        fact2 = _make_fact_row(fact_id="f-002", text="Second fact.", source_id="src-001")
+        fact2 = _make_fact_row(
+            fact_id="f-002", text="Second fact.", source_id="src-001"
+        )
 
         result_one = render_entity_page(
             entity=entity,
@@ -753,9 +755,7 @@ class TestPerFactAnchors:
 
 
 class TestEntityMarkerResolution:
-    def _make_linked_entity(
-        self, name: str, category: str, slug: str
-    ) -> EntityRow:
+    def _make_linked_entity(self, name: str, category: str, slug: str) -> EntityRow:
         return _make_entity_row(name, category, slug)
 
     def test_marker_resolves_to_link(self) -> None:
@@ -783,7 +783,9 @@ class TestEntityMarkerResolution:
         assert "[[mystery/unknown]]" not in result
         assert "mystery/unknown" in result
 
-    def test_unresolvable_marker_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_unresolvable_marker_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """Unresolvable marker emits a logged warning."""
         lookup: dict[tuple[str, str], EntityRow] = {}
         prose = "See [[mystery/unknown]] here."
@@ -855,6 +857,30 @@ class TestCrossReferenceFootnotes:
         )
         assert "[[fact:unknown]]" not in new_prose
         assert not footnote_defs
+
+    def test_unresolvable_crossref_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unresolvable [[fact:unknown]] emits a logged warning."""
+        linked_fact_index: dict[str, tuple[EntityRow, FactRow]] = {}
+        prose = "See [[fact:unknown]]."
+        with caplog.at_level(logging.WARNING, logger="auto_lorebook.stage4"):
+            _resolve_crossref_markers(
+                prose, linked_fact_index, from_category="characters"
+            )
+        assert any("unknown" in r.message for r in caplog.records)
+
+    def test_duplicate_crossref_marker_single_footnote_def(self) -> None:
+        """Same [[fact:f-n01]] twice → exactly one footnote def."""
+        linked_ent = self._make_linked()
+        linked_fact = _make_fact_row(fact_id="f-n01", text="Aldara was built.")
+        linked_fact_index = {"f-n01": (linked_ent, linked_fact)}
+        prose = "First [[fact:f-n01]] and again [[fact:f-n01]]."
+        _, footnote_defs = _resolve_crossref_markers(
+            prose, linked_fact_index, from_category="characters"
+        )
+        assert footnote_defs.count(footnote_defs[0]) == 1
+        assert len([d for d in footnote_defs if "f-n01" in d]) == 1
 
     def test_crossref_only_for_cited_linked_facts(self) -> None:
         """Only [[fact:…]] markers that appear in prose generate footnotes."""

--- a/tests/test_wiki_cmd.py
+++ b/tests/test_wiki_cmd.py
@@ -11,7 +11,7 @@ import yaml
 from auto_lorebook import config as cfg_mod
 from auto_lorebook.cli import create_parser
 from auto_lorebook.commands import wiki_cmd
-from auto_lorebook.commands._shared import resolve_wiki  # noqa: PLC2701
+from auto_lorebook.commands._shared import resolve_wiki
 from auto_lorebook.config import ConfigError
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## What this fixes

Stage 4 renders entity `.md` pages from LLM prose. Slice 3 makes that prose verifiable and navigable via three deterministic post-passes in `src/auto_lorebook/stage4.py`:

- `render_entity_page` emits a stable per-fact anchor derived from `fact.id` (replacing the old positional counter), so links can target a specific fact.
- `_resolve_crossref_markers` turns `[[fact:<id>]]` markers into cross-reference footnotes whose definition quotes the linked fact's text and links to that fact's anchor on the linked entity's page. A `seen_fact_ids` guard emits one footnote definition per fact id even when the marker repeats.
- `_resolve_entity_links` resolves `[[category/slug]]` markers to markdown links via the entity index; an unresolvable marker degrades to plain text with a logged warning instead of failing the page.

`docs/pipeline/summarizer.md` reconciled in the same branch.

## QA steps for the human

None required — the integration smoke drove the real `render_entity_page` path with all three marker kinds (resolvable, unresolvable, repeated/deduped), status grouping, footnote ordering, and the zero-fact stub, all correct. Optional eyeball: render an entity whose prose contains a `[[fact:...]]` and a `[[category/slug]]` marker and confirm the footnote + link.

## Automated coverage

`ruff check`, `ruff format --check`, `ty check`, `pytest` (944 passed, 5 skipped), `mkdocs build --strict` — all green. Plus a live integration smoke of `render_entity_page`.

Note: base branch is the Stage 4 integration branch `claude/parallel-issue-workflow-XpHwB` (slices 1–2 live there, not yet on `main`).

Closes #86

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5pePA6v63c6JKm5rUPyct)_