### PR TITLE
Stage 4 slice 4: linked-context token budgeter

### DIFF
--- a/docs/adr/0005-summaries-synthesize-across-linked-entities.md
+++ b/docs/adr/0005-summaries-synthesize-across-linked-entities.md
@@ -28,3 +28,8 @@ entity propagates to re-summarize its linked entities (one hop).
 - One new fact on a well-connected hub entity can force LLM
   re-summarization of every linked entity. Propagation is capped at one
   hop (no transitive cascade) to bound this cost.
+- A second cost bound is the linked-context token budgeter: the
+  linked-entities block in each prompt is capped to a configurable
+  fraction of the context window (`summarizer.linked_context_budget_fraction`,
+  default 0.25), keeping entities with more shared facts and dropping
+  low-priority facts first.

--- a/docs/architecture/repository-layout.md
+++ b/docs/architecture/repository-layout.md
@@ -92,6 +92,8 @@ models:
   primary_context_window: 200000
 preamble:
   budget_fraction: 0.8
+summarizer:
+  linked_context_budget_fraction: 0.25
 ```
 
 The registry is the single source of truth for which wikis the tool

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -69,6 +69,8 @@ models:
   primary_context_window: 200000
 preamble:
   budget_fraction: 0.8
+summarizer:
+  linked_context_budget_fraction: 0.25
 ```
 
 ## Switching and adding wikis

--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -118,7 +118,7 @@ default 0.25).
 1. Shared facts (fact targets both the subject entity and the linked entity).
 2. Non-shared authoritative facts.
 3. Non-shared trustworthy facts.
-4. Non-shared hearsay facts (dropped before disproven).
+4. Non-shared hearsay facts (dropped after disproven).
 5. Non-shared disproven facts (dropped first when over budget).
 
 **Entity ranking**: entities with more shared facts appear first (nearest-first);

--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -106,6 +106,39 @@ synthesize a claim drawn from a linked entity's fact, applying the same epistemi
 hedging rules as for the entity's own facts. The rendered `## Facts` section on the
 page lists only the entity's own facts.
 
+## Linked-context token budget
+
+A hub entity with many linked entities could overflow the model's context window.
+The budgeter (`linked_budget.budget_linked_context`) caps the linked-entities block
+to a configurable fraction of the context window (`summarizer.linked_context_budget_fraction`,
+default 0.25).
+
+**Priority ordering** (highest to lowest):
+
+1. Shared facts (fact targets both the subject entity and the linked entity).
+2. Non-shared authoritative facts.
+3. Non-shared trustworthy facts.
+4. Non-shared hearsay facts (dropped first when over budget).
+5. Non-shared disproven facts (dropped before hearsay).
+
+**Entity ranking**: entities with more shared facts appear first (nearest-first);
+ties broken alphabetically by `(category, slug)`. The entity-count cap
+(`max_linked_entities`) is applied before token counting.
+
+**Token estimate**: `len(rendered_block) // 4`, consistent with the preamble budget heuristic.
+
+**Degrade gracefully**: if no linked entity fits within the budget (its minimal
+single-fact block is larger than the budget), the budgeter raises
+`LinkedContextTooLargeError`. The page step catches this, logs a warning, and
+summarizes the entity from its own facts only.
+
+Configure the budget fraction in `config.yaml`:
+
+```yaml
+summarizer:
+  linked_context_budget_fraction: 0.25
+```
+
 ## Rebuild
 
 Regenerate summaries from scratch for all entities:

--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -118,8 +118,8 @@ default 0.25).
 1. Shared facts (fact targets both the subject entity and the linked entity).
 2. Non-shared authoritative facts.
 3. Non-shared trustworthy facts.
-4. Non-shared hearsay facts (dropped first when over budget).
-5. Non-shared disproven facts (dropped before hearsay).
+4. Non-shared hearsay facts (dropped before disproven).
+5. Non-shared disproven facts (dropped first when over budget).
 
 **Entity ranking**: entities with more shared facts appear first (nearest-first);
 ties broken alphabetically by `(category, slug)`. The entity-count cap

--- a/src/auto_lorebook/config.py
+++ b/src/auto_lorebook/config.py
@@ -49,6 +49,13 @@ class PreambleConfig:
 
 
 @dataclass
+class SummarizerConfig:
+    """Summarizer section of config.yaml."""
+
+    linked_context_budget_fraction: float = 0.25
+
+
+@dataclass
 class Config:
     """Loaded ~/.auto-lorebook/config.yaml."""
 
@@ -57,6 +64,7 @@ class Config:
     openrouter: OpenRouterConfig = field(default_factory=OpenRouterConfig)
     models: ModelsConfig = field(default_factory=ModelsConfig)
     preamble: PreambleConfig = field(default_factory=PreambleConfig)
+    summarizer: SummarizerConfig = field(default_factory=SummarizerConfig)
 
     def get_api_key(self) -> str | None:
         """Resolve API key. Env var wins; falls back to credentials file."""
@@ -165,6 +173,7 @@ def load_config(home: Path | None = None) -> Config:
     or_raw: dict[str, Any] = raw.get("openrouter") or {}
     models_raw: dict[str, Any] = raw.get("models") or {}
     preamble_raw: dict[str, Any] = raw.get("preamble") or {}
+    summarizer_raw: dict[str, Any] = raw.get("summarizer") or {}
 
     openrouter = OpenRouterConfig(
         api_key_env=or_raw.get("api_key_env", "OPENROUTER_API_KEY"),
@@ -179,6 +188,11 @@ def load_config(home: Path | None = None) -> Config:
     preamble = PreambleConfig(
         budget_fraction=float(preamble_raw.get("budget_fraction", 0.8)),
     )
+    summarizer_cfg = SummarizerConfig(
+        linked_context_budget_fraction=float(
+            summarizer_raw.get("linked_context_budget_fraction", 0.25)
+        ),
+    )
 
     return Config(
         wikis=wikis,
@@ -186,6 +200,7 @@ def load_config(home: Path | None = None) -> Config:
         openrouter=openrouter,
         models=models,
         preamble=preamble,
+        summarizer=summarizer_cfg,
     )
 
 
@@ -371,6 +386,11 @@ def save_config(cfg: Config, home: Path | None = None) -> None:
             "primary_context_window": cfg.models.primary_context_window,
         },
         "preamble": {"budget_fraction": cfg.preamble.budget_fraction},
+        "summarizer": {
+            "linked_context_budget_fraction": (
+                cfg.summarizer.linked_context_budget_fraction
+            ),
+        },
     }
     if cfg.models.extractor is not None:
         data["models"]["extractor"] = cfg.models.extractor

--- a/src/auto_lorebook/linked_budget.py
+++ b/src/auto_lorebook/linked_budget.py
@@ -14,7 +14,7 @@ _logger = logging.getLogger(__name__)
 LinkedContext = list[tuple["EntityRow", list["FactRow"]]]
 
 # priority order: shared > non-shared authoritative > non-shared trustworthy;
-# drop non-shared hearsay before disproven (both non-shared)
+# drop non-shared disproven before hearsay (both non-shared)
 _STATUS_PRIORITY: dict[str, int] = {
     "authoritative": 1,
     "trustworthy": 2,
@@ -132,7 +132,19 @@ def budget_linked_context(
         if used + cost <= budget:
             result.append((ent, facts))
             used += cost
-        # else: skip this entity — over budget
+            continue
+        # entity over budget: fact-level trim — drop lowest-priority facts from tail
+        trimmed = list(facts)
+        while trimmed:
+            trimmed.pop()  # drop lowest-priority fact (tail of sorted list)
+            if not trimmed:
+                break  # no facts left — skip entity entirely
+            block = _render_for_estimate(ent, trimmed)
+            cost = _estimate_tokens(block)
+            if used + cost <= budget:
+                result.append((ent, trimmed))
+                used += cost
+                break
 
     # hard check: if fact text alone exceeds budget, no trimming can help → raise
     if not result and ordered:

--- a/src/auto_lorebook/linked_budget.py
+++ b/src/auto_lorebook/linked_budget.py
@@ -1,0 +1,150 @@
+"""Linked-context token budgeter for Stage 4."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from auto_lorebook.entities import EntityRow
+    from auto_lorebook.facts import FactRow
+
+_logger = logging.getLogger(__name__)
+
+LinkedContext = list[tuple["EntityRow", list["FactRow"]]]
+
+# priority order: shared > non-shared authoritative > non-shared trustworthy;
+# drop non-shared hearsay before disproven (both non-shared)
+_STATUS_PRIORITY: dict[str, int] = {
+    "authoritative": 1,
+    "trustworthy": 2,
+    "hearsay": 3,
+    "disproven": 4,
+}
+
+
+class LinkedContextTooLargeError(RuntimeError):
+    """Linked context exceeds the configured token budget even after trimming."""
+
+
+def _shared_fact_count(facts: list[FactRow], subject_fact_ids: set[str]) -> int:
+    """Count facts whose id is in subject_fact_ids."""
+    return sum(1 for f in facts if f.id in subject_fact_ids)
+
+
+def _rank_entities(
+    linked_facts: LinkedContext,
+    subject_fact_ids: set[str],
+) -> LinkedContext:
+    """Sort entities by shared-fact count desc, then (category, slug) asc."""
+    return sorted(
+        linked_facts,
+        key=lambda item: (
+            -_shared_fact_count(item[1], subject_fact_ids),
+            item[0].category,
+            item[0].slug,
+        ),
+    )
+
+
+def _sort_facts(facts: list[FactRow], subject_fact_ids: set[str]) -> list[FactRow]:
+    """Sort facts: shared first, then by status priority asc."""
+    return sorted(
+        facts,
+        key=lambda f: (
+            0 if f.id in subject_fact_ids else 1,
+            _STATUS_PRIORITY.get(f.status, 3),
+        ),
+    )
+
+
+def _render_for_estimate(entity: EntityRow, facts: list[FactRow]) -> str:
+    """Render linked-entity block for token estimation.
+
+    Must mirror the linked block rendering in stage4.build_prompt.
+    """
+    lines: list[str] = []
+    name = entity.canonical_name
+    cat_slug = f"{entity.category}/{entity.slug}"
+    lines.append(f"\n{name} ({cat_slug}):")
+    by_status: dict[str, list[FactRow]] = {}
+    for fact in facts:
+        by_status.setdefault(fact.status, []).append(fact)
+    for status, bucket in sorted(by_status.items()):
+        lines.append(f"  {status.upper()}:")
+        for fact in bucket:
+            reason = f" [reason: {fact.status_reason}]" if fact.status_reason else ""
+            speaker = f" (speaker: {fact.speaker})" if fact.speaker else ""
+            lines.append(f"    - [{fact.id}] {fact.text}{speaker}{reason}")
+    return "\n".join(lines)
+
+
+def _estimate_tokens(text: str) -> int:
+    """Approximate token count; matches preamble.check_budget heuristic."""
+    return len(text) // 4
+
+
+def budget_linked_context(
+    linked_facts: LinkedContext,
+    subject_fact_ids: set[str],
+    *,
+    context_window: int,
+    budget_fraction: float,
+    max_linked_entities: int | None = None,
+) -> LinkedContext:
+    """Cap linked context to token budget.
+
+    Priority: shared facts first, then non-shared by status (authoritative,
+    trustworthy, hearsay, disproven). Entities ranked by shared-fact count
+    desc, tie-break (category, slug) asc. Greedily includes entities until
+    budget exhausted. Raises LinkedContextTooLargeError when no trimming
+    can satisfy the budget.
+
+    :param linked_facts: (entity, facts) pairs for linked entities
+    :param subject_fact_ids: fact ids belonging to the subject entity
+    :param context_window: model context window in tokens
+    :param budget_fraction: fraction of context_window for linked block
+    :param max_linked_entities: hard cap on entity count (None = unlimited)
+    """
+    if not linked_facts:
+        return []
+
+    budget = int(context_window * budget_fraction)
+
+    # rank entities nearest-first
+    ranked = _rank_entities(linked_facts, subject_fact_ids)
+
+    # apply entity-count cap before token budgeting
+    if max_linked_entities is not None:
+        ranked = ranked[:max_linked_entities]
+
+    # for each entity, sort facts by priority
+    ordered: LinkedContext = [
+        (ent, _sort_facts(facts, subject_fact_ids)) for ent, facts in ranked
+    ]
+
+    # greedy token budget: include entities in rank order until budget exceeded
+    result: LinkedContext = []
+    used = 0
+    for ent, facts in ordered:
+        block = _render_for_estimate(ent, facts)
+        cost = _estimate_tokens(block)
+        if used + cost <= budget:
+            result.append((ent, facts))
+            used += cost
+        # else: skip this entity — over budget
+
+    # hard check: if fact text alone exceeds budget, no trimming can help → raise
+    if not result and ordered:
+        first_ent, first_facts = ordered[0]
+        if first_facts:
+            # minimal unit = the fact with highest priority; check text tokens only
+            min_fact = first_facts[0]
+            if _estimate_tokens(min_fact.text) > budget:
+                msg = (
+                    f"Linked context for {first_ent.category}/{first_ent.slug} "
+                    f"exceeds token budget ({budget}) even after trimming."
+                )
+                raise LinkedContextTooLargeError(msg)
+
+    return result

--- a/src/auto_lorebook/page_step.py
+++ b/src/auto_lorebook/page_step.py
@@ -16,6 +16,10 @@ from typing import TYPE_CHECKING
 from auto_lorebook import entities as entities_mod
 from auto_lorebook import facts as facts_mod
 from auto_lorebook import stage4 as stage4_mod
+from auto_lorebook.linked_budget import (
+    LinkedContextTooLargeError,
+    budget_linked_context,
+)
 from auto_lorebook.regen_set import plan_regeneration_set
 
 if TYPE_CHECKING:
@@ -36,10 +40,14 @@ def run_page_step(
     wiki_setting: str = "",
     client: OpenRouterClient,
     model: str = "",
+    context_window: int = 200_000,
+    budget_fraction: float = 0.25,
 ) -> list[Path]:
     """Regenerate .md pages for touched entities and one-hop linked entities.
 
     :param touched_entities: list of (category, slug) pairs
+    :param context_window: model context window for linked-context budgeting
+    :param budget_fraction: fraction of context_window for linked context block
     :returns: list of written paths
     """
     if not touched_entities:
@@ -72,6 +80,26 @@ def run_page_step(
                 continue
             nb_facts = facts_mod.list_facts_by_entity(conn, nb_cat, nb_slug)
             linked_facts.append((nb_entity, nb_facts))
+
+        # apply token budget to linked context
+        subject_fact_ids = {
+            f.id for f in facts_mod.list_facts_by_entity(conn, category, slug)
+        }
+        try:
+            linked_facts = budget_linked_context(
+                linked_facts,
+                subject_fact_ids,
+                context_window=context_window,
+                budget_fraction=budget_fraction,
+            )
+        except LinkedContextTooLargeError as exc:
+            _logger.warning(
+                "page_step: linked context too large for %s/%s, dropping: %s",
+                category,
+                slug,
+                exc,
+            )
+            linked_facts = []
 
         try:
             path = stage4_mod.summarize_entity(

--- a/src/auto_lorebook/review.py
+++ b/src/auto_lorebook/review.py
@@ -630,6 +630,8 @@ def run(
                 wiki_setting=wiki_setting,
                 client=client,
                 model=effective_model,
+                context_window=cfg.models.primary_context_window,
+                budget_fraction=cfg.summarizer.linked_context_budget_fraction,
             )
         return result
     finally:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ from auto_lorebook.config import (
     ModelsConfig,
     OpenRouterConfig,
     PreambleConfig,
+    SummarizerConfig,
     interactive_setup,
     load_config,
     load_last_context,
@@ -544,3 +545,69 @@ def test_save_config_roundtrip(tmp_path: Path) -> None:
     assert reloaded.openrouter.api_key_env == "MY_KEY"
     assert reloaded.models.primary == "anthropic/claude-opus-4-7"
     assert reloaded.preamble.budget_fraction == pytest.approx(0.6)
+
+
+# ---------------------------------------------------------------------------
+# SummarizerConfig
+# ---------------------------------------------------------------------------
+
+
+def test_summarizer_config_default() -> None:
+    """SummarizerConfig defaults to 0.25 linked_context_budget_fraction."""
+    cfg = SummarizerConfig()
+    assert cfg.linked_context_budget_fraction == pytest.approx(0.25)
+
+
+def test_config_has_summarizer_field() -> None:
+    """Config has summarizer field defaulting to SummarizerConfig()."""
+    cfg = Config(wikis=[], active_wiki=None)
+    assert isinstance(cfg.summarizer, SummarizerConfig)
+    assert cfg.summarizer.linked_context_budget_fraction == pytest.approx(0.25)
+
+
+def test_load_config_summarizer_from_yaml(tmp_path: Path) -> None:
+    """summarizer.linked_context_budget_fraction loaded from YAML."""
+    wiki_path = str(tmp_path / "wiki")
+    _write_config(
+        tmp_path / "config.yaml",
+        {
+            "schema_version": 2,
+            "wikis": [{"nickname": "main", "path": wiki_path}],
+            "active_wiki": "main",
+            "summarizer": {"linked_context_budget_fraction": 0.15},
+        },
+    )
+    cfg = load_config(home=tmp_path)
+    assert cfg.summarizer.linked_context_budget_fraction == pytest.approx(0.15)
+
+
+def test_load_config_summarizer_defaults_when_absent(tmp_path: Path) -> None:
+    """Missing summarizer block defaults to SummarizerConfig()."""
+    wiki_path = str(tmp_path / "wiki")
+    _write_config(
+        tmp_path / "config.yaml",
+        {
+            "schema_version": 2,
+            "wikis": [{"nickname": "main", "path": wiki_path}],
+            "active_wiki": "main",
+        },
+    )
+    cfg = load_config(home=tmp_path)
+    assert cfg.summarizer.linked_context_budget_fraction == pytest.approx(0.25)
+
+
+def test_save_config_writes_summarizer_block(tmp_path: Path) -> None:
+    """save_config writes summarizer section; round-trip preserves value."""
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    cfg = Config(
+        wikis=[WikiEntry("main", wiki)],
+        active_wiki="main",
+        summarizer=SummarizerConfig(linked_context_budget_fraction=0.3),
+    )
+    save_config(cfg, home=tmp_path)
+    raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+    assert raw["summarizer"]["linked_context_budget_fraction"] == pytest.approx(0.3)
+
+    reloaded = load_config(home=tmp_path)
+    assert reloaded.summarizer.linked_context_budget_fraction == pytest.approx(0.3)

--- a/tests/test_linked_budget.py
+++ b/tests/test_linked_budget.py
@@ -110,20 +110,21 @@ def test_shared_facts_kept_over_nonshared_when_tight() -> None:
     ent = _entity("theron")
     # shared fact — id in subject_fact_ids
     shared = _fact("f-shared", "Shared fact.", status="hearsay")
-    # non-shared authoritative
+    # non-shared authoritative, large enough that entity doesn't fit with both facts
     non_shared = _fact("f-own", "X" * 300, status="authoritative")
 
-    # budget just fits one fact's worth of tokens
-    # shared text is short; non_shared is long; tight budget keeps shared
+    # budget=75: both facts ≈100 tokens (doesn't fit);
+    # shared-only ≈17 tokens (fits) → fact-level trim keeps shared, drops non-shared
     result = budget_linked_context(
         [(ent, [non_shared, shared])],
         subject_fact_ids={"f-shared"},
-        context_window=40,  # very small
+        context_window=300,
         budget_fraction=0.25,
     )
-    if result:
-        included_ids = {f.id for f in result[0][1]}
-        assert "f-shared" in included_ids
+    assert result, "entity should fit after dropping low-priority non-shared fact"
+    included_ids = {f.id for f in result[0][1]}
+    assert "f-shared" in included_ids
+    assert "f-own" not in included_ids
 
 
 def test_hearsay_dropped_before_authoritative() -> None:
@@ -144,6 +145,27 @@ def test_hearsay_dropped_before_authoritative() -> None:
     assert "f-hearsay" in ids
 
 
+def test_hearsay_dropped_before_authoritative_tight() -> None:
+    """Tight budget: hearsay dropped, authoritative kept within same entity."""
+    ent = _entity("theron")
+    # auth is short; hearsay is long; together they exceed the budget
+    auth_fact = _fact("f-auth", "Authoritative fact.", status="authoritative")
+    hearsay_fact = _fact("f-hearsay", "H" * 300, status="hearsay")
+
+    # entity with both ≈ 90+ tokens; auth-only ≈ 20 tokens
+    # budget=50 → auth-only fits, combined doesn't
+    result = budget_linked_context(
+        [(ent, [hearsay_fact, auth_fact])],
+        subject_fact_ids=set(),
+        context_window=200,
+        budget_fraction=0.25,
+    )
+    assert result, "entity should fit after dropping hearsay"
+    ids = {f.id for f in result[0][1]}
+    assert "f-auth" in ids
+    assert "f-hearsay" not in ids
+
+
 def test_disproven_dropped_before_hearsay() -> None:
     """Disproven dropped before hearsay in trim order."""
     ent = _entity("theron")
@@ -162,23 +184,46 @@ def test_disproven_dropped_before_hearsay() -> None:
     assert "f-disproven" in ids
 
 
-def test_nonshared_disproven_dropped_first() -> None:
-    """Non-shared disproven dropped before non-shared hearsay."""
+def test_disproven_dropped_before_hearsay_tight() -> None:
+    """Tight budget: disproven dropped, hearsay kept within same entity."""
     ent = _entity("theron")
-    # two long facts; budget only fits one
-    disproven = _fact("f-disproven", "D" * 400, status="disproven")
-    hearsay = _fact("f-hearsay", "H" * 400, status="hearsay")
+    # both long; together they exceed the budget; disproven has lower priority
+    hearsay = _fact("f-hearsay", "H" * 300, status="hearsay")
+    disproven = _fact("f-disproven", "D" * 300, status="disproven")
 
+    # entity with both ≈ 175 tokens; hearsay-only ≈ 85 tokens
+    # budget=100 → hearsay-only fits, combined doesn't
     result = budget_linked_context(
         [(ent, [disproven, hearsay])],
         subject_fact_ids=set(),
-        context_window=400,  # fits roughly one fact
+        context_window=400,
         budget_fraction=0.25,
     )
-    if result:
-        included_ids = {f.id for f in result[0][1]}
-        # hearsay kept over disproven
-        assert "f-disproven" not in included_ids or "f-hearsay" in included_ids
+    assert result, "entity should fit after dropping disproven"
+    ids = {f.id for f in result[0][1]}
+    assert "f-hearsay" in ids
+    assert "f-disproven" not in ids
+
+
+def test_nonshared_disproven_dropped_first() -> None:
+    """Non-shared disproven dropped before non-shared hearsay."""
+    ent = _entity("theron")
+    # two long facts; budget fits one but not both
+    disproven = _fact("f-disproven", "D" * 400, status="disproven")
+    hearsay = _fact("f-hearsay", "H" * 400, status="hearsay")
+
+    # entity with both ≈ 223 tokens; hearsay-only ≈ 114 tokens
+    # budget=150 → hearsay-only fits, combined doesn't
+    result = budget_linked_context(
+        [(ent, [disproven, hearsay])],
+        subject_fact_ids=set(),
+        context_window=600,
+        budget_fraction=0.25,
+    )
+    assert result, "entity should fit after dropping disproven"
+    included_ids = {f.id for f in result[0][1]}
+    assert "f-hearsay" in included_ids
+    assert "f-disproven" not in included_ids
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_linked_budget.py
+++ b/tests/test_linked_budget.py
@@ -1,0 +1,333 @@
+"""Tests for linked_budget.py — pure-function linked-context budgeter."""
+
+from __future__ import annotations
+
+import pytest
+
+from auto_lorebook.entities import EntityRow
+from auto_lorebook.facts import FactRow
+from auto_lorebook.linked_budget import (
+    LinkedContextTooLargeError,
+    budget_linked_context,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _entity(slug: str, category: str = "characters") -> EntityRow:
+    return EntityRow(
+        category=category,
+        slug=slug,
+        canonical_name=slug.capitalize(),
+        superseded_by_category=None,
+        superseded_by_slug=None,
+        created_at="2026-01-01T00:00:00Z",
+        created_by_ingest="ing-001",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+
+
+def _fact(
+    fact_id: str,
+    text: str = "Some fact.",
+    status: str = "authoritative",
+) -> FactRow:
+    return FactRow(
+        id=fact_id,
+        text=text,
+        raw_transcript_span="raw",
+        text_corrects_transcript=False,
+        text_source=None,
+        edited_by_human=False,
+        edited_at=None,
+        source_id="src-001",
+        locator="0:01:00",
+        speaker=None,
+        status=status,
+        status_reason=None,
+        session_date=None,
+        approved_at="2026-01-01T00:00:00Z",
+        created_by_ingest="ing-001",
+        claim_group_id=None,
+        corrections_applied=[],
+        inputs_json=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_empty() -> None:
+    result = budget_linked_context(
+        [],
+        subject_fact_ids=set(),
+        context_window=10_000,
+        budget_fraction=0.25,
+    )
+    assert result == []
+
+
+def test_under_budget_unchanged() -> None:
+    ent = _entity("theron")
+    fact = _fact("f-001", "Short fact.")
+    linked = [(ent, [fact])]
+    result = budget_linked_context(
+        linked,
+        subject_fact_ids=set(),
+        context_window=100_000,
+        budget_fraction=0.25,
+    )
+    assert len(result) == 1
+    assert result[0][0].slug == "theron"
+    # fact list preserved
+    assert result[0][1] == [fact]
+
+
+def test_under_budget_all_facts_included() -> None:
+    """All facts of an entity retained when within budget."""
+    ent = _entity("theron")
+    facts = [_fact(f"f-{i:03d}", f"Fact {i}.") for i in range(5)]
+    result = budget_linked_context(
+        [(ent, facts)],
+        subject_fact_ids=set(),
+        context_window=100_000,
+        budget_fraction=0.25,
+    )
+    assert result[0][1] == facts
+
+
+# ---------------------------------------------------------------------------
+# Fact ordering within an entity: shared first, then by status
+# ---------------------------------------------------------------------------
+
+
+def test_shared_facts_kept_over_nonshared_when_tight() -> None:
+    """When budget is tight, shared fact kept over non-shared authoritative."""
+    ent = _entity("theron")
+    # shared fact — id in subject_fact_ids
+    shared = _fact("f-shared", "Shared fact.", status="hearsay")
+    # non-shared authoritative
+    non_shared = _fact("f-own", "X" * 300, status="authoritative")
+
+    # budget just fits one fact's worth of tokens
+    # shared text is short; non_shared is long; tight budget keeps shared
+    result = budget_linked_context(
+        [(ent, [non_shared, shared])],
+        subject_fact_ids={"f-shared"},
+        context_window=40,  # very small
+        budget_fraction=0.25,
+    )
+    if result:
+        included_ids = {f.id for f in result[0][1]}
+        assert "f-shared" in included_ids
+
+
+def test_hearsay_dropped_before_authoritative() -> None:
+    """Hearsay dropped before authoritative when budget is tight."""
+    ent = _entity("theron")
+    auth_fact = _fact("f-auth", "Authoritative fact.", status="authoritative")
+    hearsay_fact = _fact("f-hearsay", "Hearsay fact.", status="hearsay")
+
+    # large budget — both included
+    result = budget_linked_context(
+        [(ent, [auth_fact, hearsay_fact])],
+        subject_fact_ids=set(),
+        context_window=100_000,
+        budget_fraction=0.25,
+    )
+    ids = {f.id for f in result[0][1]}
+    assert "f-auth" in ids
+    assert "f-hearsay" in ids
+
+
+def test_disproven_dropped_before_hearsay() -> None:
+    """Disproven dropped before hearsay in trim order."""
+    ent = _entity("theron")
+    hearsay = _fact("f-hearsay", "Hearsay fact.", status="hearsay")
+    disproven = _fact("f-disproven", "Disproven fact.", status="disproven")
+
+    # under normal budget: both present
+    result = budget_linked_context(
+        [(ent, [hearsay, disproven])],
+        subject_fact_ids=set(),
+        context_window=100_000,
+        budget_fraction=0.25,
+    )
+    ids = {f.id for f in result[0][1]}
+    assert "f-hearsay" in ids
+    assert "f-disproven" in ids
+
+
+def test_nonshared_disproven_dropped_first() -> None:
+    """Non-shared disproven dropped before non-shared hearsay."""
+    ent = _entity("theron")
+    # two long facts; budget only fits one
+    disproven = _fact("f-disproven", "D" * 400, status="disproven")
+    hearsay = _fact("f-hearsay", "H" * 400, status="hearsay")
+
+    result = budget_linked_context(
+        [(ent, [disproven, hearsay])],
+        subject_fact_ids=set(),
+        context_window=400,  # fits roughly one fact
+        budget_fraction=0.25,
+    )
+    if result:
+        included_ids = {f.id for f in result[0][1]}
+        # hearsay kept over disproven
+        assert "f-disproven" not in included_ids or "f-hearsay" in included_ids
+
+
+# ---------------------------------------------------------------------------
+# Entity-count cap (max_linked_entities)
+# ---------------------------------------------------------------------------
+
+
+def test_entity_count_cap_limits_entities() -> None:
+    entities = [
+        (_entity(f"ent{i}"), [_fact(f"f-{i:03d}", f"Fact {i}.")]) for i in range(5)
+    ]
+    result = budget_linked_context(
+        entities,
+        subject_fact_ids=set(),
+        context_window=100_000,
+        budget_fraction=0.25,
+        max_linked_entities=3,
+    )
+    assert len(result) <= 3
+
+
+def test_entity_count_cap_keeps_nearest_first_by_shared_fact_count() -> None:
+    """Entities with more shared facts ranked first; cap keeps them."""
+    # ent_a: 0 shared facts
+    ent_a = _entity("ent_a")
+    facts_a = [_fact("f-a1", "A fact.")]
+
+    # ent_b: 2 shared facts
+    ent_b = _entity("ent_b")
+    facts_b = [_fact("f-b1", "B fact 1."), _fact("f-b2", "B fact 2.")]
+
+    # ent_c: 1 shared fact
+    ent_c = _entity("ent_c")
+    facts_c = [_fact("f-c1", "C fact.")]
+
+    subject_fact_ids = {"f-b1", "f-b2", "f-c1"}
+    result = budget_linked_context(
+        [(ent_a, facts_a), (ent_b, facts_b), (ent_c, facts_c)],
+        subject_fact_ids=subject_fact_ids,
+        context_window=100_000,
+        budget_fraction=0.25,
+        max_linked_entities=2,
+    )
+    slugs = [r[0].slug for r in result]
+    # ent_b (2 shared) and ent_c (1 shared) should be kept; ent_a (0) dropped
+    assert "ent_b" in slugs
+    assert "ent_c" in slugs
+    assert "ent_a" not in slugs
+
+
+def test_entity_count_cap_tiebreak_by_category_slug() -> None:
+    """Tie on shared-fact count: sort by (category, slug) asc."""
+    ent_z = _entity("zzz", category="characters")
+    ent_a = _entity("aaa", category="characters")
+    facts_z = [_fact("f-z1", "Z fact.")]
+    facts_a = [_fact("f-a1", "A fact.")]
+
+    # both 0 shared facts; tiebreak on slug
+    result = budget_linked_context(
+        [(ent_z, facts_z), (ent_a, facts_a)],
+        subject_fact_ids=set(),
+        context_window=100_000,
+        budget_fraction=0.25,
+        max_linked_entities=1,
+    )
+    assert len(result) == 1
+    assert result[0][0].slug == "aaa"
+
+
+# ---------------------------------------------------------------------------
+# Token-budget boundary
+# ---------------------------------------------------------------------------
+
+
+def test_at_budget_boundary_entity_kept() -> None:
+    """Entity exactly at budget kept."""
+    ent = _entity("theron")
+    # fact text of exactly N chars; budget = context_window * fraction
+    # token estimate = len(text) // 4
+    text = "A" * 40  # 40 chars → 10 tokens
+    fact = _fact("f-001", text)
+
+    # budget = 100 * 0.25 = 25 tokens; 10 tokens fits
+    result = budget_linked_context(
+        [(ent, [fact])],
+        subject_fact_ids=set(),
+        context_window=100,
+        budget_fraction=0.25,
+    )
+    assert len(result) == 1
+
+
+def test_one_over_budget_trims_entity() -> None:
+    """Entity whose addition would push over budget is dropped."""
+    ent_a = _entity("ent_a")
+    ent_b = _entity("ent_b")
+
+    # large facts — budget just fits one
+    long_text = "X" * 2000
+    facts_a = [_fact("f-a1", long_text)]
+    facts_b = [_fact("f-b1", long_text)]
+
+    result = budget_linked_context(
+        [(ent_a, facts_a), (ent_b, facts_b)],
+        subject_fact_ids=set(),
+        context_window=2000,
+        budget_fraction=0.25,
+    )
+    # budget = 2000 * 0.25 = 500 tokens; one entity of 500 tokens fits, second doesn't
+    assert len(result) <= 1
+
+
+def test_raises_when_minimal_block_over_budget() -> None:
+    """LinkedContextTooLargeError when even smallest possible block exceeds budget."""
+    ent = _entity("theron")
+    # massive fact, tiny budget
+    huge_text = "Z" * 100_000
+    fact = _fact("f-001", huge_text)
+
+    with pytest.raises(LinkedContextTooLargeError):
+        budget_linked_context(
+            [(ent, [fact])],
+            subject_fact_ids=set(),
+            context_window=100,
+            budget_fraction=0.01,
+        )
+
+
+def test_token_estimate_uses_len_div_4() -> None:
+    """Token estimate is len(rendered_text) // 4, consistent with preamble heuristic."""
+    ent = _entity("theron")
+    # 400 chars → 100 tokens
+    text = "T" * 400
+    fact = _fact("f-001", text)
+
+    # budget = 1000 * 0.25 = 250 tokens; 100 tokens fits
+    result = budget_linked_context(
+        [(ent, [fact])],
+        subject_fact_ids=set(),
+        context_window=1000,
+        budget_fraction=0.25,
+    )
+    assert len(result) == 1
+
+    # budget = 200 * 0.1 = 20 tokens; 100 tokens exceeds → raises
+    with pytest.raises(LinkedContextTooLargeError):
+        budget_linked_context(
+            [(ent, [fact])],
+            subject_fact_ids=set(),
+            context_window=200,
+            budget_fraction=0.1,
+        )

--- a/tests/test_review_cmd.py
+++ b/tests/test_review_cmd.py
@@ -400,6 +400,8 @@ class TestReviewWritesLLMProse:
             wiki_setting: str = "",  # noqa: ARG001
             client: object,
             model: str = "",  # noqa: ARG001
+            context_window: int = 200_000,  # noqa: ARG001
+            budget_fraction: float = 0.25,  # noqa: ARG001
         ) -> list[object]:
             from pathlib import Path as _Path  # noqa: PLC0415
 

--- a/tests/test_stage4.py
+++ b/tests/test_stage4.py
@@ -698,3 +698,86 @@ class TestBuildPromptLinkedFacts:
         user_content = " ".join(m["content"] for m in messages if m["role"] == "user")
         assert "Aldara is an ancient city." in user_content
         assert result.prose == "Theron founded Aldara."
+
+
+# ---------------------------------------------------------------------------
+# page_step.run_page_step — linked-context budgeting
+# ---------------------------------------------------------------------------
+
+
+class TestRunPageStepBudget:
+    def _seed_with_linked(self, conn: sqlite3.Connection) -> None:
+        """Add aldara entity sharing a fact with theron."""
+        conn.execute(
+            "INSERT INTO entities(category, slug, canonical_name, created_at,"
+            " created_by_ingest, updated_at)"
+            " VALUES ('locations', 'aldara', 'Aldara',"
+            " '2026-01-01T00:00:00Z', 'ing-001', '2026-01-01T00:00:00Z')"
+        )
+        create_fact_with_targets(
+            conn,
+            fact_id="f-shared",
+            text="Theron founded Aldara.",
+            raw_transcript_span="raw",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:04:32",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            targets=[
+                ("characters", "theron", "biography"),
+                ("locations", "aldara", "founding"),
+            ],
+            by="tester",
+        )
+        conn.commit()
+
+    def test_page_step_caps_linked_context(self, tmp_path: Path) -> None:
+        """run_page_step applies budget_linked_context; large budget passes facts."""
+        conn = _seed_conn()
+        self._seed_with_linked(conn)
+
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Generated prose."}')
+
+        # large budget → linked facts included; LLM called with linked context
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            context_window=200_000,
+            budget_fraction=0.25,
+        )
+        # LLM should have been called (theron has shared fact)
+        assert client.complete.called
+
+    def test_page_step_degrades_on_over_budget(self, tmp_path: Path) -> None:
+        """When linked context too large, page step still summarizes own facts."""
+        conn = _seed_conn()
+        self._seed_with_linked(conn)
+
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Generated prose."}')
+
+        # budget so tiny that fact text ("Theron founded Aldara." = 22 chars → 5 tokens)
+        # exceeds budget → LinkedContextTooLargeError → degrade to empty linked context
+        paths = run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            context_window=4,  # budget = 4 * 0.25 = 1 token; fact text → 5 tokens
+            budget_fraction=0.25,
+        )
+        # entity still summarized even when linked context dropped
+        theron_path = tmp_path / "characters" / "theron.md"
+        assert theron_path in paths
+        assert theron_path.exists()


### PR DESCRIPTION
## What this fixes

Issue #87 adds a token budgeter for the Stage 4 linked-context block so a hub entity with many linked entities does not overflow the model's context window. New module `src/auto_lorebook/linked_budget.py` (`budget_linked_context`):

- Ranks linked entities nearest-first by shared-fact count, ties by `(category, slug)`; applies the `max_linked_entities` count cap first.
- Greedily includes entities by token budget; when an entity does not fit, fact-level trimming pops the lowest-priority facts from the tail — priority shared > authoritative > trustworthy > hearsay > disproven, so disproven is dropped first, then hearsay.
- Raises `LinkedContextTooLargeError` when even the minimal unit exceeds budget; `page_step` catches it and degrades to summarizing the entity from its own facts.
- New config key `summarizer.linked_context_budget_fraction` (default 0.25).

Wired into `page_step.py` prompt assembly. `docs/pipeline/summarizer.md` reconciled.

## QA steps for the human

None required — the integration smoke drove `budget_linked_context` live across 7 scenarios (budget cap, nearest-first ranking, entity-count cap, fact-trim order, exact token boundary, `LinkedContextTooLargeError`) and confirmed `page_step.run_page_step` invokes it on the prompt-assembly path with graceful degradation.

## Automated coverage

`ruff check`, `ruff format --check`, `ty check`, `pytest` (953 passed, 5 skipped), `mkdocs build --strict` — all green. Plus a live integration smoke.

Note: base branch is the Stage 4 integration branch `claude/parallel-issue-workflow-XpHwB`.

Closes #87

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5pePA6v63c6JKm5rUPyct)_