### PR TITLE
Stage 4: LLM-prose entity pages with cross-linked-entity propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ src/*/_version.py
 
 # MkDocs build output
 site/
+
+# Agent worktree scratch space
+.claude/worktrees/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,12 @@ A per-route prompt, shown after a route is approved, asking whether a planner-su
 **Ingest**:
 One end-to-end run from source to approved facts, possibly partial. Every entity and alias records the ingest that created it.
 
+### Summarizer-stage terms
+
+**Linked entity**:
+Entity sharing at least one fact with a given entity via `fact_targets`. Symmetric relation. A summary regeneration of an entity propagates to its linked entities.
+_Avoid_: connected entity, related entity, neighbour.
+
 ## Relationships
 
 - A **Reading** produces zero or more **Plans** (one per replan).
@@ -71,6 +77,7 @@ One end-to-end run from source to approved facts, possibly partial. Every entity
 - Extraction emits one **Proposal** per **Route**.
 - A **Bundle** is one **Claim group** as presented during review.
 - Approving a **Bundle** creates one **Fact** plus one **Fact target** per approved route.
+- Two entities are **linked** when a **Fact** targets both; regenerating one entity's summary propagates to its **linked entities**.
 
 ## Example dialogue
 

--- a/docs/adr/0005-summaries-synthesize-across-linked-entities.md
+++ b/docs/adr/0005-summaries-synthesize-across-linked-entities.md
@@ -1,0 +1,30 @@
+# Entity summaries synthesize across linked entities
+
+Stage 4 generates an entity's summary prose with an LLM that receives,
+alongside the entity's own facts, the facts of every *linked* entity —
+any entity co-targeted by a shared fact. The summary prose may
+therefore state and cite a claim drawn from a linked entity's facts
+even though that fact does not target this entity, so a new fact on one
+entity propagates to re-summarize its linked entities (one hop).
+
+## Considered Options
+
+- **Self-only.** Each summary uses only its own entity's facts.
+  Rejected: cross-entity context is impossible, and a neighbour's page
+  goes silently stale once a relevant fact lands on a linked entity.
+- **Pulled-in facts.** An entity page renders the facts of its linked
+  entities directly. Rejected: redefines "entity page = its own
+  approved facts", double-counts facts across pages, and bloats every
+  page with its neighbourhood.
+
+## Consequences
+
+- The `## Facts` section still lists only the entity's own
+  `fact_targets`. A summary sentence drawn from a linked fact renders a
+  cross-reference footnote pointing at the linked entity's page
+  (anchored to that fact), not a duplicated citation.
+- The entity-page staleness hash must include linked entities' facts,
+  not just the entity's own — see `docs/architecture/staleness.md`.
+- One new fact on a well-connected hub entity can force LLM
+  re-summarization of every linked entity. Propagation is capped at one
+  hop (no transitive cascade) to bound this cost.

--- a/docs/adr/0005-summaries-synthesize-across-linked-entities.md
+++ b/docs/adr/0005-summaries-synthesize-across-linked-entities.md
@@ -28,3 +28,8 @@ entity propagates to re-summarize its linked entities (one hop).
 - One new fact on a well-connected hub entity can force LLM
   re-summarization of every linked entity. Propagation is capped at one
   hop (no transitive cascade) to bound this cost.
+- A second cost bound is the linked-context token budgeter: the
+  linked-entities block in each prompt is capped to a configurable
+  fraction of the context window (`summarizer.linked_context_budget_fraction`,
+  default 0.25), keeping entities with more shared facts and dropping
+  low-priority facts first.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -65,8 +65,10 @@ YouTube URL / SRT / text file
   facts and entities enter the wiki. First approval of a claim
   targeting a new entity creates the entity stub atomically.
 - **[Stage 4: Summarizer](../pipeline/summarizer.md)** — regenerates
-  readable entity prose from approved facts. The YAML is truth; the
-  markdown is a view.
+  readable entity prose from approved facts. Propagates one hop to
+  linked entities (co-targets via `fact_targets`); each entity's prompt
+  includes linked-entity facts for cross-entity synthesis (B2 content model).
+  The YAML is truth; the markdown is a view.
 
 ## Two gates, not three
 

--- a/docs/architecture/repository-layout.md
+++ b/docs/architecture/repository-layout.md
@@ -92,6 +92,8 @@ models:
   primary_context_window: 200000
 preamble:
   budget_fraction: 0.8
+summarizer:
+  linked_context_budget_fraction: 0.25
 ```
 
 The registry is the single source of truth for which wikis the tool

--- a/docs/architecture/schema-versioning.md
+++ b/docs/architecture/schema-versioning.md
@@ -13,7 +13,7 @@ SELECT version FROM schema_version;  -- e.g. 1
 ```
 
 This is the authoritative version for the relational schema. It covers
-all 16 tables that store entities, facts, ingests, proposals, and related
+all 17 tables that store entities, facts, ingests, proposals, and related
 metadata.
 
 ### Versioning rules

--- a/docs/architecture/staleness.md
+++ b/docs/architecture/staleness.md
@@ -49,7 +49,7 @@ whether it is an alias is what matters to downstream stages.
 | `reading.md` (approved) | same as draft (but staleness is a warning, not a blocker — see below) |
 | `plan.yaml` | approved `reading.md`, `.wiki-context.yaml`, entity index, model, model params |
 | `proposals/*.yaml` | `plan.yaml`, approved `reading.md`, transcript, `.transcription-corrections.yaml`, model, model params |
-| entity `.md` (summary) | entity YAML, entity index |
+| entity `.md` (summary) | entity's own facts, linked entities' facts, entity index, `.wiki-context.yaml` setting, model, model params |
 
 The preamble hash is derived from several of these inputs; it's
 recorded for debugging but the individual input hashes determine
@@ -128,9 +128,12 @@ command uses staleness of an approved fact to gate behavior.
   stages.
 - `reject-ingest` is unaffected — it works by `created_by_ingest`,
   independent of hashes.
-- `wiki rebuild` optimizes: it skips regeneration for entity `.md`
-  files whose recorded inputs match the current entity YAML and
-  index. `wiki rebuild --force` regenerates unconditionally.
+- `wiki rebuild` skips regeneration for entity `.md` files whose
+  recorded inputs hash (stored in `entity_page_staleness` keyed by
+  `(category, slug)`) matches the current inputs. Inputs are: entity's
+  own facts, linked entities' facts, entity index, `.wiki-context.yaml`
+  setting, model, model params. `wiki rebuild --force` regenerates
+  unconditionally. Hashes are stored only in the DB, not in `.md` files.
 - `replan` preserves approved proposals as facts in entity YAMLs,
   with their original `inputs` snapshots intact. Re-planning does not
   retroactively "update" historical facts to reflect the new input

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -81,6 +81,7 @@ auto-lorebook wiki use <path> --name <nickname>   # register with explicit nickn
 auto-lorebook wiki add <nickname> <path>          # register without switching
 auto-lorebook wiki remove <nickname>    # deregister; refuses if active
 auto-lorebook wiki rename <old> <new>
+auto-lorebook wiki rebuild              # regenerate all pages; delete orphans
 ```
 
 Per-invocation override on any subcommand:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -69,6 +69,8 @@ models:
   primary_context_window: 200000
 preamble:
   budget_fraction: 0.8
+summarizer:
+  linked_context_budget_fraction: 0.25
 ```
 
 ## Switching and adding wikis

--- a/docs/pipeline/review.md
+++ b/docs/pipeline/review.md
@@ -141,9 +141,10 @@ seeds its dedup set from on-disk alias records whose
   transaction. Confirmed aliases are written to `aliases` inside the
   same transaction — a mid-tx failure rolls back both the fact and the
   aliases. Declined aliases produce zero DB writes. Entity rows are
-  created if new. After commit, `<category>/<slug>.md` is regenerated
-  for each target. Unchecked routes are dropped before the insert —
-  they never reach `facts`.
+  created if new. Each approved target is recorded in the session's
+  touched-entity list; `.md` files are written in a batch at session
+  completion (see below). Unchecked routes are dropped before the
+  insert — they never reach `facts`.
 - **Edit** — bundle-level edits to `text`, `status`, and
   `status_reason` propagate to every checked route. Per-target
   `section` / `speaker` overrides are set in `[t]argets`. Tracks
@@ -184,6 +185,16 @@ Two recovery invariants cover partial runs:
 
 See also [ADR 0001](../adr/0001-plan-canonicality.md) for the decision
 rationale.
+
+## Batched page generation
+
+After all bundles are approved or rejected, the review session runs a
+single **page step** that regenerates `.md` files for every entity that
+received at least one approved fact. LLM prose is generated via Stage 4
+(`stage4.summarize_entity`). If the session is interrupted (Ctrl-C),
+no `.md` files are written; resuming and completing the session
+generates them. This avoids redundant LLM calls for entities touched
+multiple times in one session.
 
 ## No skip, no defer
 

--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -118,7 +118,7 @@ default 0.25).
 1. Shared facts (fact targets both the subject entity and the linked entity).
 2. Non-shared authoritative facts.
 3. Non-shared trustworthy facts.
-4. Non-shared hearsay facts (dropped before disproven).
+4. Non-shared hearsay facts (dropped after disproven).
 5. Non-shared disproven facts (dropped first when over budget).
 
 **Entity ranking**: entities with more shared facts appear first (nearest-first);

--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -106,6 +106,39 @@ synthesize a claim drawn from a linked entity's fact, applying the same epistemi
 hedging rules as for the entity's own facts. The rendered `## Facts` section on the
 page lists only the entity's own facts.
 
+## Linked-context token budget
+
+A hub entity with many linked entities could overflow the model's context window.
+The budgeter (`linked_budget.budget_linked_context`) caps the linked-entities block
+to a configurable fraction of the context window (`summarizer.linked_context_budget_fraction`,
+default 0.25).
+
+**Priority ordering** (highest to lowest):
+
+1. Shared facts (fact targets both the subject entity and the linked entity).
+2. Non-shared authoritative facts.
+3. Non-shared trustworthy facts.
+4. Non-shared hearsay facts (dropped first when over budget).
+5. Non-shared disproven facts (dropped before hearsay).
+
+**Entity ranking**: entities with more shared facts appear first (nearest-first);
+ties broken alphabetically by `(category, slug)`. The entity-count cap
+(`max_linked_entities`) is applied before token counting.
+
+**Token estimate**: `len(rendered_block) // 4`, consistent with the preamble budget heuristic.
+
+**Degrade gracefully**: if no linked entity fits within the budget (its minimal
+single-fact block is larger than the budget), the budgeter raises
+`LinkedContextTooLargeError`. The page step catches this, logs a warning, and
+summarizes the entity from its own facts only.
+
+Configure the budget fraction in `config.yaml`:
+
+```yaml
+summarizer:
+  linked_context_budget_fraction: 0.25
+```
+
 ## Rebuild
 
 Regenerate summaries from scratch for all entities:

--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -27,34 +27,36 @@ Entity markdown file, overwritten in full on each regeneration:
 ## Summary
 
 Aldara is a kingdom founded in the Second Age by the grandfather of King
-Theron. Its ruling bloodline has remained unbroken since its founding.
-Some tavern rumors suggest the founding king was cursed by an elven
-sorceress, though this is unconfirmed.
+[Theron](../characters/theron.md). Its ruling bloodline has remained unbroken
+since its founding.[^f-n01] Some tavern rumors suggest the founding king was
+cursed by an elven sorceress, though this is unconfirmed.
 
 ## Facts
 
 ### Authoritative
 
-[^1]: "Theron's grandfather founded Aldara in the Second Age."
-[^2]: "Aldara's kings have always come from the Theron bloodline."
+[^fact-001]: "Theron's grandfather founded Aldara in the Second Age."
+[^fact-002]: "Aldara's kings have always come from the Theron bloodline."
 
 ### Hearsay
 
-[^3]: "The founding king was cursed by an elven sorceress."
+[^fact-003]: "The founding king was cursed by an elven sorceress."
 
 ### Disproven
 
-[^4]: ~~The founding king was mortal.~~ — Later shown to be half-fae.
+[^fact-004]: ~~The founding king was mortal.~~ — Later shown to be half-fae.
 
 ## References
 
 1. Worldbuilding Session 3 — https://youtube.com/watch?v=abc123
 
-[^1]: "Theron's grandfather founded Aldara in the Second Age."  — DM, [0:04:32-0:04:41](https://youtube.com/watch?v=abc123&t=272) (session: 2026-01-15)
-[^2]: "Aldara's kings have always come from the Theron bloodline."  — DM, 0:06:02 (session: 2026-01-20)
-[^3]: "The founding king was cursed by an elven sorceress."  — Innkeeper NPC, [1:23:40-1:24:15](https://youtube.com/watch?v=abc123&t=5020) (session: 2026-02-03)
-[^4]: "The founding king was mortal."  — DM, 0:08:00 (session: 2026-02-03)
+[^fact-001]: "Theron's grandfather founded Aldara in the Second Age."  — DM, [0:04:32-0:04:41](https://youtube.com/watch?v=abc123&t=272) (session: 2026-01-15)
+[^fact-002]: "Aldara's kings have always come from the Theron bloodline."  — DM, 0:06:02 (session: 2026-01-20)
+[^fact-003]: "The founding king was cursed by an elven sorceress."  — Innkeeper NPC, [1:23:40-1:24:15](https://youtube.com/watch?v=abc123&t=5020) (session: 2026-02-03)
+[^fact-004]: "The founding king was mortal."  — DM, 0:08:00 (session: 2026-02-03)
   *Later shown to be half-fae.*
+
+[^f-n01]: "Theron's bloodline has remained unbroken." — [Theron](../characters/theron.md#fn:f-n01)
 ```
 
 ## Summarizer rules
@@ -71,7 +73,8 @@ sorceress, though this is unconfirmed.
 - **Disproven facts** excluded from summary by default; rendered
   struck-through in their own section with the reason.
 - Every summary sentence cites fact IDs; citation labels in the
-  rendered view are footnote numbers.
+  rendered view are stable anchors derived from the fact's ID
+  (e.g. `[^fact-001]`), not positional counters.
 
 ## Model slot
 
@@ -105,6 +108,34 @@ facts of its one-hop linked entities (grouped by epistemic status). The LLM may
 synthesize a claim drawn from a linked entity's fact, applying the same epistemic-status
 hedging rules as for the entity's own facts. The rendered `## Facts` section on the
 page lists only the entity's own facts.
+
+## Cross-references and entity links
+
+The LLM may embed two kinds of inline markers in its prose output, which
+the renderer resolves before writing the page.
+
+**Entity links** — `[[category/slug]]` markers become clickable markdown
+links using the entity's canonical name. Same-category links resolve to a
+bare `slug.md` path; cross-category links resolve to `../category/slug.md`.
+If a marker cannot be found in the entity index, the renderer degrades it
+to plain `category/slug` text and logs a warning — the page is always
+written.
+
+**Cross-reference citations** — `[[fact:<id>]]` markers indicate that the
+preceding prose sentence draws on a linked entity's fact. The renderer
+replaces each marker with a footnote reference `[^<id>]` and appends a
+cross-reference footnote definition that quotes the source fact text and
+links to the linked entity's page anchored at `#fn:<id>` (Python-Markdown
+footnote convention). Only facts actually cited in prose generate crossref
+footnotes; the full linked-entity fact set is available to the LLM for
+context but does not appear unless cited. Unresolvable markers degrade to
+plain text and log a warning.
+
+Example crossref footnote in rendered output:
+
+```markdown
+[^f-n01]: "Theron's bloodline has remained unbroken." — [Theron](../characters/theron.md#fn:f-n01)
+```
 
 ## Rebuild
 

--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -1,8 +1,8 @@
 # Stage 4: Summarizer
 
-The summarizer regenerates readable summary prose for an entity from
-its approved facts. It runs after fact approvals and may batch
-regeneration at session end rather than per-fact for efficiency.
+The summarizer generates LLM-written prose for an entity from its
+approved facts. It runs once per review session after all fact
+decisions are made, batching regeneration for all touched entities.
 
 ## Purpose
 
@@ -13,9 +13,9 @@ next regeneration.
 
 ## Input
 
-- Entity YAML (all approved facts). See
-  [entity model](../architecture/entity-model.md).
-- Entity index (for alias-aware rendering of cross-references).
+- Approved facts for the entity (from the DB).
+- Entity index (for cross-reference awareness in prose).
+- Wiki setting description (from `.wiki-context.yaml`).
 
 ## Output
 
@@ -26,45 +26,35 @@ Entity markdown file, overwritten in full on each regeneration:
 
 ## Summary
 
-Aldara is a kingdom founded in the Second Age [^1][^2] by the grandfather
-of King Theron [^1]. Its ruling bloodline has remained unbroken since
-its founding [^3]. Some tavern rumors suggest the founding king was
-cursed by an elven sorceress [^4], though this is unconfirmed.
+Aldara is a kingdom founded in the Second Age by the grandfather of King
+Theron. Its ruling bloodline has remained unbroken since its founding.
+Some tavern rumors suggest the founding king was cursed by an elven
+sorceress, though this is unconfirmed.
 
 ## Facts
 
 ### Authoritative
 
-**Founding**
-
 [^1]: "Theron's grandfather founded Aldara in the Second Age."
-  — DM, [Worldbuilding Session 3, 0:04:32-0:04:41](https://youtube.com/watch?v=abc123&t=272)
-  (session: 2026-01-15)
-
-[^2]: "Scholars dispute the exact year, but the Second Age attribution is well-attested."
-  — DM, [Worldbuilding Session 3, 0:06:02-0:06:14](https://youtube.com/watch?v=abc123&t=362)
-  (session: 2026-01-15)
-
-**Government**
-
-[^3]: "Aldara's kings have always come from the Theron bloodline."
-  — DM, Campaign Notes, lines 47-48 (session: 2026-01-20)
+[^2]: "Aldara's kings have always come from the Theron bloodline."
 
 ### Hearsay
 
-[^4]: "The founding king was cursed by an elven sorceress."
-  — Innkeeper NPC, [Worldbuilding Session 3, 1:23:40-1:24:15](https://youtube.com/watch?v=abc123&t=5020)
-  (session: 2026-02-03)
-  *Told to the party by a tavern NPC, not confirmed.*
+[^3]: "The founding king was cursed by an elven sorceress."
 
 ### Disproven
 
-_(none)_
+[^4]: ~~The founding king was mortal.~~ — Later shown to be half-fae.
 
 ## References
 
 1. Worldbuilding Session 3 — https://youtube.com/watch?v=abc123
-2. Campaign Notes — sources/txt-campaign-notes/notes.txt
+
+[^1]: "Theron's grandfather founded Aldara in the Second Age."  — DM, [0:04:32-0:04:41](https://youtube.com/watch?v=abc123&t=272) (session: 2026-01-15)
+[^2]: "Aldara's kings have always come from the Theron bloodline."  — DM, 0:06:02 (session: 2026-01-20)
+[^3]: "The founding king was cursed by an elven sorceress."  — Innkeeper NPC, [1:23:40-1:24:15](https://youtube.com/watch?v=abc123&t=5020) (session: 2026-02-03)
+[^4]: "The founding king was mortal."  — DM, 0:08:00 (session: 2026-02-03)
+  *Later shown to be half-fae.*
 ```
 
 ## Summarizer rules
@@ -83,27 +73,27 @@ _(none)_
 - Every summary sentence cites fact IDs; citation labels in the
   rendered view are footnote numbers.
 
-## Section ordering and normalization
+## Model slot
 
-The summarizer reads the free-text `section` field on each fact and
-groups facts by normalized section name — case-insensitive, trimmed.
-If two facts have sections "founding" and "Founding", they group
-together under the canonical casing of whichever appears more often,
-with a tie broken by first-seen. This papers over drift without
-forcing a controlled vocabulary.
+The summarizer uses the `models.summarizer` config key if set, falling
+back to `models.primary`. Override per-session by passing a model name
+to `review`.
 
-A future enhancement may allow per-category section vocabularies in
-`.wiki-context.yaml` — see [roadmap](../roadmap/index.md).
+## Zero-fact entities
+
+Entities with no approved facts get a mechanical stub (heading + aliases
+only) with no LLM call.
+
+## Batched page step
+
+Regeneration runs once per `review` session after all fact decisions are
+made, not per approval. Interrupted review (Ctrl-C) writes no pages;
+resuming and completing the session triggers the batch.
 
 ## Rebuild
 
-Regenerate all summaries from scratch:
+Regenerate summaries from scratch for all entities:
 
 ```bash
 auto-lorebook wiki rebuild
 ```
-
-By default, `wiki rebuild` skips regeneration for entity `.md` files
-whose recorded inputs match the current entity YAML and index.
-`wiki rebuild --force` regenerates unconditionally. See
-[staleness](../architecture/staleness.md#integration-with-commands).

--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -189,5 +189,11 @@ corruption, a crashed page step, or a renamed entity.
 The wiki root and `.wiki-state/` directory are not scanned; only the
 six category subdirectories are touched.
 
-Staleness-skip (regenerate only entities whose facts changed since the
-last build) is future work.
+### Staleness-skip
+
+`wiki rebuild` skips pages whose recorded inputs hash matches. The
+hash covers: entity's own facts, linked entities' facts, entity index,
+`.wiki-context.yaml` setting description, model, and model params.
+Hashes are stored in the `entity_page_staleness` DB table (keyed by
+`(category, slug)`); they are never written to `.md` files. Use
+`wiki rebuild --force` to regenerate all pages unconditionally.

--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -118,8 +118,8 @@ default 0.25).
 1. Shared facts (fact targets both the subject entity and the linked entity).
 2. Non-shared authoritative facts.
 3. Non-shared trustworthy facts.
-4. Non-shared hearsay facts (dropped first when over budget).
-5. Non-shared disproven facts (dropped before hearsay).
+4. Non-shared hearsay facts (dropped before disproven).
+5. Non-shared disproven facts (dropped first when over budget).
 
 **Entity ranking**: entities with more shared facts appear first (nearest-first);
 ties broken alphabetically by `(category, slug)`. The entity-count cap

--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -90,6 +90,22 @@ Regeneration runs once per `review` session after all fact decisions are
 made, not per approval. Interrupted review (Ctrl-C) writes no pages;
 resuming and completing the session triggers the batch.
 
+## Linked-entity propagation
+
+When a fact is approved for entity A that co-targets entity B (via `fact_targets`),
+the page step also regenerates B's page. This is **one-hop, non-transitive**:
+only entities directly sharing a fact with a touched entity are included.
+
+The regeneration set is `touched ∪ linked(touched)`, where `linked` is the
+symmetric co-target relation. Touched entities are regenerated first, then linked
+entities (sorted by category and slug).
+
+Each entity's LLM prompt includes a **linked-entities context block** listing the
+facts of its one-hop linked entities (grouped by epistemic status). The LLM may
+synthesize a claim drawn from a linked entity's fact, applying the same epistemic-status
+hedging rules as for the entity's own facts. The rendered `## Facts` section on the
+page lists only the entity's own facts.
+
 ## Rebuild
 
 Regenerate summaries from scratch for all entities:

--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -108,8 +108,22 @@ page lists only the entity's own facts.
 
 ## Rebuild
 
-Regenerate summaries from scratch for all entities:
+Regenerate all entity pages from scratch and reconcile the filesystem
+against the DB:
 
 ```bash
 auto-lorebook wiki rebuild
 ```
+
+Every non-superseded entity page is regenerated using the page step
+(prose + linked-entity propagation logic). After regeneration, the
+command scans each entity-category subdirectory (`characters`,
+`locations`, `factions`, `events`, `items`, `concepts`) and deletes
+any `.md` file that has no matching entity in the DB — recovering from
+corruption, a crashed page step, or a renamed entity.
+
+The wiki root and `.wiki-state/` directory are not scanned; only the
+six category subdirectories are touched.
+
+Staleness-skip (regenerate only entities whose facts changed since the
+last build) is future work.

--- a/docs/pipeline/summarizer.md
+++ b/docs/pipeline/summarizer.md
@@ -93,6 +93,13 @@ Regeneration runs once per `review` session after all fact decisions are
 made, not per approval. Interrupted review (Ctrl-C) writes no pages;
 resuming and completing the session triggers the batch.
 
+`run_page_step` accepts an optional `removed_entities` list for
+reject-ingest reconciliation. Removed entities' pages are deleted before
+regeneration begins. Any entity in both `removed_entities` and
+`touched_entities` is treated as removed only — it is not re-summarized.
+If only `removed_entities` is supplied (no `touched_entities`), the page
+step still runs to delete those pages.
+
 ## Linked-entity propagation
 
 When a fact is approved for entity A that co-targets entity B (via `fact_targets`),

--- a/docs/reference/audit.md
+++ b/docs/reference/audit.md
@@ -56,11 +56,23 @@ Removes everything attributable to that ingest:
    whose `facts` list is now empty. Entities that were created by
    this ingest but have since received facts from other ingests stay
    (with the rejected facts and aliases removed).
-4. Regenerates affected summaries.
+4. Page reconciliation: the removed entities' `.md` pages are deleted
+   and linked survivors (entities that shared a fact with a now-deleted
+   entity) are re-summarized. When an API key is available the
+   re-summarization uses the LLM page step; otherwise it falls back
+   to the mechanical renderer. An entity that loses all its facts
+   but is not deleted (created by a different ingest) gets a
+   mechanical stub.
 
 This gives a clean "what did this ingest add" answer: an ingest's net
 contribution is exactly the facts tagged with its ID plus the entities
 tagged with its ID.
+
+## Replanning
+
+`replan` discards only unreviewed proposals; it never deletes approved
+facts or entity pages. Because no entity data is removed, there is
+nothing to reconcile — no page deletion or re-summarization runs.
 
 ## What the audit trail does not do
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -165,6 +165,16 @@ must already exist on disk.
 `wiki rename` renames an entry in place. If the renamed entry is active,
 `active_wiki` is updated to the new nickname.
 
+```bash
+auto-lorebook wiki rebuild
+```
+
+Regenerates every entity page from scratch using the page step (prose +
+linked-entity propagation) and reconciles the filesystem against the DB
+— deletes any `.md` file in the entity-category subdirectories with no
+matching entity. Use after corruption, a crashed page step, or a prompt
+change. Staleness-skip is future work.
+
 ### `--wiki` override flag
 
 ```bash

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -79,6 +79,11 @@ implementation status.
     without its own gate; its failure modes surface during fact review,
     with `replan` as the escape hatch.
 
+    Phase 5 slice 1 landed: Stage 4 LLM-prose summarizer. Entity `.md`
+    files are now generated with LLM prose, status-grouped facts, and
+    per-fact footnote citations. Review sessions batch page generation
+    for all touched entities on completion.
+
 ## Phase 1: Reading stage
 
 **Goal** — ingest a YouTube URL, gather context, produce a reviewable,
@@ -223,13 +228,19 @@ one sibling leaves the others intact.
 
 ## Phase 5: Summarizer
 
-**Scope**
+**Slice 1 landed:** Stage 4 LLM-prose summarizer (`stage4.py`) and
+batched page-step orchestrator (`page_step.py`). Entities with approved
+facts get LLM-generated prose plus `## Facts` grouped by epistemic
+status, per-fact footnote citations with timestamps, and `## References`.
+Zero-fact entities get a mechanical stub with no LLM call. Review
+session batches regeneration for all touched entities at completion;
+Ctrl-C leaves no partial writes. `models.summarizer` config slot added
+(falls back to `models.primary`).
 
-- Stage 4 summarizer with status-aware rendering.
+**Remaining scope**
+
 - Section normalization (case-insensitive grouping of free-text
   section names).
-- Integration with fact approval flow (batched regeneration at
-  session end).
 - `wiki rebuild` command to regenerate all summaries from scratch.
 - `promote-correction` command (with `first_seen_in` / `also_seen_in`
   tracking).

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -79,10 +79,12 @@ implementation status.
     without its own gate; its failure modes surface during fact review,
     with `replan` as the escape hatch.
 
-    Phase 5 slice 1 landed: Stage 4 LLM-prose summarizer. Entity `.md`
-    files are now generated with LLM prose, status-grouped facts, and
-    per-fact footnote citations. Review sessions batch page generation
-    for all touched entities on completion.
+    Phase 5 slices 1 and 5 landed: Stage 4 LLM-prose summarizer and
+    `auto-lorebook wiki rebuild`. Entity `.md` files are now generated
+    with LLM prose, status-grouped facts, and per-fact footnote
+    citations. Review sessions batch page generation for all touched
+    entities on completion. `wiki rebuild` regenerates all pages from
+    scratch and removes orphan `.md` files with no matching entity.
 
 ## Phase 1: Reading stage
 
@@ -237,11 +239,18 @@ session batches regeneration for all touched entities at completion;
 Ctrl-C leaves no partial writes. `models.summarizer` config slot added
 (falls back to `models.primary`).
 
+**Slice 5 landed:** `auto-lorebook wiki rebuild` regenerates every
+entity page from scratch (prose + linked-entity propagation) and
+reconciles the filesystem against the DB — deletes any `.md` file in
+the entity-category subdirectories with no matching entity. Recovers
+from corruption, crashed page steps, or prompt changes. Staleness-skip
+(regenerate only entities whose facts changed since last build) remains
+future work.
+
 **Remaining scope**
 
 - Section normalization (case-insensitive grouping of free-text
   section names).
-- `wiki rebuild` command to regenerate all summaries from scratch.
 - `promote-correction` command (with `first_seen_in` / `also_seen_in`
   tracking).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,3 +80,4 @@ nav:
       - adr/0002-status-edit-audit-asymmetry.md
       - adr/0003-wiki-state-lives-inside-the-wiki.md
       - adr/0004-sqlite-replaces-yaml-wiki-store.md
+      - adr/0005-summaries-synthesize-across-linked-entities.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
     "S101", # Allow assert in tests
+    "PLC2701", # Allow private-name imports from internal modules
 ]
 
 [tool.ruff.format]

--- a/src/auto_lorebook/commands/wiki.py
+++ b/src/auto_lorebook/commands/wiki.py
@@ -113,6 +113,11 @@ def add_parser(
             "filesystem against the DB — deletes any .md file with no matching entity."
         ),
     )
+    p_rebuild.add_argument(
+        "--force",
+        action="store_true",
+        help="Regenerate every page even if inputs are unchanged",
+    )
     p_rebuild.set_defaults(func=run)
 
     return parser
@@ -296,6 +301,7 @@ def _run_rebuild(args: argparse.Namespace, home: Path | None) -> int:
         wiki_setting = wiki_ctx.setting.description or ""
         entity_index = entities_mod.render_for_preamble(conn)
 
+        force = getattr(args, "force", False)
         written = page_step_mod.run_page_step(
             conn,
             wiki_repo,
@@ -304,6 +310,7 @@ def _run_rebuild(args: argparse.Namespace, home: Path | None) -> int:
             wiki_setting=wiki_setting,
             client=client,
             model=effective_model,
+            skip_unchanged=not force,
         )
 
         # orphan cleanup: delete .md files in category dirs with no matching entity
@@ -319,8 +326,10 @@ def _run_rebuild(args: argparse.Namespace, home: Path | None) -> int:
                     orphans_removed += 1
                     _logger.info("removed orphan: %s", md_file)
 
+        skipped = len(touched) - len(written)
         print(  # noqa: T201
             f"Rebuild complete: {len(written)} pages regenerated, "
+            f"{skipped} skipped, "
             f"{orphans_removed} orphan(s) removed."
         )
         return 0

--- a/src/auto_lorebook/commands/wiki.py
+++ b/src/auto_lorebook/commands/wiki.py
@@ -1,6 +1,6 @@
 """auto-lorebook wiki subcommand group.
 
-Registry management: `wiki <list|use|add|remove|rename>`.
+Registry management: `wiki <list|use|add|remove|rename|rebuild>`.
 All dispatch through `run()` on `args.wiki_action`.
 """
 
@@ -14,12 +14,22 @@ from auto_lorebook import config as cfg_mod
 from auto_lorebook import db, wiki_state
 from auto_lorebook import wiki_bootstrap as wiki_bootstrap_mod
 from auto_lorebook.config import save_config
+from auto_lorebook.openrouter import OpenRouterClient
 from auto_lorebook.wiki_registry import WikiEntry, WikiRegistry, WikiRegistryError
 
 if TYPE_CHECKING:
     import argparse
 
 _logger = logging.getLogger(__name__)
+
+_ENTITY_CATEGORIES = (
+    "characters",
+    "locations",
+    "factions",
+    "events",
+    "items",
+    "concepts",
+)
 
 
 def add_parser(
@@ -93,6 +103,18 @@ def add_parser(
     p_rename.add_argument("new", help="New nickname")
     p_rename.set_defaults(func=run)
 
+    # rebuild
+    p_rebuild = sub.add_parser(
+        "rebuild",
+        parents=[common_parser],
+        help="Regenerate all entity pages; delete orphan .md files",
+        description=(
+            "Regenerate every entity page from scratch and reconcile the "
+            "filesystem against the DB — deletes any .md file with no matching entity."
+        ),
+    )
+    p_rebuild.set_defaults(func=run)
+
     return parser
 
 
@@ -110,6 +132,8 @@ def run(args: argparse.Namespace) -> int:
         return _run_remove(args, home)
     if action == "rename":
         return _run_rename(args, home)
+    if action == "rebuild":
+        return _run_rebuild(args, home)
     msg = f"unknown wiki action: {action}"
     raise ValueError(msg)
 
@@ -233,3 +257,72 @@ def _run_use(args: argparse.Namespace, home: Path | None) -> int:
     save_config(cfg, home=home)
     print(f"active wiki: {nick!r} → {candidate}")  # noqa: T201
     return 0
+
+
+def _run_rebuild(args: argparse.Namespace, home: Path | None) -> int:
+    """Regenerate all entity pages; delete orphan .md files."""
+    from auto_lorebook import entities as entities_mod  # noqa: PLC0415
+    from auto_lorebook import page_step as page_step_mod  # noqa: PLC0415
+    from auto_lorebook import wiki_context as wiki_context_mod  # noqa: PLC0415
+
+    cfg = cfg_mod.load_config(home=home)
+    try:
+        wiki_repo = cfg.resolve_active_wiki(getattr(args, "wiki", None))
+    except cfg_mod.ConfigError as e:
+        print(f"error: {e}")  # noqa: T201
+        return 1
+
+    api_key = cfg.get_api_key()
+    if not api_key:
+        print(  # noqa: T201
+            f"error: no API key found. "
+            f"Export ${cfg.openrouter.api_key_env} or store in "
+            "~/.auto-lorebook/credentials."
+        )
+        return 1
+
+    conn = db.open(wiki_state.wiki_db_path(wiki_repo))
+    try:
+        rows = entities_mod.list_entities(conn, wiki_repo=wiki_repo)
+        touched = [(e.category, e.slug) for e in rows]
+
+        client = OpenRouterClient(
+            api_key=api_key,
+            default_model=cfg.models.summarizer or cfg.models.primary,
+            app_title="auto-lorebook",
+        )
+        effective_model = cfg.models.summarizer or cfg.models.primary
+        wiki_ctx = wiki_context_mod.read(conn, wiki_repo=wiki_repo)
+        wiki_setting = wiki_ctx.setting.description or ""
+        entity_index = entities_mod.render_for_preamble(conn)
+
+        written = page_step_mod.run_page_step(
+            conn,
+            wiki_repo,
+            touched,
+            entity_index=entity_index,
+            wiki_setting=wiki_setting,
+            client=client,
+            model=effective_model,
+        )
+
+        # orphan cleanup: delete .md files in category dirs with no matching entity
+        valid_paths = {wiki_repo / e.category / f"{e.slug}.md" for e in rows}
+        orphans_removed = 0
+        for cat in _ENTITY_CATEGORIES:
+            cat_dir = wiki_repo / cat
+            if not cat_dir.is_dir():
+                continue
+            for md_file in cat_dir.glob("*.md"):
+                if md_file not in valid_paths:
+                    md_file.unlink()
+                    orphans_removed += 1
+                    _logger.info("removed orphan: %s", md_file)
+
+        print(  # noqa: T201
+            f"Rebuild complete: {len(written)} pages regenerated, "
+            f"{orphans_removed} orphan(s) removed."
+        )
+        return 0
+    finally:
+        conn.close()

--- a/src/auto_lorebook/config.py
+++ b/src/auto_lorebook/config.py
@@ -49,6 +49,13 @@ class PreambleConfig:
 
 
 @dataclass
+class SummarizerConfig:
+    """Summarizer section of config.yaml."""
+
+    linked_context_budget_fraction: float = 0.25
+
+
+@dataclass
 class Config:
     """Loaded ~/.auto-lorebook/config.yaml."""
 
@@ -57,6 +64,7 @@ class Config:
     openrouter: OpenRouterConfig = field(default_factory=OpenRouterConfig)
     models: ModelsConfig = field(default_factory=ModelsConfig)
     preamble: PreambleConfig = field(default_factory=PreambleConfig)
+    summarizer: SummarizerConfig = field(default_factory=SummarizerConfig)
 
     def get_api_key(self) -> str | None:
         """Resolve API key. Env var wins; falls back to credentials file."""
@@ -165,6 +173,7 @@ def load_config(home: Path | None = None) -> Config:
     or_raw: dict[str, Any] = raw.get("openrouter") or {}
     models_raw: dict[str, Any] = raw.get("models") or {}
     preamble_raw: dict[str, Any] = raw.get("preamble") or {}
+    summarizer_raw: dict[str, Any] = raw.get("summarizer") or {}
 
     openrouter = OpenRouterConfig(
         api_key_env=or_raw.get("api_key_env", "OPENROUTER_API_KEY"),
@@ -179,6 +188,11 @@ def load_config(home: Path | None = None) -> Config:
     preamble = PreambleConfig(
         budget_fraction=float(preamble_raw.get("budget_fraction", 0.8)),
     )
+    summarizer_cfg = SummarizerConfig(
+        linked_context_budget_fraction=float(
+            summarizer_raw.get("linked_context_budget_fraction", 0.25)
+        ),
+    )
 
     return Config(
         wikis=wikis,
@@ -186,6 +200,7 @@ def load_config(home: Path | None = None) -> Config:
         openrouter=openrouter,
         models=models,
         preamble=preamble,
+        summarizer=summarizer_cfg,
     )
 
 
@@ -371,6 +386,11 @@ def save_config(cfg: Config, home: Path | None = None) -> None:
             "primary_context_window": cfg.models.primary_context_window,
         },
         "preamble": {"budget_fraction": cfg.preamble.budget_fraction},
+        "summarizer": {
+            "linked_context_budget_fraction": (
+                cfg.summarizer.linked_context_budget_fraction
+            ),
+        },
     }
     if cfg.models.extractor is not None:
         data["models"]["extractor"] = cfg.models.extractor

--- a/src/auto_lorebook/config.py
+++ b/src/auto_lorebook/config.py
@@ -38,6 +38,7 @@ class ModelsConfig:
     primary_context_window: int = 200_000
     extractor: str | None = None
     planner: str | None = None
+    summarizer: str | None = None
 
 
 @dataclass
@@ -173,6 +174,7 @@ def load_config(home: Path | None = None) -> Config:
         primary_context_window=int(models_raw.get("primary_context_window", 200_000)),
         extractor=models_raw.get("extractor"),
         planner=models_raw.get("planner"),
+        summarizer=models_raw.get("summarizer"),
     )
     preamble = PreambleConfig(
         budget_fraction=float(preamble_raw.get("budget_fraction", 0.8)),
@@ -374,6 +376,8 @@ def save_config(cfg: Config, home: Path | None = None) -> None:
         data["models"]["extractor"] = cfg.models.extractor
     if cfg.models.planner is not None:
         data["models"]["planner"] = cfg.models.planner
+    if cfg.models.summarizer is not None:
+        data["models"]["summarizer"] = cfg.models.summarizer
     atomic_write_text(
         cfg_path, yaml.safe_dump(data, allow_unicode=True, sort_keys=False)
     )

--- a/src/auto_lorebook/db/ddl.py
+++ b/src/auto_lorebook/db/ddl.py
@@ -288,6 +288,17 @@ CREATE TABLE proposal_targets (
 )
 """
 
+ENTITY_PAGE_STALENESS = """
+CREATE TABLE entity_page_staleness (
+    category      TEXT NOT NULL,
+    slug          TEXT NOT NULL,
+    inputs_sha256 TEXT NOT NULL,
+    generated_at  TEXT NOT NULL,
+    PRIMARY KEY (category, slug),
+    FOREIGN KEY (category, slug) REFERENCES entities(category, slug) ON DELETE CASCADE
+)
+"""
+
 PLAN_METADATA = """
 CREATE TABLE plan_metadata (
     ingest_id                TEXT PRIMARY KEY,

--- a/src/auto_lorebook/db/migrations.py
+++ b/src/auto_lorebook/db/migrations.py
@@ -527,12 +527,28 @@ def _migration_005_multi_target_proposals(conn: sqlite3.Connection) -> None:
     conn.execute("UPDATE schema_version SET version = 5")
 
 
+def _migration_006_entity_page_staleness(conn: sqlite3.Connection) -> None:
+    """Add entity_page_staleness table for wiki rebuild skip logic."""
+    conn.execute("""
+CREATE TABLE entity_page_staleness (
+    category      TEXT NOT NULL,
+    slug          TEXT NOT NULL,
+    inputs_sha256 TEXT NOT NULL,
+    generated_at  TEXT NOT NULL,
+    PRIMARY KEY (category, slug),
+    FOREIGN KEY (category, slug) REFERENCES entities(category, slug) ON DELETE CASCADE
+)
+""")
+    conn.execute("UPDATE schema_version SET version = 6")
+
+
 MIGRATIONS: tuple[Callable[[sqlite3.Connection], None], ...] = (
     _migration_001_initial,
     _migration_002_widen_source_type,
     _migration_003_fix_segment_status_and_add_flags_json,
     _migration_004_plan_metadata_and_flag_reason,
     _migration_005_multi_target_proposals,
+    _migration_006_entity_page_staleness,
 )
 
 CURRENT_SCHEMA_VERSION: int = len(MIGRATIONS)

--- a/src/auto_lorebook/facts.py
+++ b/src/auto_lorebook/facts.py
@@ -314,6 +314,34 @@ def get_fact(conn: sqlite3.Connection, fact_id: str) -> FactRow | None:
     return _fact_from_row(row) if row else None
 
 
+def list_linked_entities(
+    conn: sqlite3.Connection,
+    entity_category: str,
+    entity_slug: str,
+) -> list[tuple[str, str]]:
+    """Return entities co-targeted with (entity_category, entity_slug) via fact_targets.
+
+    One-hop symmetric: any entity sharing at least one fact with the input.
+    Excludes self and superseded entities. Sorted by (category, slug), deduped.
+    """
+    rows = conn.execute(
+        """
+        SELECT DISTINCT ft2.entity_category, ft2.entity_slug
+        FROM fact_targets ft1
+        JOIN fact_targets ft2 ON ft2.fact_id = ft1.fact_id
+        JOIN entities e ON e.category = ft2.entity_category
+                       AND e.slug = ft2.entity_slug
+        WHERE ft1.entity_category = ?
+          AND ft1.entity_slug = ?
+          AND (ft2.entity_category != ? OR ft2.entity_slug != ?)
+          AND e.superseded_by_slug IS NULL
+        ORDER BY ft2.entity_category, ft2.entity_slug
+        """,
+        (entity_category, entity_slug, entity_category, entity_slug),
+    ).fetchall()
+    return [(r[0], r[1]) for r in rows]
+
+
 def list_facts_by_entity(
     conn: sqlite3.Connection,
     entity_category: str,

--- a/src/auto_lorebook/ingest_cleanup.py
+++ b/src/auto_lorebook/ingest_cleanup.py
@@ -5,6 +5,13 @@ from the DB, deletes entity rows that the ingest created and are now
 empty of facts, removes their `.md` summaries, and removes pipeline
 artifacts under `pending/<source_id>/` (plan + proposals).
 
+Page reconciliation: after DB deletion, removed entities' pages are
+deleted and linked survivors are re-summarized via `run_page_step`
+(LLM path when API key is available; mechanical fallback otherwise).
+
+`replan` needs no page reconciliation: it only discards unreviewed
+proposals and never deletes approved facts or entity pages.
+
 Decisions:
 
 - Stub deletion criterion: empty facts AND `entity.created_by_ingest == source_id`.
@@ -103,10 +110,14 @@ def reject_ingest(
     source_id: str,
     wiki_override: str | None = None,
 ) -> RejectResult:
-    """Remove `source_id`'s contributions from DB; clean pending."""
+    """Remove `source_id`'s contributions from DB; clean pending; reconcile pages."""
     wiki_repo = cfg.resolve_active_wiki(wiki_override)
     conn = db_mod.open(wiki_state_mod.wiki_db_path(wiki_repo))
     result = RejectResult()
+    removed_entity_keys: list[tuple[str, str]] = []
+    partial_survivors: set[tuple[str, str]] = set()
+    linked_survivors: set[tuple[str, str]] = set()
+
     try:
         # collect entities affected before deletion
         fact_rows = conn.execute(
@@ -126,6 +137,29 @@ def reject_ingest(
                     conn, r["entity_category"], r["entity_slug"]
                 )
 
+        # compute removed/linked sets BEFORE deletion (co-target rows still exist)
+        for (cat, slug), entity in affected_entities.items():
+            if entity is None:
+                continue
+            remaining_after = conn.execute(
+                "SELECT COUNT(*) FROM facts f"
+                " JOIN fact_targets ft ON ft.fact_id=f.id"
+                " WHERE ft.entity_category=? AND ft.entity_slug=?"
+                " AND f.created_by_ingest!=?",
+                (cat, slug, source_id),
+            ).fetchone()[0]
+            if remaining_after == 0 and entity.created_by_ingest == source_id:
+                removed_entity_keys.append((cat, slug))
+                # linked neighbors of this removed entity
+                linked_survivors.update(facts_mod.list_linked_entities(conn, cat, slug))
+            else:
+                partial_survivors.add((cat, slug))
+
+        removed_set = set(removed_entity_keys)
+        # one-hop neighbors minus removed entities, plus partial survivors
+        linked_survivors -= removed_set
+        linked_survivors |= partial_survivors
+
         # delete facts + cascade (fact_targets, fact_status_history)
         conn.execute(
             "DELETE FROM facts WHERE created_by_ingest=?",
@@ -139,31 +173,64 @@ def reject_ingest(
         )
         result.aliases_removed = cur.rowcount
 
-        # delete or mark entities
-        for (cat, slug), entity in affected_entities.items():
-            if entity is None:
-                continue
-            remaining = conn.execute(
-                "SELECT COUNT(*) FROM facts f"
-                " JOIN fact_targets ft ON ft.fact_id=f.id"
-                " WHERE ft.entity_category=? AND ft.entity_slug=?",
+        # delete entity rows for fully-removed stubs
+        for cat, slug in removed_entity_keys:
+            conn.execute(
+                "DELETE FROM entities WHERE category=? AND slug=?",
                 (cat, slug),
-            ).fetchone()[0]
-            if remaining == 0 and entity.created_by_ingest == source_id:
-                conn.execute(
-                    "DELETE FROM entities WHERE category=? AND slug=?",
-                    (cat, slug),
-                )
-                regen_mod.delete_entity_summary(wiki_repo, cat, slug)
-                result.stubs_deleted += 1
-            elif remaining < (result.facts_removed):
-                # partial removal; regenerate .md
-                with contextlib.suppress(ValueError):
-                    regen_mod.regenerate_entity(conn, wiki_repo, cat, slug)
-                result.entities_modified += 1
+            )
+            result.stubs_deleted += 1
+
+        result.entities_modified = len(partial_survivors)
 
     finally:
         conn.close()
+
+    # page reconciliation
+    api_key = cfg.get_api_key()
+    if api_key:
+        # LLM path: deleted pages + re-summarize linked survivors
+        from auto_lorebook import entities as _entities_mod  # noqa: PLC0415
+        from auto_lorebook import wiki_context as wiki_context_mod  # noqa: PLC0415
+        from auto_lorebook.openrouter import OpenRouterClient  # noqa: PLC0415
+        from auto_lorebook.page_step import run_page_step  # noqa: PLC0415
+
+        llm_conn = db_mod.open(wiki_state_mod.wiki_db_path(wiki_repo))
+        try:
+            client = OpenRouterClient(
+                api_key=api_key,
+                default_model=cfg.models.summarizer or cfg.models.primary,
+                app_title="auto-lorebook",
+            )
+            model = cfg.models.summarizer or cfg.models.primary
+            wiki_ctx = wiki_context_mod.read(llm_conn, wiki_repo=wiki_repo)
+            wiki_setting = wiki_ctx.setting.description or ""
+            entity_index = _entities_mod.render_for_preamble(llm_conn)
+            run_page_step(
+                llm_conn,
+                wiki_repo,
+                sorted(linked_survivors),
+                removed_entities=removed_entity_keys,
+                entity_index=entity_index,
+                wiki_setting=wiki_setting,
+                client=client,
+                model=model,
+                context_window=cfg.models.primary_context_window,
+                budget_fraction=cfg.summarizer.linked_context_budget_fraction,
+            )
+        finally:
+            llm_conn.close()
+    else:
+        # offline fallback: delete removed pages, mechanically regen survivors
+        for cat, slug in removed_entity_keys:
+            regen_mod.delete_entity_summary(wiki_repo, cat, slug)
+        offline_conn = db_mod.open(wiki_state_mod.wiki_db_path(wiki_repo))
+        try:
+            for cat, slug in sorted(linked_survivors):
+                with contextlib.suppress(ValueError):
+                    regen_mod.regenerate_entity(offline_conn, wiki_repo, cat, slug)
+        finally:
+            offline_conn.close()
 
     # Pipeline artifacts: drop plan.yaml + proposals/. Leave reading-state
     # DB rows (ingests/segments/segment_bullets) alone so replan /

--- a/src/auto_lorebook/linked_budget.py
+++ b/src/auto_lorebook/linked_budget.py
@@ -14,7 +14,7 @@ _logger = logging.getLogger(__name__)
 LinkedContext = list[tuple["EntityRow", list["FactRow"]]]
 
 # priority order: shared > non-shared authoritative > non-shared trustworthy;
-# drop non-shared hearsay before disproven (both non-shared)
+# drop non-shared disproven before hearsay (both non-shared)
 _STATUS_PRIORITY: dict[str, int] = {
     "authoritative": 1,
     "trustworthy": 2,
@@ -132,7 +132,19 @@ def budget_linked_context(
         if used + cost <= budget:
             result.append((ent, facts))
             used += cost
-        # else: skip this entity — over budget
+            continue
+        # entity over budget: fact-level trim — drop lowest-priority facts from tail
+        trimmed = list(facts)
+        while trimmed:
+            trimmed.pop()  # drop lowest-priority fact (tail of sorted list)
+            if not trimmed:
+                break  # no facts left — skip entity entirely
+            block = _render_for_estimate(ent, trimmed)
+            cost = _estimate_tokens(block)
+            if used + cost <= budget:
+                result.append((ent, trimmed))
+                used += cost
+                break
 
     # hard check: if fact text alone exceeds budget, no trimming can help → raise
     if not result and ordered:

--- a/src/auto_lorebook/linked_budget.py
+++ b/src/auto_lorebook/linked_budget.py
@@ -1,0 +1,150 @@
+"""Linked-context token budgeter for Stage 4."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from auto_lorebook.entities import EntityRow
+    from auto_lorebook.facts import FactRow
+
+_logger = logging.getLogger(__name__)
+
+LinkedContext = list[tuple["EntityRow", list["FactRow"]]]
+
+# priority order: shared > non-shared authoritative > non-shared trustworthy;
+# drop non-shared hearsay before disproven (both non-shared)
+_STATUS_PRIORITY: dict[str, int] = {
+    "authoritative": 1,
+    "trustworthy": 2,
+    "hearsay": 3,
+    "disproven": 4,
+}
+
+
+class LinkedContextTooLargeError(RuntimeError):
+    """Linked context exceeds the configured token budget even after trimming."""
+
+
+def _shared_fact_count(facts: list[FactRow], subject_fact_ids: set[str]) -> int:
+    """Count facts whose id is in subject_fact_ids."""
+    return sum(1 for f in facts if f.id in subject_fact_ids)
+
+
+def _rank_entities(
+    linked_facts: LinkedContext,
+    subject_fact_ids: set[str],
+) -> LinkedContext:
+    """Sort entities by shared-fact count desc, then (category, slug) asc."""
+    return sorted(
+        linked_facts,
+        key=lambda item: (
+            -_shared_fact_count(item[1], subject_fact_ids),
+            item[0].category,
+            item[0].slug,
+        ),
+    )
+
+
+def _sort_facts(facts: list[FactRow], subject_fact_ids: set[str]) -> list[FactRow]:
+    """Sort facts: shared first, then by status priority asc."""
+    return sorted(
+        facts,
+        key=lambda f: (
+            0 if f.id in subject_fact_ids else 1,
+            _STATUS_PRIORITY.get(f.status, 3),
+        ),
+    )
+
+
+def _render_for_estimate(entity: EntityRow, facts: list[FactRow]) -> str:
+    """Render linked-entity block for token estimation.
+
+    Must mirror the linked block rendering in stage4.build_prompt.
+    """
+    lines: list[str] = []
+    name = entity.canonical_name
+    cat_slug = f"{entity.category}/{entity.slug}"
+    lines.append(f"\n{name} ({cat_slug}):")
+    by_status: dict[str, list[FactRow]] = {}
+    for fact in facts:
+        by_status.setdefault(fact.status, []).append(fact)
+    for status, bucket in sorted(by_status.items()):
+        lines.append(f"  {status.upper()}:")
+        for fact in bucket:
+            reason = f" [reason: {fact.status_reason}]" if fact.status_reason else ""
+            speaker = f" (speaker: {fact.speaker})" if fact.speaker else ""
+            lines.append(f"    - [{fact.id}] {fact.text}{speaker}{reason}")
+    return "\n".join(lines)
+
+
+def _estimate_tokens(text: str) -> int:
+    """Approximate token count; matches preamble.check_budget heuristic."""
+    return len(text) // 4
+
+
+def budget_linked_context(
+    linked_facts: LinkedContext,
+    subject_fact_ids: set[str],
+    *,
+    context_window: int,
+    budget_fraction: float,
+    max_linked_entities: int | None = None,
+) -> LinkedContext:
+    """Cap linked context to token budget.
+
+    Priority: shared facts first, then non-shared by status (authoritative,
+    trustworthy, hearsay, disproven). Entities ranked by shared-fact count
+    desc, tie-break (category, slug) asc. Greedily includes entities until
+    budget exhausted. Raises LinkedContextTooLargeError when no trimming
+    can satisfy the budget.
+
+    :param linked_facts: (entity, facts) pairs for linked entities
+    :param subject_fact_ids: fact ids belonging to the subject entity
+    :param context_window: model context window in tokens
+    :param budget_fraction: fraction of context_window for linked block
+    :param max_linked_entities: hard cap on entity count (None = unlimited)
+    """
+    if not linked_facts:
+        return []
+
+    budget = int(context_window * budget_fraction)
+
+    # rank entities nearest-first
+    ranked = _rank_entities(linked_facts, subject_fact_ids)
+
+    # apply entity-count cap before token budgeting
+    if max_linked_entities is not None:
+        ranked = ranked[:max_linked_entities]
+
+    # for each entity, sort facts by priority
+    ordered: LinkedContext = [
+        (ent, _sort_facts(facts, subject_fact_ids)) for ent, facts in ranked
+    ]
+
+    # greedy token budget: include entities in rank order until budget exceeded
+    result: LinkedContext = []
+    used = 0
+    for ent, facts in ordered:
+        block = _render_for_estimate(ent, facts)
+        cost = _estimate_tokens(block)
+        if used + cost <= budget:
+            result.append((ent, facts))
+            used += cost
+        # else: skip this entity — over budget
+
+    # hard check: if fact text alone exceeds budget, no trimming can help → raise
+    if not result and ordered:
+        first_ent, first_facts = ordered[0]
+        if first_facts:
+            # minimal unit = the fact with highest priority; check text tokens only
+            min_fact = first_facts[0]
+            if _estimate_tokens(min_fact.text) > budget:
+                msg = (
+                    f"Linked context for {first_ent.category}/{first_ent.slug} "
+                    f"exceeds token budget ({budget}) even after trimming."
+                )
+                raise LinkedContextTooLargeError(msg)
+
+    return result

--- a/src/auto_lorebook/page_step.py
+++ b/src/auto_lorebook/page_step.py
@@ -1,0 +1,62 @@
+"""Batched page-step orchestrator for Stage 4.
+
+Regenerates .md files for a set of touched entities after all facts are
+decided. Reports progress to stdout.
+
+Public API:
+    run_page_step(conn, wiki_repo, touched_entities, entity_index,
+                  wiki_setting, client, model) -> list[Path]
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from auto_lorebook import stage4 as stage4_mod
+
+if TYPE_CHECKING:
+    import sqlite3
+    from pathlib import Path
+
+    from auto_lorebook.openrouter import OpenRouterClient
+
+_logger = logging.getLogger(__name__)
+
+
+def run_page_step(
+    conn: sqlite3.Connection,
+    wiki_repo: Path,
+    touched_entities: list[tuple[str, str]],
+    *,
+    entity_index: str = "",
+    wiki_setting: str = "",
+    client: OpenRouterClient,
+    model: str = "",
+) -> list[Path]:
+    """Regenerate .md pages for all touched entities; report progress.
+
+    :param touched_entities: list of (category, slug) pairs
+    :returns: list of written paths
+    """
+    n = len(touched_entities)
+    if n == 0:
+        return []
+    print(f"Summarizing {n} {'entity' if n == 1 else 'entities'}...")  # noqa: T201
+    paths: list[Path] = []
+    for category, slug in touched_entities:
+        try:
+            path = stage4_mod.summarize_entity(
+                conn,
+                wiki_repo,
+                category,
+                slug,
+                entity_index=entity_index,
+                wiki_setting=wiki_setting,
+                client=client,
+                model=model,
+            )
+            paths.append(path)
+        except Exception as exc:  # noqa: BLE001
+            _logger.warning("page_step: skipping %s/%s: %s", category, slug, exc)
+    return paths

--- a/src/auto_lorebook/page_step.py
+++ b/src/auto_lorebook/page_step.py
@@ -1,7 +1,7 @@
 """Batched page-step orchestrator for Stage 4.
 
-Regenerates .md files for a set of touched entities after all facts are
-decided. Reports progress to stdout.
+Regenerates .md files for touched entities and their one-hop linked
+entities after all facts are decided. Reports progress to stdout.
 
 Public API:
     run_page_step(conn, wiki_repo, touched_entities, entity_index,
@@ -13,7 +13,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from auto_lorebook import entities as entities_mod
+from auto_lorebook import facts as facts_mod
 from auto_lorebook import stage4 as stage4_mod
+from auto_lorebook.regen_set import plan_regeneration_set
 
 if TYPE_CHECKING:
     import sqlite3
@@ -34,17 +37,42 @@ def run_page_step(
     client: OpenRouterClient,
     model: str = "",
 ) -> list[Path]:
-    """Regenerate .md pages for all touched entities; report progress.
+    """Regenerate .md pages for touched entities and one-hop linked entities.
 
     :param touched_entities: list of (category, slug) pairs
     :returns: list of written paths
     """
-    n = len(touched_entities)
-    if n == 0:
+    if not touched_entities:
         return []
-    print(f"Summarizing {n} {'entity' if n == 1 else 'entities'}...")  # noqa: T201
+
+    def linked_of(entity: tuple[str, str]) -> list[tuple[str, str]]:
+        return facts_mod.list_linked_entities(conn, entity[0], entity[1])
+
+    regen = plan_regeneration_set(touched_entities, linked_of)
+    n_touched = len(regen.touched)
+    n_linked = len(regen.linked)
+
+    if n_linked:
+        print(  # noqa: T201
+            f"Summarizing {n_touched} touched + {n_linked} linked"
+            f" {'entity' if n_touched + n_linked == 1 else 'entities'}..."
+        )
+    else:
+        n = n_touched
+        print(f"Summarizing {n} {'entity' if n == 1 else 'entities'}...")  # noqa: T201
+
     paths: list[Path] = []
-    for category, slug in touched_entities:
+    for category, slug in regen.ordered:
+        # collect linked-entity facts for synthesis context
+        linked_keys = facts_mod.list_linked_entities(conn, category, slug)
+        linked_facts = []
+        for nb_cat, nb_slug in linked_keys:
+            nb_entity = entities_mod.get_entity(conn, nb_cat, nb_slug)
+            if nb_entity is None:
+                continue
+            nb_facts = facts_mod.list_facts_by_entity(conn, nb_cat, nb_slug)
+            linked_facts.append((nb_entity, nb_facts))
+
         try:
             path = stage4_mod.summarize_entity(
                 conn,
@@ -55,6 +83,7 @@ def run_page_step(
                 wiki_setting=wiki_setting,
                 client=client,
                 model=model,
+                linked_facts=linked_facts or None,
             )
             paths.append(path)
         except Exception as exc:  # noqa: BLE001

--- a/src/auto_lorebook/page_step.py
+++ b/src/auto_lorebook/page_step.py
@@ -3,9 +3,13 @@
 Regenerates .md files for touched entities and their one-hop linked
 entities after all facts are decided. Reports progress to stdout.
 
+On reject-ingest, pass ``removed_entities`` to delete removed pages
+and exclude removed entities from regeneration.
+
 Public API:
     run_page_step(conn, wiki_repo, touched_entities, entity_index,
-                  wiki_setting, client, model) -> list[Path]
+                  wiki_setting, client, model,
+                  removed_entities) -> list[Path]
 """
 
 from __future__ import annotations
@@ -21,6 +25,7 @@ from auto_lorebook.linked_budget import (
     budget_linked_context,
 )
 from auto_lorebook.regen_set import plan_regeneration_set
+from auto_lorebook.summary_regen import delete_entity_summary
 
 if TYPE_CHECKING:
     import sqlite3
@@ -36,6 +41,7 @@ def run_page_step(
     wiki_repo: Path,
     touched_entities: list[tuple[str, str]],
     *,
+    removed_entities: list[tuple[str, str]] | None = None,
     entity_index: str = "",
     wiki_setting: str = "",
     client: OpenRouterClient,
@@ -45,20 +51,43 @@ def run_page_step(
 ) -> list[Path]:
     """Regenerate .md pages for touched entities and one-hop linked entities.
 
-    :param touched_entities: list of (category, slug) pairs
+    :param touched_entities: (category, slug) pairs to summarize
+    :param removed_entities: (category, slug) pairs whose pages to delete;
+        excluded from regeneration even if also in touched_entities
     :param context_window: model context window for linked-context budgeting
     :param budget_fraction: fraction of context_window for linked context block
     :returns: list of written paths
     """
-    if not touched_entities:
+    removed_set: frozenset[tuple[str, str]] = (
+        frozenset(removed_entities) if removed_entities else frozenset()
+    )
+    # delete pages of removed entities
+    for cat, slug in removed_set:
+        delete_entity_summary(wiki_repo, cat, slug)
+
+    if not touched_entities and not removed_set:
+        return []
+
+    # filter removed entities out of regen inputs
+    filtered_touched = [e for e in touched_entities if e not in removed_set]
+
+    if not filtered_touched and not removed_set:
         return []
 
     def linked_of(entity: tuple[str, str]) -> list[tuple[str, str]]:
-        return facts_mod.list_linked_entities(conn, entity[0], entity[1])
+        # exclude removed entities from linked set
+        return [
+            e
+            for e in facts_mod.list_linked_entities(conn, entity[0], entity[1])
+            if e not in removed_set
+        ]
 
-    regen = plan_regeneration_set(touched_entities, linked_of)
+    regen = plan_regeneration_set(filtered_touched, linked_of)
     n_touched = len(regen.touched)
     n_linked = len(regen.linked)
+
+    if not regen.ordered:
+        return []
 
     if n_linked:
         print(  # noqa: T201

--- a/src/auto_lorebook/page_step.py
+++ b/src/auto_lorebook/page_step.py
@@ -16,6 +16,10 @@ from typing import TYPE_CHECKING
 from auto_lorebook import entities as entities_mod
 from auto_lorebook import facts as facts_mod
 from auto_lorebook import stage4 as stage4_mod
+from auto_lorebook.linked_budget import (
+    LinkedContextTooLargeError,
+    budget_linked_context,
+)
 from auto_lorebook.regen_set import plan_regeneration_set
 
 if TYPE_CHECKING:
@@ -36,10 +40,14 @@ def run_page_step(
     wiki_setting: str = "",
     client: OpenRouterClient,
     model: str = "",
+    context_window: int = 200_000,
+    budget_fraction: float = 0.25,
 ) -> list[Path]:
     """Regenerate .md pages for touched entities and one-hop linked entities.
 
     :param touched_entities: list of (category, slug) pairs
+    :param context_window: model context window for linked-context budgeting
+    :param budget_fraction: fraction of context_window for linked context block
     :returns: list of written paths
     """
     if not touched_entities:
@@ -72,6 +80,26 @@ def run_page_step(
                 continue
             nb_facts = facts_mod.list_facts_by_entity(conn, nb_cat, nb_slug)
             linked_facts.append((nb_entity, nb_facts))
+
+        # apply token budget to linked context
+        subject_fact_ids = {
+            f.id for f in facts_mod.list_facts_by_entity(conn, category, slug)
+        }
+        try:
+            linked_facts = budget_linked_context(
+                linked_facts,
+                subject_fact_ids,
+                context_window=context_window,
+                budget_fraction=budget_fraction,
+            )
+        except LinkedContextTooLargeError as exc:
+            _logger.warning(
+                "page_step: linked context too large for %s/%s, dropping: %s",
+                category,
+                slug,
+                exc,
+            )
+            linked_facts = []
 
         try:
             path = stage4_mod.summarize_entity(

--- a/src/auto_lorebook/page_step.py
+++ b/src/auto_lorebook/page_step.py
@@ -21,6 +21,11 @@ from auto_lorebook.linked_budget import (
     budget_linked_context,
 )
 from auto_lorebook.regen_set import plan_regeneration_set
+from auto_lorebook.staleness_store import (
+    compute_page_inputs_hash,
+    get_page_hash,
+    record_page_hash,
+)
 
 if TYPE_CHECKING:
     import sqlite3
@@ -42,12 +47,14 @@ def run_page_step(
     model: str = "",
     context_window: int = 200_000,
     budget_fraction: float = 0.25,
+    skip_unchanged: bool = False,
 ) -> list[Path]:
     """Regenerate .md pages for touched entities and one-hop linked entities.
 
     :param touched_entities: list of (category, slug) pairs
     :param context_window: model context window for linked-context budgeting
     :param budget_fraction: fraction of context_window for linked context block
+    :param skip_unchanged: skip pages whose inputs hash matches stored hash
     :returns: list of written paths
     """
     if not touched_entities:
@@ -71,6 +78,8 @@ def run_page_step(
 
     paths: list[Path] = []
     for category, slug in regen.ordered:
+        entity = entities_mod.get_entity(conn, category, slug)
+
         # collect linked-entity facts for synthesis context
         linked_keys = facts_mod.list_linked_entities(conn, category, slug)
         linked_facts = []
@@ -82,9 +91,8 @@ def run_page_step(
             linked_facts.append((nb_entity, nb_facts))
 
         # apply token budget to linked context
-        subject_fact_ids = {
-            f.id for f in facts_mod.list_facts_by_entity(conn, category, slug)
-        }
+        own_facts = facts_mod.list_facts_by_entity(conn, category, slug)
+        subject_fact_ids = {f.id for f in own_facts}
         try:
             linked_facts = budget_linked_context(
                 linked_facts,
@@ -101,6 +109,29 @@ def run_page_step(
             )
             linked_facts = []
 
+        # staleness check
+        if entity is not None:
+            aliases = entities_mod.list_aliases(conn, category, slug)
+            current_hash: str | None = compute_page_inputs_hash(
+                entity=entity,
+                aliases=aliases,
+                facts=own_facts,
+                linked_facts=linked_facts,
+                entity_index=entity_index,
+                wiki_setting=wiki_setting,
+                model=model,
+                model_params={},
+            )
+        else:
+            current_hash = None
+        if (
+            skip_unchanged
+            and current_hash is not None
+            and (get_page_hash(conn, category, slug) == current_hash)
+        ):
+            _logger.debug("page_step: skipping unchanged %s/%s", category, slug)
+            continue
+
         try:
             path = stage4_mod.summarize_entity(
                 conn,
@@ -114,6 +145,9 @@ def run_page_step(
                 linked_facts=linked_facts or None,
             )
             paths.append(path)
+            if current_hash is not None:
+                record_page_hash(conn, category, slug, current_hash)
+                conn.commit()
         except Exception as exc:  # noqa: BLE001
             _logger.warning("page_step: skipping %s/%s: %s", category, slug, exc)
     return paths

--- a/src/auto_lorebook/regen_set.py
+++ b/src/auto_lorebook/regen_set.py
@@ -1,0 +1,62 @@
+"""Regeneration-set planner for Stage 4 page step.
+
+Pure function — no I/O, no sqlite3 import.
+
+Public API:
+    RegenerationSet, plan_regeneration_set
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+
+@dataclass(frozen=True)
+class RegenerationSet:
+    """Ordered entity set for page regeneration.
+
+    touched: deduped input entities, original order preserved.
+    linked:  one-hop co-targets not in touched, sorted (category, slug).
+    """
+
+    touched: tuple[tuple[str, str], ...]
+    linked: tuple[tuple[str, str], ...]
+
+    @property
+    def ordered(self) -> tuple[tuple[str, str], ...]:
+        """Touched first, then linked."""
+        return self.touched + self.linked
+
+
+def plan_regeneration_set(
+    touched: Iterable[tuple[str, str]],
+    linked_of: Callable[[tuple[str, str]], Iterable[tuple[str, str]]],
+) -> RegenerationSet:
+    """Build RegenerationSet: touched (deduped, order-preserved) + one-hop linked.
+
+    linked_of: called once per touched entity, returns its co-targets.
+    One hop, non-transitive — linked_of never called on linked entities.
+    """
+    seen: set[tuple[str, str]] = set()
+    touched_deduped: list[tuple[str, str]] = []
+    for entity in touched:
+        if entity not in seen:
+            seen.add(entity)
+            touched_deduped.append(entity)
+
+    linked_set: set[tuple[str, str]] = set()
+    for entity in touched_deduped:
+        for linked_entity in linked_of(entity):
+            if linked_entity not in seen:
+                linked_set.add(linked_entity)
+
+    linked_sorted = sorted(linked_set)
+
+    return RegenerationSet(
+        touched=tuple(touched_deduped),
+        linked=tuple(linked_sorted),
+    )

--- a/src/auto_lorebook/review.py
+++ b/src/auto_lorebook/review.py
@@ -630,6 +630,8 @@ def run(
                 wiki_setting=wiki_setting,
                 client=client,
                 model=effective_model,
+                context_window=cfg.models.primary_context_window,
+                budget_fraction=cfg.summarizer.linked_context_budget_fraction,
             )
         return result
     finally:

--- a/src/auto_lorebook/review.py
+++ b/src/auto_lorebook/review.py
@@ -22,12 +22,14 @@ from auto_lorebook import config as cfg_mod
 from auto_lorebook import db as db_mod
 from auto_lorebook import entities as entities_mod
 from auto_lorebook import info_yaml as info_yaml_mod
+from auto_lorebook import page_step as page_step_mod
 from auto_lorebook import plan_yaml as plan_yaml_mod
 from auto_lorebook import proposal_yaml as proposal_yaml_mod
-from auto_lorebook import summary_regen as summary_regen_mod
+from auto_lorebook import wiki_context as wiki_context_mod
 from auto_lorebook.approval import ApprovalResult
 from auto_lorebook.entities import slugify
 from auto_lorebook.entity_yaml import normalize_alias_name
+from auto_lorebook.openrouter import OpenRouterClient
 from auto_lorebook.timestamps import format_iso_now
 
 if TYPE_CHECKING:
@@ -370,6 +372,8 @@ class _ApprovalContext:
     conn: sqlite3.Connection
     merged_aliases: set[tuple[str, str]] = field(default_factory=set)
     declined_aliases: set[tuple[str, str]] = field(default_factory=set)
+    # (category, slug) pairs approved during this review session
+    touched_entities: list[tuple[str, str]] = field(default_factory=list)
 
 
 def _resolve_target(
@@ -543,14 +547,17 @@ def run(
     source_id: str,
     reviewer: Reviewer,
     wiki_override: str | None = None,
+    client: OpenRouterClient | None = None,
+    model: str | None = None,
 ) -> ReviewResult:
-    """Walk pending bundles; approve into DB; write .md files; return counts.
+    """Walk pending bundles; approve into DB; write .md pages; return counts.
 
     Each claim group is one `Proposal` with N `ProposalTarget` entries;
     surfaced as a single `BundleView`; one `decide_bundle` call covers
     every target. approved/edited/rejected count proposals, not targets.
+    On completion, runs the page step for all touched entities (batched).
     KeyboardInterrupt propagates after recording the count of proposals
-    left in DB as `remaining`.
+    left in DB as `remaining`; interrupted reviews write no pages.
     """
     wiki_repo = cfg.resolve_active_wiki(wiki_override)
     from auto_lorebook import wiki_state as wiki_state_mod  # noqa: PLC0415
@@ -594,6 +601,36 @@ def run(
             except KeyboardInterrupt:
                 result.remaining = _count_remaining(conn, source_id)
                 raise
+
+        # page step: batched regeneration for all touched entities
+        if ctx.touched_entities:
+            if client is None:
+                api_key = cfg.get_api_key()
+                if not api_key:
+                    msg = (
+                        "OpenRouter API key not found. Either export "
+                        f"${cfg.openrouter.api_key_env} or store the key in "
+                        "~/.auto-lorebook/credentials."
+                    )
+                    raise ReviewError(msg)
+                client = OpenRouterClient(
+                    api_key=api_key,
+                    default_model=cfg.models.summarizer or cfg.models.primary,
+                    app_title="auto-lorebook",
+                )
+            effective_model = model or (cfg.models.summarizer or cfg.models.primary)
+            wiki_ctx = wiki_context_mod.read(conn, wiki_repo=wiki_repo)
+            wiki_setting = wiki_ctx.setting.description or ""
+            entity_index = entities_mod.render_for_preamble(conn)
+            page_step_mod.run_page_step(
+                conn,
+                wiki_repo,
+                ctx.touched_entities,
+                entity_index=entity_index,
+                wiki_setting=wiki_setting,
+                client=client,
+                model=effective_model,
+            )
         return result
     finally:
         conn.close()
@@ -704,18 +741,11 @@ def _process_bundle(
             ctx.merged_aliases.add((target_key, normalize_alias_name(alias_name)))
 
     if approval_result == ApprovalResult.APPROVED:
-        # regen .md per target only after the fact is committed
+        # collect touched entities for batched page step at review completion
         for category, slug, _section in targets_resolved:
-            try:
-                summary_regen_mod.regenerate_entity(
-                    ctx.conn, ctx.wiki_repo, category, slug
-                )
-            except ValueError:
-                _logger.warning(
-                    "review: regenerate_entity failed for %s/%s; .md not written",
-                    category,
-                    slug,
-                )
+            entry = (category, slug)
+            if entry not in ctx.touched_entities:
+                ctx.touched_entities.append(entry)
         if bundle_edits is not None:
             result.edited += 1
         else:
@@ -725,4 +755,4 @@ def _process_bundle(
                 result.edited += 1
             else:
                 result.approved += 1
-    # SKIPPED_IDEMPOTENT: no counter increment, no regen
+    # SKIPPED_IDEMPOTENT: no counter increment, no page regeneration

--- a/src/auto_lorebook/stage4.py
+++ b/src/auto_lorebook/stage4.py
@@ -2,6 +2,7 @@
 
 Generates readable prose pages for entities with approved facts.
 Zero-fact entities get a mechanical stub with no LLM call.
+Linked-entity facts (one-hop co-targets) can be threaded in for synthesis context.
 
 Public API:
     Stage4Error, SummarizeResult
@@ -46,6 +47,9 @@ Rules:
 - Disproven facts: do NOT include in the prose; they appear only in the Facts section.
 - Be concise. One to three paragraphs.
 - Do NOT invent facts beyond what is listed.
+- Linked-entity facts (below): you MAY synthesize a claim drawn from a
+  linked entity's fact, with the same epistemic-status hedging as above.
+  Do not fabricate beyond what is listed.
 
 Emit a single JSON object:
 {
@@ -74,8 +78,9 @@ def build_prompt(
     facts: list[FactRow],
     entity_index: str,
     wiki_setting: str,
+    linked_facts: list[tuple[EntityRow, list[FactRow]]] | None = None,
 ) -> str:
-    """Assemble user message from entity facts, index, and wiki setting."""
+    """Assemble user message from entity facts, index, wiki setting, linked context."""
     parts: list[str] = []
 
     if wiki_setting.strip():
@@ -113,6 +118,30 @@ def build_prompt(
             reason = f" [reason: {fact.status_reason}]" if fact.status_reason else ""
             speaker = f" (speaker: {fact.speaker})" if fact.speaker else ""
             parts.append(f"  - [{fact.id}] {fact.text}{speaker}{reason}")
+
+    # linked-entity context block (one-hop linked entities)
+    if linked_facts:
+        parts.extend(["", "Linked entities (for synthesis context):"])
+        for linked_ent, linked_fact_rows in linked_facts:
+            name = linked_ent.canonical_name
+            cat_slug = f"{linked_ent.category}/{linked_ent.slug}"
+            parts.append(f"\n{name} ({cat_slug}):")
+            nb_by_status: dict[str, list[FactRow]] = {s: [] for s in _STATUS_ORDER}
+            for fact in linked_fact_rows:
+                bucket = fact.status if fact.status in nb_by_status else "hearsay"
+                nb_by_status[bucket].append(fact)
+            for status in _STATUS_ORDER:
+                nb_bucket = nb_by_status[status]
+                if not nb_bucket:
+                    continue
+                parts.append(f"  {status.upper()}:")
+                for fact in nb_bucket:
+                    reason = (
+                        f" [reason: {fact.status_reason}]" if fact.status_reason else ""
+                    )
+                    speaker = f" (speaker: {fact.speaker})" if fact.speaker else ""
+                    parts.append(f"    - [{fact.id}] {fact.text}{speaker}{reason}")
+
     return "\n".join(parts)
 
 
@@ -136,6 +165,7 @@ def run(
     wiki_setting: str,
     client: OpenRouterClient,
     model: str,
+    linked_facts: list[tuple[EntityRow, list[FactRow]]] | None = None,
 ) -> SummarizeResult:
     """Run Stage 4 LLM call for one entity; return SummarizeResult.
 
@@ -147,6 +177,7 @@ def run(
         facts=facts,
         entity_index=entity_index,
         wiki_setting=wiki_setting,
+        linked_facts=linked_facts,
     )
     messages = [
         {
@@ -324,11 +355,13 @@ def summarize_entity(
     wiki_setting: str,
     client: OpenRouterClient,
     model: str,
+    linked_facts: list[tuple[EntityRow, list[FactRow]]] | None = None,
 ) -> Path:
     """Render entity page (LLM prose or stub); write atomically. Return path.
 
     Zero-fact entities: write mechanical stub, no LLM call.
     Entities with facts: call LLM, write prose page.
+    linked_facts: linked-entity (entity, facts) pairs for synthesis context.
     """
     entity = entities_mod.get_entity(conn, category, slug)
     if entity is None:
@@ -347,6 +380,7 @@ def summarize_entity(
             wiki_setting=wiki_setting,
             client=client,
             model=model,
+            linked_facts=linked_facts,
         )
         prose = result.prose
 

--- a/src/auto_lorebook/stage4.py
+++ b/src/auto_lorebook/stage4.py
@@ -1,0 +1,363 @@
+"""Stage 4: LLM-prose entity summarizer.
+
+Generates readable prose pages for entities with approved facts.
+Zero-fact entities get a mechanical stub with no LLM call.
+
+Public API:
+    Stage4Error, SummarizeResult
+    build_prompt, parse_response, run
+    render_entity_page, summarize_entity
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from auto_lorebook import entities as entities_mod
+from auto_lorebook import facts as facts_mod
+from auto_lorebook._io import atomic_write_text
+from auto_lorebook.llm_helpers import build_system_prompt, parse_json_object
+
+if TYPE_CHECKING:
+    import sqlite3
+    from pathlib import Path
+
+    from auto_lorebook.entities import AliasRow, EntityRow
+    from auto_lorebook.facts import FactRow
+    from auto_lorebook.openrouter import OpenRouterClient
+
+_logger = logging.getLogger(__name__)
+
+_STATUS_ORDER = ("authoritative", "trustworthy", "hearsay", "disproven")
+
+_TASK_INSTRUCTIONS = """\
+You are writing a prose summary for one entity in a worldbuilding wiki.
+The entity's facts (approved claims from transcripts) are listed below,
+grouped by epistemic status. Write a cohesive, readable summary paragraph
+that integrates these facts naturally.
+
+Rules:
+- Write in third person, present tense.
+- Authoritative facts: state as plain fact.
+- Trustworthy facts: attribute to source ("According to X, ...").
+- Hearsay facts: hedge appropriately ("Some accounts suggest ...", "Rumors hold ...").
+- Disproven facts: do NOT include in the prose; they appear only in the Facts section.
+- Be concise. One to three paragraphs.
+- Do NOT invent facts beyond what is listed.
+
+Emit a single JSON object:
+{
+  "prose": "<the prose summary>"
+}
+
+Emit ONLY the JSON object. No prose outside it, no code fences.
+"""
+
+
+class Stage4Error(RuntimeError):
+    """Stage 4 failed: bad LLM output or schema violation."""
+
+
+@dataclass(frozen=True)
+class SummarizeResult:
+    """LLM output from the summarizer stage."""
+
+    prose: str
+
+
+def build_prompt(
+    *,
+    entity: EntityRow,
+    aliases: list[AliasRow],
+    facts: list[FactRow],
+    entity_index: str,
+    wiki_setting: str,
+) -> str:
+    """Assemble user message from entity facts, index, and wiki setting."""
+    parts: list[str] = []
+
+    if wiki_setting.strip():
+        parts.extend(["Setting context:", wiki_setting.strip(), ""])
+
+    parts.extend([
+        f"Entity: {entity.canonical_name}",
+        f"Category: {entity.category}",
+    ])
+    if aliases:
+        alias_names = ", ".join(a.name for a in aliases)
+        parts.append(f"Aliases: {alias_names}")
+    parts.append("")
+
+    if entity_index.strip():
+        parts.extend([
+            "Entity index (for cross-reference awareness):",
+            entity_index.strip(),
+            "",
+        ])
+
+    # group facts by status
+    by_status: dict[str, list[FactRow]] = {s: [] for s in _STATUS_ORDER}
+    for fact in facts:
+        bucket = fact.status if fact.status in by_status else "hearsay"
+        by_status[bucket].append(fact)
+
+    parts.append("Facts (by epistemic status):")
+    for status in _STATUS_ORDER:
+        bucket = by_status[status]
+        if not bucket:
+            continue
+        parts.append(f"\n{status.upper()}:")
+        for fact in bucket:
+            reason = f" [reason: {fact.status_reason}]" if fact.status_reason else ""
+            speaker = f" (speaker: {fact.speaker})" if fact.speaker else ""
+            parts.append(f"  - [{fact.id}] {fact.text}{speaker}{reason}")
+    return "\n".join(parts)
+
+
+def parse_response(payload: dict[str, Any]) -> SummarizeResult:
+    """Extract SummarizeResult from LLM JSON payload.
+
+    :raises Stage4Error: missing prose field
+    """
+    if "prose" not in payload:
+        msg = "Stage 4 response missing required 'prose' field"
+        raise Stage4Error(msg)
+    return SummarizeResult(prose=str(payload["prose"]))
+
+
+def run(
+    *,
+    entity: EntityRow,
+    aliases: list[AliasRow],
+    facts: list[FactRow],
+    entity_index: str,
+    wiki_setting: str,
+    client: OpenRouterClient,
+    model: str,
+) -> SummarizeResult:
+    """Run Stage 4 LLM call for one entity; return SummarizeResult.
+
+    :raises Stage4Error: bad LLM output
+    """
+    user_msg = build_prompt(
+        entity=entity,
+        aliases=aliases,
+        facts=facts,
+        entity_index=entity_index,
+        wiki_setting=wiki_setting,
+    )
+    messages = [
+        {
+            "role": "system",
+            "content": build_system_prompt("", _TASK_INSTRUCTIONS),
+        },
+        {"role": "user", "content": user_msg},
+    ]
+    resp = client.complete(
+        messages,
+        model=model,
+        response_format={"type": "json_object"},
+    )
+    try:
+        payload = parse_json_object(resp.text, "Stage 4")
+    except ValueError as e:
+        raise Stage4Error(str(e)) from e
+    return parse_response(payload)
+
+
+def _source_url_with_ts(source_url: str | None, locator: str) -> str | None:
+    """Append timestamp query param to YouTube URLs."""
+    if not source_url:
+        return None
+    parts = locator.split(":")
+    try:
+        if len(parts) == 3:
+            h, m, s = int(parts[0]), int(parts[1]), int(float(parts[2]))
+            secs = h * 3600 + m * 60 + s
+        elif len(parts) == 2:
+            m, s = int(parts[0]), int(float(parts[1]))
+            secs = m * 60 + s
+        else:
+            return source_url
+    except (ValueError, IndexError):
+        return source_url
+    if "youtube.com" in source_url or "youtu.be" in source_url:
+        sep = "&" if "?" in source_url else "?"
+        return f"{source_url}{sep}t={secs}"
+    return source_url
+
+
+def _resolve_source_url(
+    conn: sqlite3.Connection | None,
+    source_id: str,
+    locator: str,
+) -> str | None:
+    """Look up source URL and apply timestamp; returns None if conn is None."""
+    if conn is None:
+        return None
+    row = conn.execute(
+        "SELECT source_url FROM sources WHERE source_id=?",
+        (source_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return _source_url_with_ts(row[0], locator)
+
+
+def render_entity_page(
+    *,
+    entity: EntityRow,
+    aliases: list[AliasRow],
+    facts: list[FactRow],
+    prose: str | None,
+    conn: sqlite3.Connection | None,
+) -> str:
+    """Render full Markdown page for entity.
+
+    Zero-fact entities (prose=None): mechanical stub, no ``## Summary``.
+    Entities with facts: ``## Summary`` + prose + status-grouped facts + references.
+    """
+    lines: list[str] = [f"# {entity.canonical_name}", ""]
+
+    if aliases:
+        lines.extend(["## Aliases", *[f"- {a.name}" for a in aliases], ""])
+
+    # zero-fact stub — minimal mechanical output
+    if not facts or prose is None:
+        return "\n".join(lines)
+
+    # prose summary section
+    lines.extend(["## Summary", "", prose.strip(), ""])
+
+    # group facts by status; assign footnote numbers
+    by_status: dict[str, list[FactRow]] = {s: [] for s in _STATUS_ORDER}
+    for fact in facts:
+        bucket = fact.status if fact.status in by_status else "hearsay"
+        by_status[bucket].append(fact)
+
+    # build footnote index: fact_id → footnote number
+    fn_counter = 0
+    fact_footnote: dict[str, int] = {}
+    for status in _STATUS_ORDER:
+        for fact in by_status[status]:
+            fn_counter += 1
+            fact_footnote[fact.id] = fn_counter
+
+    # ## Facts section
+    lines.extend(["## Facts", ""])
+    for status in _STATUS_ORDER:
+        bucket = by_status[status]
+        if not bucket:
+            continue
+        lines.extend((f"### {status.capitalize()}", ""))
+        for fact in bucket:
+            fn = fact_footnote[fact.id]
+            if status == "disproven":
+                text_part = f"~~{fact.text}~~"
+                reason_part = f" — {fact.status_reason}" if fact.status_reason else ""
+                lines.append(f"[^{fn}]: {text_part}{reason_part}")
+            else:
+                lines.append(f"[^{fn}]: {fact.text}")
+        lines.append("")
+
+    # ## References section
+    source_ids_seen: list[str] = []
+    source_ids_set: set[str] = set()
+    for status in _STATUS_ORDER:
+        for fact in by_status[status]:
+            if fact.source_id not in source_ids_set:
+                source_ids_set.add(fact.source_id)
+                source_ids_seen.append(fact.source_id)
+
+    if source_ids_seen:
+        lines.extend(["## References", ""])
+        for i, source_id in enumerate(source_ids_seen, start=1):
+            url: str | None = None
+            title: str | None = None
+            if conn is not None:
+                row = conn.execute(
+                    "SELECT source_url, title FROM sources WHERE source_id=?",
+                    (source_id,),
+                ).fetchone()
+                if row:
+                    url = row[0]
+                    title = row[1] if len(row) > 1 else None
+            label = title or source_id
+            if url:
+                lines.append(f"{i}. {label} — {url}")
+            else:
+                lines.append(f"{i}. {label}")
+        lines.append("")
+
+    # per-fact footnote citations with full details
+    lines.append("")
+    for status in _STATUS_ORDER:
+        for fact in by_status[status]:
+            fn = fact_footnote[fact.id]
+            src_url = _resolve_source_url(conn, fact.source_id, fact.locator)
+            link = f"[{fact.locator}]({src_url})" if src_url else fact.locator
+            speaker = f"— {fact.speaker}, " if fact.speaker else ""
+            session = f" (session: {fact.session_date})" if fact.session_date else ""
+            quote = f'"{fact.text}"'
+            if status == "disproven":
+                reason = f"\n  *{fact.status_reason}*" if fact.status_reason else ""
+                lines.append(f"[^{fn}]: {quote}  {speaker}{link}{session}{reason}")
+            else:
+                lines.append(f"[^{fn}]: {quote}  {speaker}{link}{session}")
+
+    return "\n".join(lines)
+
+
+def _summary_path(wiki_repo: Path, category: str, slug: str) -> Path:
+    return wiki_repo / category / f"{slug}.md"
+
+
+def summarize_entity(
+    conn: sqlite3.Connection,
+    wiki_repo: Path,
+    category: str,
+    slug: str,
+    *,
+    entity_index: str,
+    wiki_setting: str,
+    client: OpenRouterClient,
+    model: str,
+) -> Path:
+    """Render entity page (LLM prose or stub); write atomically. Return path.
+
+    Zero-fact entities: write mechanical stub, no LLM call.
+    Entities with facts: call LLM, write prose page.
+    """
+    entity = entities_mod.get_entity(conn, category, slug)
+    if entity is None:
+        msg = f"entity not found: {category}/{slug}"
+        raise ValueError(msg)
+    aliases = entities_mod.list_aliases(conn, category, slug)
+    fact_rows = facts_mod.list_facts_by_entity(conn, category, slug)
+
+    prose: str | None = None
+    if fact_rows:
+        result = run(
+            entity=entity,
+            aliases=aliases,
+            facts=fact_rows,
+            entity_index=entity_index,
+            wiki_setting=wiki_setting,
+            client=client,
+            model=model,
+        )
+        prose = result.prose
+
+    text = render_entity_page(
+        entity=entity,
+        aliases=aliases,
+        facts=fact_rows,
+        prose=prose,
+        conn=conn,
+    )
+    path = _summary_path(wiki_repo, category, slug)
+    atomic_write_text(path, text)
+    _logger.debug("stage4: wrote %s", path)
+    return path

--- a/src/auto_lorebook/stage4.py
+++ b/src/auto_lorebook/stage4.py
@@ -13,6 +13,7 @@ Public API:
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -50,6 +51,8 @@ Rules:
 - Linked-entity facts (below): you MAY synthesize a claim drawn from a
   linked entity's fact, with the same epistemic-status hedging as above.
   Do not fabricate beyond what is listed.
+- Markers: use [[category/slug]] to link an entity by name (e.g. [[locations/aldara]]);
+  use [[fact:<fact_id>]] to cite a linked entity's fact (e.g. [[fact:f-n01]]).
 
 Emit a single JSON object:
 {
@@ -198,6 +201,69 @@ def run(
     return parse_response(payload)
 
 
+_ENTITY_LINK_RE = re.compile(r"\[\[([a-z0-9-]+)/([a-z0-9-]+)\]\]")
+_FACT_REF_RE = re.compile(r"\[\[fact:([^\]]+)\]\]")
+
+
+def _resolve_entity_links(
+    prose: str,
+    entity_lookup: dict[tuple[str, str], EntityRow],
+    *,
+    from_category: str,
+) -> str:
+    """Scan [[category/slug]] markers; resolve to markdown links or plain text.
+
+    Same-category: bare ``slug.md``; cross-category: ``../category/slug.md``.
+    Unresolvable: raw ``category/slug`` text + logged warning.  Never raises.
+    """
+
+    def _replace(m: re.Match[str]) -> str:
+        cat, slug = m.group(1), m.group(2)
+        entity = entity_lookup.get((cat, slug))
+        if entity is None:
+            _logger.warning("unresolvable entity marker: %s/%s", cat, slug)
+            return f"{cat}/{slug}"
+        path = f"{slug}.md" if cat == from_category else f"../{cat}/{slug}.md"
+        return f"[{entity.canonical_name}]({path})"
+
+    return _ENTITY_LINK_RE.sub(_replace, prose)
+
+
+def _resolve_crossref_markers(
+    prose: str,
+    linked_fact_index: dict[str, tuple[EntityRow, FactRow]],
+    *,
+    from_category: str,
+) -> tuple[str, list[str]]:
+    """Scan [[fact:<id>]] markers; resolve to footnote refs + footnote defs.
+
+    Resolvable: inline marker → ``[^<id>]``; footnote def quotes linked fact
+    text and links to linked entity's page anchored at ``#fn:<id>``.
+    Unresolvable: plain text + logged warning.  Never raises.
+    Returns (rewritten_prose, footnote_def_lines).
+    """
+    footnote_defs: list[str] = []
+
+    def _replace(m: re.Match[str]) -> str:
+        fact_id = m.group(1)
+        entry = linked_fact_index.get(fact_id)
+        if entry is None:
+            _logger.warning("unresolvable fact marker: %s", fact_id)
+            return fact_id
+        linked_ent, linked_fact = entry
+        cat = linked_ent.category
+        slug = linked_ent.slug
+        path = f"{slug}.md" if cat == from_category else f"../{cat}/{slug}.md"
+        anchor = f"#fn:{fact_id}"
+        quote = f'"{linked_fact.text}"'
+        link = f"[{linked_ent.canonical_name}]({path}{anchor})"
+        footnote_defs.append(f"[^{fact_id}]: {quote} — {link}")
+        return f"[^{fact_id}]"
+
+    rewritten = _FACT_REF_RE.sub(_replace, prose)
+    return rewritten, footnote_defs
+
+
 def _source_url_with_ts(source_url: str | None, locator: str) -> str | None:
     """Append timestamp query param to YouTube URLs."""
     if not source_url:
@@ -244,11 +310,15 @@ def render_entity_page(
     facts: list[FactRow],
     prose: str | None,
     conn: sqlite3.Connection | None,
+    entity_lookup: dict[tuple[str, str], EntityRow] | None = None,
+    linked_facts: list[tuple[EntityRow, list[FactRow]]] | None = None,
 ) -> str:
     """Render full Markdown page for entity.
 
     Zero-fact entities (prose=None): mechanical stub, no ``## Summary``.
     Entities with facts: ``## Summary`` + prose + status-grouped facts + references.
+    entity_lookup: index for [[category/slug]] marker resolution.
+    linked_facts: linked-entity pairs for [[fact:<id>]] crossref resolution.
     """
     lines: list[str] = [f"# {entity.canonical_name}", ""]
 
@@ -259,22 +329,31 @@ def render_entity_page(
     if not facts or prose is None:
         return "\n".join(lines)
 
-    # prose summary section
-    lines.extend(["## Summary", "", prose.strip(), ""])
+    # resolve entity-link and crossref markers in prose
+    resolved_prose = prose.strip()
+    crossref_footnote_defs: list[str] = []
+    if entity_lookup is not None:
+        resolved_prose = _resolve_entity_links(
+            resolved_prose, entity_lookup, from_category=entity.category
+        )
+    if linked_facts is not None:
+        # build flat index: fact_id → (entity, fact)
+        linked_fact_index: dict[str, tuple[EntityRow, FactRow]] = {}
+        for linked_ent, linked_fact_rows in linked_facts:
+            for lf in linked_fact_rows:
+                linked_fact_index[lf.id] = (linked_ent, lf)
+        resolved_prose, crossref_footnote_defs = _resolve_crossref_markers(
+            resolved_prose, linked_fact_index, from_category=entity.category
+        )
 
-    # group facts by status; assign footnote numbers
+    # prose summary section
+    lines.extend(["## Summary", "", resolved_prose, ""])
+
+    # group facts by status; use fact.id as stable anchor label
     by_status: dict[str, list[FactRow]] = {s: [] for s in _STATUS_ORDER}
     for fact in facts:
         bucket = fact.status if fact.status in by_status else "hearsay"
         by_status[bucket].append(fact)
-
-    # build footnote index: fact_id → footnote number
-    fn_counter = 0
-    fact_footnote: dict[str, int] = {}
-    for status in _STATUS_ORDER:
-        for fact in by_status[status]:
-            fn_counter += 1
-            fact_footnote[fact.id] = fn_counter
 
     # ## Facts section
     lines.extend(["## Facts", ""])
@@ -284,13 +363,12 @@ def render_entity_page(
             continue
         lines.extend((f"### {status.capitalize()}", ""))
         for fact in bucket:
-            fn = fact_footnote[fact.id]
             if status == "disproven":
                 text_part = f"~~{fact.text}~~"
                 reason_part = f" — {fact.status_reason}" if fact.status_reason else ""
-                lines.append(f"[^{fn}]: {text_part}{reason_part}")
+                lines.append(f"[^{fact.id}]: {text_part}{reason_part}")
             else:
-                lines.append(f"[^{fn}]: {fact.text}")
+                lines.append(f"[^{fact.id}]: {fact.text}")
         lines.append("")
 
     # ## References section
@@ -326,7 +404,6 @@ def render_entity_page(
     lines.append("")
     for status in _STATUS_ORDER:
         for fact in by_status[status]:
-            fn = fact_footnote[fact.id]
             src_url = _resolve_source_url(conn, fact.source_id, fact.locator)
             link = f"[{fact.locator}]({src_url})" if src_url else fact.locator
             speaker = f"— {fact.speaker}, " if fact.speaker else ""
@@ -334,9 +411,14 @@ def render_entity_page(
             quote = f'"{fact.text}"'
             if status == "disproven":
                 reason = f"\n  *{fact.status_reason}*" if fact.status_reason else ""
-                lines.append(f"[^{fn}]: {quote}  {speaker}{link}{session}{reason}")
+                lines.append(f"[^{fact.id}]: {quote}  {speaker}{link}{session}{reason}")
             else:
-                lines.append(f"[^{fn}]: {quote}  {speaker}{link}{session}")
+                lines.append(f"[^{fact.id}]: {quote}  {speaker}{link}{session}")
+
+    # crossref footnote defs (linked-entity citations)
+    if crossref_footnote_defs:
+        lines.append("")
+        lines.extend(crossref_footnote_defs)
 
     return "\n".join(lines)
 
@@ -370,6 +452,12 @@ def summarize_entity(
     aliases = entities_mod.list_aliases(conn, category, slug)
     fact_rows = facts_mod.list_facts_by_entity(conn, category, slug)
 
+    # build entity lookup for [[category/slug]] marker resolution
+    all_entities = entities_mod.list_entities(conn)
+    entity_lookup: dict[tuple[str, str], EntityRow] = {
+        (e.category, e.slug): e for e in all_entities
+    }
+
     prose: str | None = None
     if fact_rows:
         result = run(
@@ -390,6 +478,8 @@ def summarize_entity(
         facts=fact_rows,
         prose=prose,
         conn=conn,
+        entity_lookup=entity_lookup,
+        linked_facts=linked_facts,
     )
     path = _summary_path(wiki_repo, category, slug)
     atomic_write_text(path, text)

--- a/src/auto_lorebook/stage4.py
+++ b/src/auto_lorebook/stage4.py
@@ -243,6 +243,7 @@ def _resolve_crossref_markers(
     Returns (rewritten_prose, footnote_def_lines).
     """
     footnote_defs: list[str] = []
+    seen_fact_ids: set[str] = set()
 
     def _replace(m: re.Match[str]) -> str:
         fact_id = m.group(1)
@@ -257,7 +258,9 @@ def _resolve_crossref_markers(
         anchor = f"#fn:{fact_id}"
         quote = f'"{linked_fact.text}"'
         link = f"[{linked_ent.canonical_name}]({path}{anchor})"
-        footnote_defs.append(f"[^{fact_id}]: {quote} — {link}")
+        if fact_id not in seen_fact_ids:
+            seen_fact_ids.add(fact_id)
+            footnote_defs.append(f"[^{fact_id}]: {quote} — {link}")
         return f"[^{fact_id}]"
 
     rewritten = _FACT_REF_RE.sub(_replace, prose)

--- a/src/auto_lorebook/staleness_store.py
+++ b/src/auto_lorebook/staleness_store.py
@@ -1,0 +1,103 @@
+"""DB-backed staleness store for wiki page rebuild skip logic.
+
+Public API:
+    compute_page_inputs_hash(*, entity, aliases, facts, linked_facts,
+                              entity_index, wiki_setting, model, model_params) -> str
+    get_page_hash(conn, category, slug) -> str | None
+    record_page_hash(conn, category, slug, inputs_sha256, *, generated_at) -> None
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING
+
+from auto_lorebook.timestamps import format_iso_now
+
+if TYPE_CHECKING:
+    import sqlite3
+
+    from auto_lorebook.entities import AliasRow, EntityRow
+    from auto_lorebook.facts import FactRow
+
+
+def _fact_tuple(fact: FactRow) -> list[object]:
+    """Fixed-order list of prose-affecting fields from a FactRow."""
+    return [
+        fact.id,
+        fact.text,
+        fact.status,
+        fact.status_reason,
+        fact.speaker,
+        fact.source_id,
+        fact.locator,
+        fact.session_date,
+    ]
+
+
+def compute_page_inputs_hash(
+    *,
+    entity: EntityRow,  # noqa: ARG001
+    aliases: list[AliasRow],  # noqa: ARG001
+    facts: list[FactRow],
+    linked_facts: list[tuple[EntityRow, list[FactRow]]],
+    entity_index: str,
+    wiki_setting: str,
+    model: str,
+    model_params: dict[str, object],
+) -> str:
+    """SHA-256 of canonical inputs that affect generated prose.
+
+    Deterministic; order of facts/linked_facts does not matter.
+    ``entity`` and ``aliases`` reserved for future use; not hashed today.
+    """
+    obj = {
+        "own_facts": [_fact_tuple(f) for f in sorted(facts, key=lambda f: f.id)],
+        "linked_facts": [
+            {
+                "entity": f"{le.category}/{le.slug}",
+                "facts": [_fact_tuple(f) for f in sorted(lf, key=lambda f: f.id)],
+            }
+            for le, lf in sorted(
+                linked_facts, key=lambda p: f"{p[0].category}/{p[0].slug}"
+            )
+        ],
+        "entity_index": entity_index,
+        "wiki_setting": wiki_setting,
+        "model": model,
+        "model_params": model_params,
+    }
+    serialized = json.dumps(
+        obj, sort_keys=True, ensure_ascii=False, separators=(",", ":")
+    )
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+def get_page_hash(conn: sqlite3.Connection, category: str, slug: str) -> str | None:
+    """Return stored inputs_sha256 for (category, slug), or None if absent."""
+    row = conn.execute(
+        "SELECT inputs_sha256 FROM entity_page_staleness WHERE category=? AND slug=?",
+        (category, slug),
+    ).fetchone()
+    return row[0] if row else None
+
+
+def record_page_hash(
+    conn: sqlite3.Connection,
+    category: str,
+    slug: str,
+    inputs_sha256: str,
+    *,
+    generated_at: str | None = None,
+) -> None:
+    """Upsert (category, slug) staleness row with given hash and timestamp."""
+    ts = generated_at if generated_at is not None else format_iso_now()
+    conn.execute(
+        "INSERT INTO entity_page_staleness(category, slug, inputs_sha256, generated_at)"
+        " VALUES (?, ?, ?, ?)"
+        " ON CONFLICT(category, slug) DO UPDATE SET"
+        "  inputs_sha256=excluded.inputs_sha256,"
+        "  generated_at=excluded.generated_at",
+        (category, slug, inputs_sha256, ts),
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -88,6 +88,40 @@ def test_load_config_with_all_fields(tmp_path: Path) -> None:
     assert cfg.preamble.budget_fraction == pytest.approx(0.6)
 
 
+def test_models_config_summarizer_slot(tmp_path: Path) -> None:
+    """ModelsConfig has summarizer slot; defaults None; loads from config."""
+    wiki_path = str(tmp_path / "wiki")
+    _write_config(
+        tmp_path / "config.yaml",
+        {
+            "schema_version": 2,
+            "wikis": [{"nickname": "main", "path": wiki_path}],
+            "active_wiki": "main",
+            "models": {
+                "primary": "anthropic/claude-sonnet-4-5",
+                "summarizer": "anthropic/claude-haiku-4-5",
+            },
+        },
+    )
+    cfg = load_config(home=tmp_path)
+    assert cfg.models.summarizer == "anthropic/claude-haiku-4-5"
+
+
+def test_models_config_summarizer_defaults_none() -> None:
+    """Summarizer defaults to None when not set."""
+    cfg = ModelsConfig()
+    assert cfg.summarizer is None
+
+
+def test_models_config_summarizer_fallback_to_primary() -> None:
+    """Summarizer or primary gives primary when summarizer is None."""
+    cfg = ModelsConfig(primary="anthropic/claude-sonnet-4-5")
+    assert cfg.summarizer is None
+    # consumer code pattern: cfg.models.summarizer or cfg.models.primary
+    effective = cfg.summarizer or cfg.primary
+    assert effective == "anthropic/claude-sonnet-4-5"
+
+
 def test_load_config_missing_file_raises(tmp_path: Path) -> None:
     with pytest.raises(MissingConfigError, match="not found"):
         load_config(home=tmp_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ from auto_lorebook.config import (
     ModelsConfig,
     OpenRouterConfig,
     PreambleConfig,
+    SummarizerConfig,
     interactive_setup,
     load_config,
     load_last_context,
@@ -544,3 +545,69 @@ def test_save_config_roundtrip(tmp_path: Path) -> None:
     assert reloaded.openrouter.api_key_env == "MY_KEY"
     assert reloaded.models.primary == "anthropic/claude-opus-4-7"
     assert reloaded.preamble.budget_fraction == pytest.approx(0.6)
+
+
+# ---------------------------------------------------------------------------
+# SummarizerConfig
+# ---------------------------------------------------------------------------
+
+
+def test_summarizer_config_default() -> None:
+    """SummarizerConfig defaults to 0.25 linked_context_budget_fraction."""
+    cfg = SummarizerConfig()
+    assert cfg.linked_context_budget_fraction == pytest.approx(0.25)
+
+
+def test_config_has_summarizer_field() -> None:
+    """Config has summarizer field defaulting to SummarizerConfig()."""
+    cfg = Config(wikis=[], active_wiki=None)
+    assert isinstance(cfg.summarizer, SummarizerConfig)
+    assert cfg.summarizer.linked_context_budget_fraction == pytest.approx(0.25)
+
+
+def test_load_config_summarizer_from_yaml(tmp_path: Path) -> None:
+    """summarizer.linked_context_budget_fraction loaded from YAML."""
+    wiki_path = str(tmp_path / "wiki")
+    _write_config(
+        tmp_path / "config.yaml",
+        {
+            "schema_version": 2,
+            "wikis": [{"nickname": "main", "path": wiki_path}],
+            "active_wiki": "main",
+            "summarizer": {"linked_context_budget_fraction": 0.15},
+        },
+    )
+    cfg = load_config(home=tmp_path)
+    assert cfg.summarizer.linked_context_budget_fraction == pytest.approx(0.15)
+
+
+def test_load_config_summarizer_defaults_when_absent(tmp_path: Path) -> None:
+    """Missing summarizer block defaults to SummarizerConfig()."""
+    wiki_path = str(tmp_path / "wiki")
+    _write_config(
+        tmp_path / "config.yaml",
+        {
+            "schema_version": 2,
+            "wikis": [{"nickname": "main", "path": wiki_path}],
+            "active_wiki": "main",
+        },
+    )
+    cfg = load_config(home=tmp_path)
+    assert cfg.summarizer.linked_context_budget_fraction == pytest.approx(0.25)
+
+
+def test_save_config_writes_summarizer_block(tmp_path: Path) -> None:
+    """save_config writes summarizer section; round-trip preserves value."""
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    cfg = Config(
+        wikis=[WikiEntry("main", wiki)],
+        active_wiki="main",
+        summarizer=SummarizerConfig(linked_context_budget_fraction=0.3),
+    )
+    save_config(cfg, home=tmp_path)
+    raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+    assert raw["summarizer"]["linked_context_budget_fraction"] == pytest.approx(0.3)
+
+    reloaded = load_config(home=tmp_path)
+    assert reloaded.summarizer.linked_context_budget_fraction == pytest.approx(0.3)

--- a/tests/test_db_migrations.py
+++ b/tests/test_db_migrations.py
@@ -34,6 +34,7 @@ _EXPECTED_TABLES = frozenset({
     "proposals",
     "plan_metadata",
     "proposal_targets",
+    "entity_page_staleness",
 })
 
 
@@ -479,3 +480,109 @@ def test_migration_004_preserves_existing_rows(tmp_path: Path) -> None:
     assert seg_row is not None
     assert seg_row[0] == "seg-001"
     assert pm_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Migration 006 specific tests
+# ---------------------------------------------------------------------------
+
+
+def test_migration_006_entity_page_staleness_exists() -> None:
+    """entity_page_staleness has expected columns after full migration."""
+    conn = db.open(":memory:")
+    cols = {
+        row[1]
+        for row in conn.execute("PRAGMA table_info(entity_page_staleness)").fetchall()
+    }
+    conn.close()
+    assert cols == {"category", "slug", "inputs_sha256", "generated_at"}
+
+
+def test_migration_006_preserves_existing_rows(tmp_path: Path) -> None:
+    """Rows from v5 survive migration 006; entity_page_staleness starts empty."""
+    from auto_lorebook.db.migrations import (  # noqa: PLC0415
+        _migration_001_initial,
+        _migration_002_widen_source_type,
+        _migration_003_fix_segment_status_and_add_flags_json,
+        _migration_004_plan_metadata_and_flag_reason,
+        _migration_005_multi_target_proposals,
+    )
+
+    db_path = tmp_path / "wiki.db"
+    raw = sqlite3.connect(str(db_path))
+    raw.execute("PRAGMA foreign_keys=ON")
+    _migration_001_initial(raw)
+    _migration_002_widen_source_type(raw)
+    _migration_003_fix_segment_status_and_add_flags_json(raw)
+    _migration_004_plan_metadata_and_flag_reason(raw)
+    _migration_005_multi_target_proposals(raw)
+    raw.execute(
+        "INSERT INTO sources(source_id, source_type, fetched_at)"
+        " VALUES ('s1', 'srt', '2026-01-01T00:00:00+00:00')"
+    )
+    raw.execute(
+        "INSERT INTO ingests(ingest_id, source_id, started_at, state)"
+        " VALUES ('i1', 's1', '2026-01-01T00:00:00+00:00', 'done')"
+    )
+    raw.execute(
+        "INSERT INTO entities(category, slug, canonical_name, created_at,"
+        " created_by_ingest, updated_at)"
+        " VALUES ('characters', 'theron', 'Theron',"
+        " '2026-01-01T00:00:00+00:00', 'i1', '2026-01-01T00:00:00+00:00')"
+    )
+    raw.execute("DELETE FROM schema_version")
+    raw.execute("INSERT INTO schema_version(version) VALUES (5)")
+    raw.commit()
+    raw.close()
+
+    conn = db.open(db_path)
+    version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
+    ent_row = conn.execute("SELECT slug FROM entities WHERE slug='theron'").fetchone()
+    staleness_count = conn.execute(
+        "SELECT COUNT(*) FROM entity_page_staleness"
+    ).fetchone()[0]
+    conn.close()
+
+    assert version == CURRENT_SCHEMA_VERSION
+    assert ent_row is not None
+    assert staleness_count == 0
+
+
+def test_migration_006_fk_cascade_deletes_staleness_row() -> None:
+    """Deleting an entity CASCADE-deletes its entity_page_staleness row."""
+    conn = db.open(":memory:")
+    conn.execute(
+        "INSERT INTO sources(source_id, source_type, fetched_at)"
+        " VALUES ('s1', 'srt', '2026-01-01T00:00:00+00:00')"
+    )
+    conn.execute(
+        "INSERT INTO ingests(ingest_id, source_id, started_at, state)"
+        " VALUES ('i1', 's1', '2026-01-01T00:00:00+00:00', 'done')"
+    )
+    conn.execute(
+        "INSERT INTO entities(category, slug, canonical_name, created_at,"
+        " created_by_ingest, updated_at)"
+        " VALUES ('characters', 'theron', 'Theron',"
+        " '2026-01-01T00:00:00+00:00', 'i1', '2026-01-01T00:00:00+00:00')"
+    )
+    conn.execute(
+        "INSERT INTO entity_page_staleness(category, slug, inputs_sha256, generated_at)"
+        " VALUES ('characters', 'theron', 'abc123', '2026-01-01T00:00:00+00:00')"
+    )
+    conn.commit()
+
+    # verify staleness row exists before delete
+    before = conn.execute(
+        "SELECT COUNT(*) FROM entity_page_staleness WHERE slug='theron'"
+    ).fetchone()[0]
+    assert before == 1
+
+    # delete entity → CASCADE deletes staleness row
+    conn.execute("DELETE FROM entities WHERE category='characters' AND slug='theron'")
+    conn.commit()
+
+    after = conn.execute(
+        "SELECT COUNT(*) FROM entity_page_staleness WHERE slug='theron'"
+    ).fetchone()[0]
+    conn.close()
+    assert after == 0

--- a/tests/test_db_migrations.py
+++ b/tests/test_db_migrations.py
@@ -198,7 +198,7 @@ def test_migration_002_preserves_existing_rows(tmp_path: Path) -> None:
 
     # Create a v1 DB (only migration 001)
     from auto_lorebook.db.migrations import (  # noqa: PLC0415
-        _migration_001_initial,  # noqa: PLC2701
+        _migration_001_initial,
     )
 
     raw = sqlite3.connect(str(db_path))
@@ -263,8 +263,8 @@ def test_migration_003_preserves_existing_rows(tmp_path: Path) -> None:
     db_path = tmp_path / "wiki.db"
 
     from auto_lorebook.db.migrations import (  # noqa: PLC0415
-        _migration_001_initial,  # noqa: PLC2701
-        _migration_002_widen_source_type,  # noqa: PLC2701
+        _migration_001_initial,
+        _migration_002_widen_source_type,
     )
 
     raw = sqlite3.connect(str(db_path))
@@ -371,10 +371,10 @@ def test_migration_005_drops_per_target_columns_from_proposals() -> None:
 def test_migration_005_preserves_existing_rows(tmp_path: Path) -> None:
     """Rows from v4 survive migration 005; proposal_targets populated from proposals."""
     from auto_lorebook.db.migrations import (  # noqa: PLC0415
-        _migration_001_initial,  # noqa: PLC2701
-        _migration_002_widen_source_type,  # noqa: PLC2701
-        _migration_003_fix_segment_status_and_add_flags_json,  # noqa: PLC2701
-        _migration_004_plan_metadata_and_flag_reason,  # noqa: PLC2701
+        _migration_001_initial,
+        _migration_002_widen_source_type,
+        _migration_003_fix_segment_status_and_add_flags_json,
+        _migration_004_plan_metadata_and_flag_reason,
     )
 
     db_path = tmp_path / "wiki.db"
@@ -437,9 +437,9 @@ def test_migration_005_preserves_existing_rows(tmp_path: Path) -> None:
 def test_migration_004_preserves_existing_rows(tmp_path: Path) -> None:
     """Rows from v3 survive migration 004; flag_reason is NULL on legacy proposals."""
     from auto_lorebook.db.migrations import (  # noqa: PLC0415
-        _migration_001_initial,  # noqa: PLC2701
-        _migration_002_widen_source_type,  # noqa: PLC2701
-        _migration_003_fix_segment_status_and_add_flags_json,  # noqa: PLC2701
+        _migration_001_initial,
+        _migration_002_widen_source_type,
+        _migration_003_fix_segment_status_and_add_flags_json,
     )
 
     db_path = tmp_path / "wiki.db"

--- a/tests/test_facts.py
+++ b/tests/test_facts.py
@@ -19,6 +19,7 @@ from auto_lorebook.facts import (
     delete_ref,
     get_fact,
     list_facts_by_entity,
+    list_linked_entities,
     list_refs_by_fact,
     update_status,
 )
@@ -906,3 +907,211 @@ class TestRefAtomicity:
             "SELECT COUNT(*) FROM fact_status_history WHERE fact_id='f-001'"
         ).fetchone()[0]
         assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# Step 8 — list_linked_entities
+# ---------------------------------------------------------------------------
+
+
+def _seed_linked_entities(conn: sqlite3.Connection) -> None:
+    """Seed two extra entities (locations/aldara, factions/guild) for link tests."""
+    conn.execute(
+        "INSERT INTO entities(category, slug, canonical_name, created_at,"
+        " created_by_ingest, updated_at)"
+        " VALUES ('locations', 'aldara', 'Aldara',"
+        " '2026-01-01T00:00:00Z', 'ing-001', '2026-01-01T00:00:00Z')"
+    )
+    conn.execute(
+        "INSERT INTO entities(category, slug, canonical_name, created_at,"
+        " created_by_ingest, updated_at)"
+        " VALUES ('factions', 'guild', 'The Guild',"
+        " '2026-01-01T00:00:00Z', 'ing-001', '2026-01-01T00:00:00Z')"
+    )
+
+
+class TestListLinkedEntities:
+    def test_co_target_returned(self, conn: sqlite3.Connection) -> None:
+        """Fact targeting both theron and aldara → aldara linked to theron."""
+        _seed_linked_entities(conn)
+        create_fact_with_targets(
+            conn,
+            fact_id="f-link-01",
+            text="Theron founded Aldara.",
+            raw_transcript_span="Theron founded Aldara.",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:04:00",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            targets=[
+                ("characters", "theron", "biography"),
+                ("locations", "aldara", "founding"),
+            ],
+            by="test-user",
+        )
+        conn.commit()
+        linked = list_linked_entities(conn, "characters", "theron")
+        assert ("locations", "aldara") in linked
+
+    def test_symmetric(self, conn: sqlite3.Connection) -> None:
+        """Linked relation is symmetric: aldara also linked to theron."""
+        _seed_linked_entities(conn)
+        create_fact_with_targets(
+            conn,
+            fact_id="f-link-01",
+            text="Theron founded Aldara.",
+            raw_transcript_span="Theron founded Aldara.",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:04:00",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            targets=[
+                ("characters", "theron", "biography"),
+                ("locations", "aldara", "founding"),
+            ],
+            by="test-user",
+        )
+        conn.commit()
+        linked = list_linked_entities(conn, "locations", "aldara")
+        assert ("characters", "theron") in linked
+
+    def test_self_excluded(self, conn: sqlite3.Connection) -> None:
+        """Entity not linked to itself."""
+        _seed_linked_entities(conn)
+        create_fact_with_targets(
+            conn,
+            fact_id="f-link-01",
+            text="Theron founded Aldara.",
+            raw_transcript_span="Theron founded Aldara.",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:04:00",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            targets=[
+                ("characters", "theron", "biography"),
+                ("locations", "aldara", "founding"),
+            ],
+            by="test-user",
+        )
+        conn.commit()
+        linked = list_linked_entities(conn, "characters", "theron")
+        assert ("characters", "theron") not in linked
+
+    def test_no_shared_fact_returns_empty(self, conn: sqlite3.Connection) -> None:
+        """Entity with no co-targeted fact returns empty list."""
+        _seed_linked_entities(conn)
+        # theron has a single-target fact
+        _make_fact(conn, fact_id="f-solo", status="authoritative")
+        conn.commit()
+        linked = list_linked_entities(conn, "characters", "theron")
+        assert linked == []
+
+    def test_dedup_multiple_shared_facts(self, conn: sqlite3.Connection) -> None:
+        """Two facts linking same pair → aldara appears once."""
+        _seed_linked_entities(conn)
+        create_fact_with_targets(
+            conn,
+            fact_id="f-link-01",
+            text="Claim one.",
+            raw_transcript_span="Claim one.",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:01:00",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            targets=[
+                ("characters", "theron", "biography"),
+                ("locations", "aldara", "founding"),
+            ],
+            by="test-user",
+        )
+        create_fact_with_targets(
+            conn,
+            fact_id="f-link-02",
+            text="Claim two.",
+            raw_transcript_span="Claim two.",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:02:00",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            targets=[
+                ("characters", "theron", "biography"),
+                ("locations", "aldara", "founding"),
+            ],
+            by="test-user",
+        )
+        conn.commit()
+        linked = list_linked_entities(conn, "characters", "theron")
+        aldara_hits = [e for e in linked if e == ("locations", "aldara")]
+        assert len(aldara_hits) == 1
+
+    def test_superseded_entity_excluded(self, conn: sqlite3.Connection) -> None:
+        """Superseded (non-null superseded_by_*) entity excluded from results."""
+        _seed_linked_entities(conn)
+        # make a third entity that supersedes aldara
+        conn.execute(
+            "INSERT INTO entities(category, slug, canonical_name, created_at,"
+            " created_by_ingest, updated_at)"
+            " VALUES ('locations', 'old-aldara', 'Old Aldara',"
+            " '2026-01-01T00:00:00Z', 'ing-001', '2026-01-01T00:00:00Z')"
+        )
+        # mark old-aldara superseded by aldara
+        conn.execute(
+            "UPDATE entities SET superseded_by_category='locations',"
+            " superseded_by_slug='aldara'"
+            " WHERE category='locations' AND slug='old-aldara'"
+        )
+        create_fact_with_targets(
+            conn,
+            fact_id="f-link-01",
+            text="Shared claim.",
+            raw_transcript_span="Shared claim.",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:01:00",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            targets=[
+                ("characters", "theron", "biography"),
+                ("locations", "old-aldara", "founding"),
+            ],
+            by="test-user",
+        )
+        conn.commit()
+        linked = list_linked_entities(conn, "characters", "theron")
+        assert ("locations", "old-aldara") not in linked
+
+    def test_sorted_by_category_slug(self, conn: sqlite3.Connection) -> None:
+        """Results sorted by (category, slug)."""
+        _seed_linked_entities(conn)
+        create_fact_with_targets(
+            conn,
+            fact_id="f-link-01",
+            text="Three-way claim.",
+            raw_transcript_span="Three-way claim.",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:01:00",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            targets=[
+                ("characters", "theron", "biography"),
+                ("factions", "guild", "members"),
+                ("locations", "aldara", "founding"),
+            ],
+            by="test-user",
+        )
+        conn.commit()
+        linked = list_linked_entities(conn, "characters", "theron")
+        assert linked == [("factions", "guild"), ("locations", "aldara")]

--- a/tests/test_ingest_cleanup.py
+++ b/tests/test_ingest_cleanup.py
@@ -530,3 +530,202 @@ class TestProposalsDirAbsent:
         assert result.stubs_deleted == 1
         # No exception; pending paths just don't exist.
         assert not reading_pipeline.pending_plan_path("yt-x").exists()
+
+
+# ---------------------------------------------------------------------------
+# Page reconciliation during reject-ingest (offline fallback path)
+# ---------------------------------------------------------------------------
+
+
+def _seed_shared_fact(
+    conn: sqlite3.Connection,
+    *,
+    fact_id: str,
+    ingest: str,
+    cat_a: str,
+    slug_a: str,
+    cat_b: str,
+    slug_b: str,
+    text: str = "A shared fact.",
+) -> None:
+    """Seed a fact co-targeting two entities."""
+    conn.execute(
+        "INSERT OR IGNORE INTO sources"
+        "(source_id, source_type, fetched_at, context_json)"
+        " VALUES (?, 'youtube', '2026-01-01T00:00:00Z', '{}')",
+        (ingest,),
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO ingests(ingest_id, source_id, started_at, state)"
+        " VALUES (?, ?, '2026-01-01T00:00:00Z', 'done')",
+        (ingest, ingest),
+    )
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO facts (
+            id, text, raw_transcript_span, text_corrects_transcript,
+            text_source, edited_by_human, edited_at,
+            source_id, locator, speaker,
+            status, status_reason, session_date,
+            approved_at, created_by_ingest, claim_group_id,
+            corrections_applied_json, inputs_json
+        ) VALUES (?,?,?,0,NULL,0,NULL,?,?,?,?,NULL,?,?,?,NULL,'[]',NULL)
+        """,
+        (
+            fact_id,
+            text,
+            text,
+            ingest,
+            "0:00:01",
+            "DM",
+            "authoritative",
+            "2026-04-15",
+            "2026-04-20T00:00:00Z",
+            ingest,
+        ),
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO fact_targets"
+        "(fact_id, entity_category, entity_slug, section)"
+        " VALUES (?,?,?,?)",
+        (fact_id, cat_a, slug_a, "s1"),
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO fact_targets"
+        "(fact_id, entity_category, entity_slug, section)"
+        " VALUES (?,?,?,?)",
+        (fact_id, cat_b, slug_b, "s2"),
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO fact_status_history(fact_id, status, at, by, reason)"
+        " VALUES (?,?,?,?,NULL)",
+        (fact_id, "authoritative", "2026-04-20T00:00:00Z", "test"),
+    )
+
+
+class TestPageReconciliation:
+    """reject_ingest page reconciliation via offline fallback."""
+
+    def test_removed_entity_md_deleted(self, cfg: cfg_mod.Config) -> None:
+        """Removed entity's .md is deleted after reject-ingest."""
+        wiki = cfg.resolve_active_wiki(None)
+        conn = _open_db(wiki)
+        _seed_entity(
+            conn,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="yt-x",
+        )
+        _seed_fact(conn, fact_id="f001", ingest="yt-x")
+        conn.close()
+        # pre-create .md
+        md = wiki / "locations" / "aldara.md"
+        md.parent.mkdir(parents=True, exist_ok=True)
+        md.write_text("old content", encoding="utf-8")
+
+        reject_ingest(cfg, "yt-x")
+
+        assert not md.exists()
+
+    def test_linked_survivor_resummarized(self, cfg: cfg_mod.Config) -> None:
+        """Survivor linked to deleted entity has its .md regenerated."""
+        wiki = cfg.resolve_active_wiki(None)
+        conn = _open_db(wiki)
+        # aldara: created by yt-x, will be fully removed
+        _seed_entity(
+            conn,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="yt-x",
+        )
+        # theron: survivor created by other-ingest
+        _seed_entity(
+            conn,
+            name="Theron",
+            category="characters",
+            slug="theron",
+            created_by_ingest="other-ingest",
+        )
+        # shared fact: links aldara (yt-x) and theron (other-ingest)
+        _seed_shared_fact(
+            conn,
+            fact_id="shared-f001",
+            ingest="yt-x",
+            cat_a="locations",
+            slug_a="aldara",
+            cat_b="characters",
+            slug_b="theron",
+        )
+        # theron also has an independent fact from other-ingest
+        _seed_fact(
+            conn,
+            fact_id="theron-f001",
+            ingest="other-ingest",
+            entity_category="characters",
+            entity_slug="theron",
+        )
+        conn.close()
+
+        # pre-create old .md files
+        aldara_md = wiki / "locations" / "aldara.md"
+        aldara_md.parent.mkdir(parents=True, exist_ok=True)
+        aldara_md.write_text("old aldara", encoding="utf-8")
+        theron_md = wiki / "characters" / "theron.md"
+        theron_md.parent.mkdir(parents=True, exist_ok=True)
+        theron_md.write_text("old theron", encoding="utf-8")
+
+        reject_ingest(cfg, "yt-x")
+
+        # aldara's page gone; theron's page regenerated (new content)
+        assert not aldara_md.exists()
+        assert theron_md.exists()
+        assert theron_md.read_text(encoding="utf-8") != "old theron"
+
+    def test_survivor_zero_facts_renders_stub(self, cfg: cfg_mod.Config) -> None:
+        """Survivor with zero facts post-rejection renders mechanical stub."""
+        wiki = cfg.resolve_active_wiki(None)
+        conn = _open_db(wiki)
+        # theron: created by other-ingest, has only the yt-x shared fact
+        _seed_entity(
+            conn,
+            name="Theron",
+            category="characters",
+            slug="theron",
+            created_by_ingest="other-ingest",
+        )
+        # aldara: will be removed entirely
+        _seed_entity(
+            conn,
+            name="Aldara",
+            category="locations",
+            slug="aldara",
+            created_by_ingest="yt-x",
+        )
+        # shared fact from yt-x: when rejected, theron loses it → zero facts remain
+        _seed_shared_fact(
+            conn,
+            fact_id="shared-f002",
+            ingest="yt-x",
+            cat_a="locations",
+            slug_a="aldara",
+            cat_b="characters",
+            slug_b="theron",
+        )
+        conn.close()
+
+        theron_md = wiki / "characters" / "theron.md"
+        theron_md.parent.mkdir(parents=True, exist_ok=True)
+        theron_md.write_text("old theron", encoding="utf-8")
+        aldara_md = wiki / "locations" / "aldara.md"
+        aldara_md.parent.mkdir(parents=True, exist_ok=True)
+        aldara_md.write_text("old aldara", encoding="utf-8")
+
+        reject_ingest(cfg, "yt-x")
+
+        # aldara gone; theron stub written (heading only)
+        assert not aldara_md.exists()
+        assert theron_md.exists()
+        stub_text = theron_md.read_text(encoding="utf-8")
+        assert "# Theron" in stub_text

--- a/tests/test_linked_budget.py
+++ b/tests/test_linked_budget.py
@@ -110,20 +110,21 @@ def test_shared_facts_kept_over_nonshared_when_tight() -> None:
     ent = _entity("theron")
     # shared fact — id in subject_fact_ids
     shared = _fact("f-shared", "Shared fact.", status="hearsay")
-    # non-shared authoritative
+    # non-shared authoritative, large enough that entity doesn't fit with both facts
     non_shared = _fact("f-own", "X" * 300, status="authoritative")
 
-    # budget just fits one fact's worth of tokens
-    # shared text is short; non_shared is long; tight budget keeps shared
+    # budget=75: both facts ≈100 tokens (doesn't fit);
+    # shared-only ≈17 tokens (fits) → fact-level trim keeps shared, drops non-shared
     result = budget_linked_context(
         [(ent, [non_shared, shared])],
         subject_fact_ids={"f-shared"},
-        context_window=40,  # very small
+        context_window=300,
         budget_fraction=0.25,
     )
-    if result:
-        included_ids = {f.id for f in result[0][1]}
-        assert "f-shared" in included_ids
+    assert result, "entity should fit after dropping low-priority non-shared fact"
+    included_ids = {f.id for f in result[0][1]}
+    assert "f-shared" in included_ids
+    assert "f-own" not in included_ids
 
 
 def test_hearsay_dropped_before_authoritative() -> None:
@@ -144,6 +145,27 @@ def test_hearsay_dropped_before_authoritative() -> None:
     assert "f-hearsay" in ids
 
 
+def test_hearsay_dropped_before_authoritative_tight() -> None:
+    """Tight budget: hearsay dropped, authoritative kept within same entity."""
+    ent = _entity("theron")
+    # auth is short; hearsay is long; together they exceed the budget
+    auth_fact = _fact("f-auth", "Authoritative fact.", status="authoritative")
+    hearsay_fact = _fact("f-hearsay", "H" * 300, status="hearsay")
+
+    # entity with both ≈ 90+ tokens; auth-only ≈ 20 tokens
+    # budget=50 → auth-only fits, combined doesn't
+    result = budget_linked_context(
+        [(ent, [hearsay_fact, auth_fact])],
+        subject_fact_ids=set(),
+        context_window=200,
+        budget_fraction=0.25,
+    )
+    assert result, "entity should fit after dropping hearsay"
+    ids = {f.id for f in result[0][1]}
+    assert "f-auth" in ids
+    assert "f-hearsay" not in ids
+
+
 def test_disproven_dropped_before_hearsay() -> None:
     """Disproven dropped before hearsay in trim order."""
     ent = _entity("theron")
@@ -162,23 +184,46 @@ def test_disproven_dropped_before_hearsay() -> None:
     assert "f-disproven" in ids
 
 
-def test_nonshared_disproven_dropped_first() -> None:
-    """Non-shared disproven dropped before non-shared hearsay."""
+def test_disproven_dropped_before_hearsay_tight() -> None:
+    """Tight budget: disproven dropped, hearsay kept within same entity."""
     ent = _entity("theron")
-    # two long facts; budget only fits one
-    disproven = _fact("f-disproven", "D" * 400, status="disproven")
-    hearsay = _fact("f-hearsay", "H" * 400, status="hearsay")
+    # both long; together they exceed the budget; disproven has lower priority
+    hearsay = _fact("f-hearsay", "H" * 300, status="hearsay")
+    disproven = _fact("f-disproven", "D" * 300, status="disproven")
 
+    # entity with both ≈ 175 tokens; hearsay-only ≈ 85 tokens
+    # budget=100 → hearsay-only fits, combined doesn't
     result = budget_linked_context(
         [(ent, [disproven, hearsay])],
         subject_fact_ids=set(),
-        context_window=400,  # fits roughly one fact
+        context_window=400,
         budget_fraction=0.25,
     )
-    if result:
-        included_ids = {f.id for f in result[0][1]}
-        # hearsay kept over disproven
-        assert "f-disproven" not in included_ids or "f-hearsay" in included_ids
+    assert result, "entity should fit after dropping disproven"
+    ids = {f.id for f in result[0][1]}
+    assert "f-hearsay" in ids
+    assert "f-disproven" not in ids
+
+
+def test_nonshared_disproven_dropped_first() -> None:
+    """Non-shared disproven dropped before non-shared hearsay."""
+    ent = _entity("theron")
+    # two long facts; budget fits one but not both
+    disproven = _fact("f-disproven", "D" * 400, status="disproven")
+    hearsay = _fact("f-hearsay", "H" * 400, status="hearsay")
+
+    # entity with both ≈ 223 tokens; hearsay-only ≈ 114 tokens
+    # budget=150 → hearsay-only fits, combined doesn't
+    result = budget_linked_context(
+        [(ent, [disproven, hearsay])],
+        subject_fact_ids=set(),
+        context_window=600,
+        budget_fraction=0.25,
+    )
+    assert result, "entity should fit after dropping disproven"
+    included_ids = {f.id for f in result[0][1]}
+    assert "f-hearsay" in included_ids
+    assert "f-disproven" not in included_ids
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_linked_budget.py
+++ b/tests/test_linked_budget.py
@@ -1,0 +1,333 @@
+"""Tests for linked_budget.py — pure-function linked-context budgeter."""
+
+from __future__ import annotations
+
+import pytest
+
+from auto_lorebook.entities import EntityRow
+from auto_lorebook.facts import FactRow
+from auto_lorebook.linked_budget import (
+    LinkedContextTooLargeError,
+    budget_linked_context,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _entity(slug: str, category: str = "characters") -> EntityRow:
+    return EntityRow(
+        category=category,
+        slug=slug,
+        canonical_name=slug.capitalize(),
+        superseded_by_category=None,
+        superseded_by_slug=None,
+        created_at="2026-01-01T00:00:00Z",
+        created_by_ingest="ing-001",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+
+
+def _fact(
+    fact_id: str,
+    text: str = "Some fact.",
+    status: str = "authoritative",
+) -> FactRow:
+    return FactRow(
+        id=fact_id,
+        text=text,
+        raw_transcript_span="raw",
+        text_corrects_transcript=False,
+        text_source=None,
+        edited_by_human=False,
+        edited_at=None,
+        source_id="src-001",
+        locator="0:01:00",
+        speaker=None,
+        status=status,
+        status_reason=None,
+        session_date=None,
+        approved_at="2026-01-01T00:00:00Z",
+        created_by_ingest="ing-001",
+        claim_group_id=None,
+        corrections_applied=[],
+        inputs_json=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_empty() -> None:
+    result = budget_linked_context(
+        [],
+        subject_fact_ids=set(),
+        context_window=10_000,
+        budget_fraction=0.25,
+    )
+    assert result == []
+
+
+def test_under_budget_unchanged() -> None:
+    ent = _entity("theron")
+    fact = _fact("f-001", "Short fact.")
+    linked = [(ent, [fact])]
+    result = budget_linked_context(
+        linked,
+        subject_fact_ids=set(),
+        context_window=100_000,
+        budget_fraction=0.25,
+    )
+    assert len(result) == 1
+    assert result[0][0].slug == "theron"
+    # fact list preserved
+    assert result[0][1] == [fact]
+
+
+def test_under_budget_all_facts_included() -> None:
+    """All facts of an entity retained when within budget."""
+    ent = _entity("theron")
+    facts = [_fact(f"f-{i:03d}", f"Fact {i}.") for i in range(5)]
+    result = budget_linked_context(
+        [(ent, facts)],
+        subject_fact_ids=set(),
+        context_window=100_000,
+        budget_fraction=0.25,
+    )
+    assert result[0][1] == facts
+
+
+# ---------------------------------------------------------------------------
+# Fact ordering within an entity: shared first, then by status
+# ---------------------------------------------------------------------------
+
+
+def test_shared_facts_kept_over_nonshared_when_tight() -> None:
+    """When budget is tight, shared fact kept over non-shared authoritative."""
+    ent = _entity("theron")
+    # shared fact — id in subject_fact_ids
+    shared = _fact("f-shared", "Shared fact.", status="hearsay")
+    # non-shared authoritative
+    non_shared = _fact("f-own", "X" * 300, status="authoritative")
+
+    # budget just fits one fact's worth of tokens
+    # shared text is short; non_shared is long; tight budget keeps shared
+    result = budget_linked_context(
+        [(ent, [non_shared, shared])],
+        subject_fact_ids={"f-shared"},
+        context_window=40,  # very small
+        budget_fraction=0.25,
+    )
+    if result:
+        included_ids = {f.id for f in result[0][1]}
+        assert "f-shared" in included_ids
+
+
+def test_hearsay_dropped_before_authoritative() -> None:
+    """Hearsay dropped before authoritative when budget is tight."""
+    ent = _entity("theron")
+    auth_fact = _fact("f-auth", "Authoritative fact.", status="authoritative")
+    hearsay_fact = _fact("f-hearsay", "Hearsay fact.", status="hearsay")
+
+    # large budget — both included
+    result = budget_linked_context(
+        [(ent, [auth_fact, hearsay_fact])],
+        subject_fact_ids=set(),
+        context_window=100_000,
+        budget_fraction=0.25,
+    )
+    ids = {f.id for f in result[0][1]}
+    assert "f-auth" in ids
+    assert "f-hearsay" in ids
+
+
+def test_disproven_dropped_before_hearsay() -> None:
+    """Disproven dropped before hearsay in trim order."""
+    ent = _entity("theron")
+    hearsay = _fact("f-hearsay", "Hearsay fact.", status="hearsay")
+    disproven = _fact("f-disproven", "Disproven fact.", status="disproven")
+
+    # under normal budget: both present
+    result = budget_linked_context(
+        [(ent, [hearsay, disproven])],
+        subject_fact_ids=set(),
+        context_window=100_000,
+        budget_fraction=0.25,
+    )
+    ids = {f.id for f in result[0][1]}
+    assert "f-hearsay" in ids
+    assert "f-disproven" in ids
+
+
+def test_nonshared_disproven_dropped_first() -> None:
+    """Non-shared disproven dropped before non-shared hearsay."""
+    ent = _entity("theron")
+    # two long facts; budget only fits one
+    disproven = _fact("f-disproven", "D" * 400, status="disproven")
+    hearsay = _fact("f-hearsay", "H" * 400, status="hearsay")
+
+    result = budget_linked_context(
+        [(ent, [disproven, hearsay])],
+        subject_fact_ids=set(),
+        context_window=400,  # fits roughly one fact
+        budget_fraction=0.25,
+    )
+    if result:
+        included_ids = {f.id for f in result[0][1]}
+        # hearsay kept over disproven
+        assert "f-disproven" not in included_ids or "f-hearsay" in included_ids
+
+
+# ---------------------------------------------------------------------------
+# Entity-count cap (max_linked_entities)
+# ---------------------------------------------------------------------------
+
+
+def test_entity_count_cap_limits_entities() -> None:
+    entities = [
+        (_entity(f"ent{i}"), [_fact(f"f-{i:03d}", f"Fact {i}.")]) for i in range(5)
+    ]
+    result = budget_linked_context(
+        entities,
+        subject_fact_ids=set(),
+        context_window=100_000,
+        budget_fraction=0.25,
+        max_linked_entities=3,
+    )
+    assert len(result) <= 3
+
+
+def test_entity_count_cap_keeps_nearest_first_by_shared_fact_count() -> None:
+    """Entities with more shared facts ranked first; cap keeps them."""
+    # ent_a: 0 shared facts
+    ent_a = _entity("ent_a")
+    facts_a = [_fact("f-a1", "A fact.")]
+
+    # ent_b: 2 shared facts
+    ent_b = _entity("ent_b")
+    facts_b = [_fact("f-b1", "B fact 1."), _fact("f-b2", "B fact 2.")]
+
+    # ent_c: 1 shared fact
+    ent_c = _entity("ent_c")
+    facts_c = [_fact("f-c1", "C fact.")]
+
+    subject_fact_ids = {"f-b1", "f-b2", "f-c1"}
+    result = budget_linked_context(
+        [(ent_a, facts_a), (ent_b, facts_b), (ent_c, facts_c)],
+        subject_fact_ids=subject_fact_ids,
+        context_window=100_000,
+        budget_fraction=0.25,
+        max_linked_entities=2,
+    )
+    slugs = [r[0].slug for r in result]
+    # ent_b (2 shared) and ent_c (1 shared) should be kept; ent_a (0) dropped
+    assert "ent_b" in slugs
+    assert "ent_c" in slugs
+    assert "ent_a" not in slugs
+
+
+def test_entity_count_cap_tiebreak_by_category_slug() -> None:
+    """Tie on shared-fact count: sort by (category, slug) asc."""
+    ent_z = _entity("zzz", category="characters")
+    ent_a = _entity("aaa", category="characters")
+    facts_z = [_fact("f-z1", "Z fact.")]
+    facts_a = [_fact("f-a1", "A fact.")]
+
+    # both 0 shared facts; tiebreak on slug
+    result = budget_linked_context(
+        [(ent_z, facts_z), (ent_a, facts_a)],
+        subject_fact_ids=set(),
+        context_window=100_000,
+        budget_fraction=0.25,
+        max_linked_entities=1,
+    )
+    assert len(result) == 1
+    assert result[0][0].slug == "aaa"
+
+
+# ---------------------------------------------------------------------------
+# Token-budget boundary
+# ---------------------------------------------------------------------------
+
+
+def test_at_budget_boundary_entity_kept() -> None:
+    """Entity exactly at budget kept."""
+    ent = _entity("theron")
+    # fact text of exactly N chars; budget = context_window * fraction
+    # token estimate = len(text) // 4
+    text = "A" * 40  # 40 chars → 10 tokens
+    fact = _fact("f-001", text)
+
+    # budget = 100 * 0.25 = 25 tokens; 10 tokens fits
+    result = budget_linked_context(
+        [(ent, [fact])],
+        subject_fact_ids=set(),
+        context_window=100,
+        budget_fraction=0.25,
+    )
+    assert len(result) == 1
+
+
+def test_one_over_budget_trims_entity() -> None:
+    """Entity whose addition would push over budget is dropped."""
+    ent_a = _entity("ent_a")
+    ent_b = _entity("ent_b")
+
+    # large facts — budget just fits one
+    long_text = "X" * 2000
+    facts_a = [_fact("f-a1", long_text)]
+    facts_b = [_fact("f-b1", long_text)]
+
+    result = budget_linked_context(
+        [(ent_a, facts_a), (ent_b, facts_b)],
+        subject_fact_ids=set(),
+        context_window=2000,
+        budget_fraction=0.25,
+    )
+    # budget = 2000 * 0.25 = 500 tokens; one entity of 500 tokens fits, second doesn't
+    assert len(result) <= 1
+
+
+def test_raises_when_minimal_block_over_budget() -> None:
+    """LinkedContextTooLargeError when even smallest possible block exceeds budget."""
+    ent = _entity("theron")
+    # massive fact, tiny budget
+    huge_text = "Z" * 100_000
+    fact = _fact("f-001", huge_text)
+
+    with pytest.raises(LinkedContextTooLargeError):
+        budget_linked_context(
+            [(ent, [fact])],
+            subject_fact_ids=set(),
+            context_window=100,
+            budget_fraction=0.01,
+        )
+
+
+def test_token_estimate_uses_len_div_4() -> None:
+    """Token estimate is len(rendered_text) // 4, consistent with preamble heuristic."""
+    ent = _entity("theron")
+    # 400 chars → 100 tokens
+    text = "T" * 400
+    fact = _fact("f-001", text)
+
+    # budget = 1000 * 0.25 = 250 tokens; 100 tokens fits
+    result = budget_linked_context(
+        [(ent, [fact])],
+        subject_fact_ids=set(),
+        context_window=1000,
+        budget_fraction=0.25,
+    )
+    assert len(result) == 1
+
+    # budget = 200 * 0.1 = 20 tokens; 100 tokens exceeds → raises
+    with pytest.raises(LinkedContextTooLargeError):
+        budget_linked_context(
+            [(ent, [fact])],
+            subject_fact_ids=set(),
+            context_window=200,
+            budget_fraction=0.1,
+        )

--- a/tests/test_live_integration.py
+++ b/tests/test_live_integration.py
@@ -18,7 +18,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from auto_lorebook import db
+from auto_lorebook.entities import create_entity, list_aliases
+from auto_lorebook.facts import create_fact_with_target, list_facts_by_entity
 from auto_lorebook.openrouter import OpenRouterClient, OpenRouterResponse
+from auto_lorebook.stage4 import SummarizeResult
+from auto_lorebook.stage4 import run as stage4_run
 from auto_lorebook.ytdlp import fetch
 
 if TYPE_CHECKING:
@@ -78,3 +83,66 @@ def test_ytdlp_fetch_subtitles_live(tmp_path: Path) -> None:
     assert body.strip(), "SRT file was empty"
     # SRT cue blocks contain `-->` between start/end timestamps.
     assert "-->" in body
+
+
+@pytest.mark.skipif(
+    not _OPENROUTER_KEY,
+    reason="set $OPENROUTER_API_KEY to run this live test",
+)
+def test_stage4_summarizer_live() -> None:
+    """Round-trip stage4 summarizer through OpenRouter with a real entity."""
+    model = os.environ.get("LIVE_TEST_MODEL", _DEFAULT_LIVE_MODEL)
+    client = OpenRouterClient(api_key=_OPENROUTER_KEY, default_model=model)
+
+    conn = db.open(":memory:")
+    conn.execute(
+        "INSERT INTO sources(source_id, source_type, fetched_at, context_json)"
+        " VALUES ('src-live', 'youtube', '2026-01-01T00:00:00Z', '{}')"
+    )
+    conn.execute(
+        "INSERT INTO ingests(ingest_id, source_id, started_at, state)"
+        " VALUES ('ing-live', 'src-live', '2026-01-01T00:00:00Z', 'done')"
+    )
+    entity = create_entity(
+        conn,
+        category="characters",
+        slug="aldara",
+        canonical_name="Aldara",
+        ingest_id="ing-live",
+    )
+    create_fact_with_target(
+        conn,
+        fact_id="f-live-001",
+        text="Aldara is an ancient sorceress who founded the city of Mireth.",
+        raw_transcript_span=(
+            "Aldara is an ancient sorceress who founded the city of Mireth."
+        ),
+        text_corrects_transcript=False,
+        source_id="src-live",
+        locator="0:01:00",
+        status="authoritative",
+        approved_at="2026-01-01T00:00:00Z",
+        created_by_ingest="ing-live",
+        entity_category="characters",
+        entity_slug="aldara",
+        section="biography",
+        by="live-test",
+    )
+    conn.commit()
+
+    aliases = list_aliases(conn, "characters", "aldara")
+    facts = list_facts_by_entity(conn, "characters", "aldara")
+
+    result = stage4_run(
+        entity=entity,
+        aliases=aliases,
+        facts=facts,
+        entity_index="characters:\n  - Aldara",
+        wiki_setting="A high-fantasy world with ancient magic.",
+        client=client,
+        model=model,
+    )
+
+    assert isinstance(result, SummarizeResult)
+    assert result.prose
+    assert len(result.prose) > 20  # non-trivial prose returned

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -918,7 +918,7 @@ class TestRenderOuterGapWarnings:
 
     def _make_summaries(self) -> list:
         from auto_lorebook.commands.approve_reading import (  # noqa: PLC0415
-            _SegSummary,  # noqa: PLC2701
+            _SegSummary,
         )
 
         return [
@@ -936,7 +936,7 @@ class TestRenderOuterGapWarnings:
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         from auto_lorebook.commands.approve_reading import (  # noqa: PLC0415
-            _render_outer,  # noqa: PLC2701
+            _render_outer,
         )
 
         summaries = self._make_summaries()
@@ -950,7 +950,7 @@ class TestRenderOuterGapWarnings:
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         from auto_lorebook.commands.approve_reading import (  # noqa: PLC0415
-            _render_outer,  # noqa: PLC2701
+            _render_outer,
         )
         from auto_lorebook.gap_check import GapWarning  # noqa: PLC0415
 

--- a/tests/test_regen_set.py
+++ b/tests/test_regen_set.py
@@ -1,0 +1,125 @@
+"""Tests for regen_set.py — pure regeneration-set planner."""
+
+from __future__ import annotations
+
+from auto_lorebook.regen_set import RegenerationSet, plan_regeneration_set
+
+
+def _no_links(_entity: tuple[str, str]) -> list[tuple[str, str]]:
+    """Linked-entity resolver with no links."""
+    return []
+
+
+class TestRegenerationSet:
+    def test_ordered_is_touched_then_linked(self) -> None:
+        rs = RegenerationSet(
+            touched=(("characters", "theron"),),
+            linked=(("locations", "aldara"),),
+        )
+        assert rs.ordered == (("characters", "theron"), ("locations", "aldara"))
+
+    def test_ordered_touched_only(self) -> None:
+        rs = RegenerationSet(touched=(("characters", "theron"),), linked=())
+        assert rs.ordered == (("characters", "theron"),)
+
+    def test_ordered_linked_only(self) -> None:
+        rs = RegenerationSet(touched=(), linked=(("locations", "aldara"),))
+        assert rs.ordered == (("locations", "aldara"),)
+
+
+class TestPlanRegenerationSet:
+    def test_touched_only_no_links(self) -> None:
+        rs = plan_regeneration_set([("characters", "theron")], _no_links)
+        assert rs.touched == (("characters", "theron"),)
+        assert rs.linked == ()
+
+    def test_touched_first_in_ordered(self) -> None:
+        def links(e: tuple[str, str]) -> list[tuple[str, str]]:
+            if e == ("characters", "theron"):
+                return [("locations", "aldara")]
+            return []
+
+        rs = plan_regeneration_set([("characters", "theron")], links)
+        assert rs.ordered[0] == ("characters", "theron")
+        assert rs.ordered[1] == ("locations", "aldara")
+
+    def test_dedup_touched_preserves_order(self) -> None:
+        rs = plan_regeneration_set(
+            [("characters", "theron"), ("characters", "theron")],
+            _no_links,
+        )
+        assert rs.touched == (("characters", "theron"),)
+        assert len(rs.touched) == 1
+
+    def test_linked_appended_deduped(self) -> None:
+        # two touched entities both link to aldara → appears once in linked
+        def links(_e: tuple[str, str]) -> list[tuple[str, str]]:
+            return [("locations", "aldara")]
+
+        rs = plan_regeneration_set(
+            [("characters", "theron"), ("factions", "guild")],
+            links,
+        )
+        aldara_count = rs.linked.count(("locations", "aldara"))
+        assert aldara_count == 1
+
+    def test_entity_both_touched_and_linked(self) -> None:
+        # aldara is touched; theron links to aldara → aldara stays in touched only
+        def links(e: tuple[str, str]) -> list[tuple[str, str]]:
+            if e == ("characters", "theron"):
+                return [("locations", "aldara")]
+            return []
+
+        rs = plan_regeneration_set(
+            [("characters", "theron"), ("locations", "aldara")],
+            links,
+        )
+        assert ("locations", "aldara") in rs.touched
+        assert ("locations", "aldara") not in rs.linked
+
+    def test_mutual_link_no_infinite_loop(self) -> None:
+        # theron ↔ aldara mutual link; both are touched
+        def links(e: tuple[str, str]) -> list[tuple[str, str]]:
+            if e == ("characters", "theron"):
+                return [("locations", "aldara")]
+            if e == ("locations", "aldara"):
+                return [("characters", "theron")]
+            return []
+
+        rs = plan_regeneration_set(
+            [("characters", "theron"), ("locations", "aldara")],
+            links,
+        )
+        # both in touched; linked must be empty (each other already in touched)
+        assert rs.linked == ()
+
+    def test_one_hop_non_transitive(self) -> None:
+        # theron → aldara → guild; guild must NOT appear (not reachable in one hop)
+        call_count: dict[tuple[str, str], int] = {}
+
+        def links(e: tuple[str, str]) -> list[tuple[str, str]]:
+            call_count[e] = call_count.get(e, 0) + 1
+            if e == ("characters", "theron"):
+                return [("locations", "aldara")]
+            if e == ("locations", "aldara"):
+                return [("factions", "guild")]
+            return []
+
+        rs = plan_regeneration_set([("characters", "theron")], links)
+        # aldara is linked, but linked_of not called on it
+        assert ("factions", "guild") not in rs.linked
+        assert ("locations", "aldara") in rs.linked
+        assert ("locations", "aldara") not in call_count
+
+    def test_linked_sorted_by_category_slug(self) -> None:
+        def links(_e: tuple[str, str]) -> list[tuple[str, str]]:
+            return [("locations", "aldara"), ("factions", "guild")]
+
+        rs = plan_regeneration_set([("characters", "theron")], links)
+        assert rs.linked == (("factions", "guild"), ("locations", "aldara"))
+
+    def test_empty_touched(self) -> None:
+        rs = plan_regeneration_set([], _no_links)
+        assert rs.touched == ()
+        assert rs.linked == ()
+        assert rs.ordered == ()

--- a/tests/test_reject_ingest_cmd.py
+++ b/tests/test_reject_ingest_cmd.py
@@ -404,6 +404,236 @@ class TestRejectIngest:
             conn.close()
 
 
+class TestPageReconciliationIntegration:
+    """Integration: reject-ingest page reconciliation."""
+
+    def _seed_entity_direct(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        name: str,
+        category: str,
+        slug: str,
+        created_by: str,
+    ) -> None:
+        conn.execute(
+            "INSERT OR IGNORE INTO sources"
+            "(source_id, source_type, fetched_at, context_json)"
+            " VALUES (?, 'youtube', '2026-01-01T00:00:00Z', '{}')",
+            (created_by,),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO ingests(ingest_id, source_id, started_at, state)"
+            " VALUES (?, ?, '2026-01-01T00:00:00Z', 'done')",
+            (created_by, created_by),
+        )
+        ts = "2026-04-20T00:00:00Z"
+        conn.execute(
+            "INSERT OR IGNORE INTO entities"
+            "(category, slug, canonical_name,"
+            " created_at, created_by_ingest, updated_at)"
+            " VALUES (?,?,?,?,?,?)",
+            (category, slug, name, ts, created_by, ts),
+        )
+
+    def _seed_shared_fact_direct(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        fact_id: str,
+        ingest: str,
+        cat_a: str,
+        slug_a: str,
+        cat_b: str,
+        slug_b: str,
+        text: str = "Shared lore.",
+    ) -> None:
+        conn.execute(
+            "INSERT OR IGNORE INTO sources"
+            "(source_id, source_type, fetched_at, context_json)"
+            " VALUES (?, 'youtube', '2026-01-01T00:00:00Z', '{}')",
+            (ingest,),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO ingests(ingest_id, source_id, started_at, state)"
+            " VALUES (?, ?, '2026-01-01T00:00:00Z', 'done')",
+            (ingest, ingest),
+        )
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO facts (
+                id, text, raw_transcript_span, text_corrects_transcript,
+                text_source, edited_by_human, edited_at,
+                source_id, locator, speaker,
+                status, status_reason, session_date,
+                approved_at, created_by_ingest, claim_group_id,
+                corrections_applied_json, inputs_json
+            ) VALUES (?,?,?,0,NULL,0,NULL,?,?,?,?,NULL,?,?,?,NULL,'[]',NULL)
+            """,
+            (
+                fact_id,
+                text,
+                text,
+                ingest,
+                "0:01:00",
+                "DM",
+                "authoritative",
+                "2026-04-15",
+                "2026-04-20T00:00:00Z",
+                ingest,
+            ),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO fact_targets"
+            "(fact_id, entity_category, entity_slug, section)"
+            " VALUES (?,?,?,?)",
+            (fact_id, cat_a, slug_a, "s1"),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO fact_targets"
+            "(fact_id, entity_category, entity_slug, section)"
+            " VALUES (?,?,?,?)",
+            (fact_id, cat_b, slug_b, "s2"),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO fact_status_history(fact_id, status, at, by, reason)"
+            " VALUES (?,?,?,?,NULL)",
+            (fact_id, "authoritative", "2026-04-20T00:00:00Z", "test"),
+        )
+
+    def _seed_own_fact_direct(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        fact_id: str,
+        ingest: str,
+        category: str,
+        slug: str,
+    ) -> None:
+        conn.execute(
+            "INSERT OR IGNORE INTO sources"
+            "(source_id, source_type, fetched_at, context_json)"
+            " VALUES (?, 'youtube', '2026-01-01T00:00:00Z', '{}')",
+            (ingest,),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO ingests(ingest_id, source_id, started_at, state)"
+            " VALUES (?, ?, '2026-01-01T00:00:00Z', 'done')",
+            (ingest, ingest),
+        )
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO facts (
+                id, text, raw_transcript_span, text_corrects_transcript,
+                text_source, edited_by_human, edited_at,
+                source_id, locator, speaker,
+                status, status_reason, session_date,
+                approved_at, created_by_ingest, claim_group_id,
+                corrections_applied_json, inputs_json
+            ) VALUES (?,?,?,0,NULL,0,NULL,?,?,?,?,NULL,?,?,?,NULL,'[]',NULL)
+            """,
+            (
+                fact_id,
+                "Own fact.",
+                "Own fact.",
+                ingest,
+                "0:02:00",
+                "DM",
+                "authoritative",
+                "2026-04-15",
+                "2026-04-20T00:00:00Z",
+                ingest,
+            ),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO fact_targets"
+            "(fact_id, entity_category, entity_slug, section)"
+            " VALUES (?,?,?,?)",
+            (fact_id, category, slug, "general"),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO fact_status_history(fact_id, status, at, by, reason)"
+            " VALUES (?,?,?,?,NULL)",
+            (fact_id, "authoritative", "2026-04-20T00:00:00Z", "test"),
+        )
+
+    def test_deleted_entity_page_removed_and_neighbour_resummarized(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Deleted entity page removed; linked survivor re-summarized."""
+        from auto_lorebook import db as db_mod  # noqa: PLC0415
+        from auto_lorebook import wiki_bootstrap  # noqa: PLC0415
+        from auto_lorebook import wiki_state as ws_mod  # noqa: PLC0415
+        from auto_lorebook.config import Config  # noqa: PLC0415
+        from auto_lorebook.ingest_cleanup import reject_ingest  # noqa: PLC0415
+        from auto_lorebook.wiki_registry import WikiEntry  # noqa: PLC0415
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("AUTO_LOREBOOK_HOME", str(home))
+        wiki = tmp_path / "wiki"
+        wiki_bootstrap.bootstrap(wiki)
+
+        # write config.yaml so reading_pipeline._active_wiki_root() resolves
+        (home / "config.yaml").write_text(
+            "schema_version: 2\nactive_wiki: main\nwikis:\n"
+            f"- nickname: main\n  path: {wiki}\n",
+            encoding="utf-8",
+        )
+        cfg = Config(wikis=[WikiEntry("main", wiki)], active_wiki="main")
+
+        conn = db_mod.open(ws_mod.wiki_db_path(wiki))
+        # aldara: created by yt-x → will be fully removed
+        self._seed_entity_direct(
+            conn, name="Aldara", category="locations", slug="aldara", created_by="yt-x"
+        )
+        # theron: created by other-ingest → linked survivor
+        self._seed_entity_direct(
+            conn,
+            name="Theron",
+            category="characters",
+            slug="theron",
+            created_by="other-ingest",
+        )
+        # shared fact from yt-x linking both; theron also has an own fact
+        self._seed_shared_fact_direct(
+            conn,
+            fact_id="shared-f1",
+            ingest="yt-x",
+            cat_a="locations",
+            slug_a="aldara",
+            cat_b="characters",
+            slug_b="theron",
+        )
+        self._seed_own_fact_direct(
+            conn,
+            fact_id="theron-own-f1",
+            ingest="other-ingest",
+            category="characters",
+            slug="theron",
+        )
+        conn.commit()
+        conn.close()
+
+        # pre-create .md files
+        aldara_md = wiki / "locations" / "aldara.md"
+        aldara_md.write_text("old aldara", encoding="utf-8")
+        theron_md = wiki / "characters" / "theron.md"
+        theron_md.write_text("old theron", encoding="utf-8")
+
+        reject_ingest(cfg, "yt-x")
+
+        # aldara's page removed
+        assert not aldara_md.exists(), "deleted entity page should be gone"
+        # theron's page regenerated
+        assert theron_md.exists(), "linked survivor's page should remain"
+        assert theron_md.read_text(encoding="utf-8") != "old theron", (
+            "linked survivor's page should be re-summarized"
+        )
+
+
 class TestRejectIngestIsolation:
     """Pending state for each wiki is isolated under its own .wiki-state/."""
 

--- a/tests/test_reject_ingest_cmd.py
+++ b/tests/test_reject_ingest_cmd.py
@@ -233,7 +233,12 @@ def _approve_one(
     monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
     client = MagicMock()
     _wire_client(client)
-    with patch("auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client):
+    review_client = MagicMock()
+    review_client.complete.return_value = MagicMock(text='{"prose": "Stub prose."}')
+    with (
+        patch("auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client),
+        patch("auto_lorebook.review.OpenRouterClient", return_value=review_client),
+    ):
         generate_reading_cmd.run(_args(source_id=SOURCE_ID))
         approve_reading_cmd.run(_args(source_id=SOURCE_ID, yes=True))
         plan_cmd.run(_args(source_id=SOURCE_ID))

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -49,8 +49,13 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture(autouse=True)
-def _stub_review_openrouter_client() -> Generator[None]:
+def _stub_review_openrouter_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None]:
     """Prevent test_review.py from hitting the real LLM via review.run()."""
+    # review.run() requires an API key before it builds the page-step client;
+    # supply a dummy so the stub below is reached instead of a ReviewError.
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-stub-key")
     stub = MagicMock()
     stub.complete.return_value = MagicMock(text='{"prose": "Stub prose."}')
     with patch("auto_lorebook.review.OpenRouterClient", return_value=stub):

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -38,7 +39,22 @@ from auto_lorebook.wiki_registry import WikiEntry
 
 if TYPE_CHECKING:
     import sqlite3
+    from collections.abc import Generator
     from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Module-level stub: no real LLM calls from review.run
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _stub_review_openrouter_client() -> Generator[None]:
+    """Prevent test_review.py from hitting the real LLM via review.run()."""
+    stub = MagicMock()
+    stub.complete.return_value = MagicMock(text='{"prose": "Stub prose."}')
+    with patch("auto_lorebook.review.OpenRouterClient", return_value=stub):
+        yield
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_review_cmd.py
+++ b/tests/test_review_cmd.py
@@ -362,6 +362,105 @@ def _args(**kwargs: object) -> argparse.Namespace:
     return argparse.Namespace(**kwargs)
 
 
+class TestReviewWritesLLMProse:
+    """Regression: review path must call run_page_step with a real client."""
+
+    def test_review_passes_real_client_to_page_step(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """review_cmd.run() must build a client and pass it to run_page_step.
+
+        Asserts run_page_step is called with a non-None client, and that the
+        resulting .md contains LLM prose text (not a mechanical bullet list).
+        """
+        _write_user_config(tmp_home, ingested_wiki)
+        monkeypatch.setenv("FAKE_OR_KEY", "sk-fake")
+
+        pipeline_client = MagicMock()
+        _wire_client_responses(pipeline_client)
+
+        prose_text = (
+            "Aldara is an ancient city founded by King Theron in the Second Age."
+        )
+        # fake client returned by OpenRouterClient constructor in review module
+        review_client = MagicMock()
+
+        captured_client: list[object] = []
+
+        def _fake_run_page_step(
+            _conn: object,
+            wiki_repo: object,
+            touched_entities: list[tuple[str, str]],
+            *,
+            entity_index: str = "",  # noqa: ARG001
+            wiki_setting: str = "",  # noqa: ARG001
+            client: object,
+            model: str = "",  # noqa: ARG001
+        ) -> list[object]:
+            from pathlib import Path as _Path  # noqa: PLC0415
+
+            captured_client.append(client)
+            paths = []
+            for category, slug in touched_entities:
+                p = _Path(str(wiki_repo)) / category / f"{slug}.md"
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text(
+                    f"# {slug.capitalize()}\n\n## Summary\n\n{prose_text}\n",
+                    encoding="utf-8",
+                )
+                paths.append(p)
+            return paths
+
+        with (
+            patch(
+                "auto_lorebook.reading_pipeline.OpenRouterClient",
+                return_value=pipeline_client,
+            ),
+            patch(
+                "auto_lorebook.review.OpenRouterClient",
+                return_value=review_client,
+            ),
+            patch(
+                "auto_lorebook.review.page_step_mod.run_page_step",
+                side_effect=_fake_run_page_step,
+            ),
+        ):
+            generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
+            assert (
+                approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=True))
+                == 0
+            )
+            plan_cmd.run(_args(source_id="yt-abc12345678"))
+            extract_cmd.run(_args(source_id="yt-abc12345678"))
+            rc = review_cmd.run(_args(source_id="yt-abc12345678", auto_approve=True))
+
+        assert rc == 0
+        # run_page_step must have been called with a real (non-None) client
+        assert len(captured_client) == 1, "run_page_step was not called"
+        assert captured_client[0] is not None, "run_page_step received client=None"
+        assert captured_client[0] is review_client, (
+            "run_page_step received wrong client; "
+            "expected the one built by review.run()"
+        )
+        md_path = ingested_wiki / "locations" / "aldara.md"
+        assert md_path.exists()
+        content = md_path.read_text(encoding="utf-8")
+        # prose path: LLM-generated prose appears in the page
+        assert prose_text in content
+        capsys.readouterr()
+
+
+def _make_review_client() -> MagicMock:
+    """Stub review-phase client: returns valid stage4 prose JSON for any entity."""
+    c = MagicMock()
+    c.complete.return_value = MagicMock(text='{"prose": "Stub prose."}')
+    return c
+
+
 class TestAutoApprove:
     def test_full_pipeline_lands_a_fact_in_entity_yaml(
         self,
@@ -375,8 +474,14 @@ class TestAutoApprove:
 
         client = MagicMock()
         _wire_client_responses(client)
-        with patch(
-            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        with (
+            patch(
+                "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+            ),
+            patch(
+                "auto_lorebook.review.OpenRouterClient",
+                return_value=_make_review_client(),
+            ),
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
             assert (
@@ -427,8 +532,14 @@ class TestEmptyDir:
 
         client = MagicMock()
         _wire_client_responses(client)
-        with patch(
-            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        with (
+            patch(
+                "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+            ),
+            patch(
+                "auto_lorebook.review.OpenRouterClient",
+                return_value=_make_review_client(),
+            ),
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
             approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=True))
@@ -490,8 +601,14 @@ class TestMultiTargetBundle:
 
         client = MagicMock()
         _wire_multi_target_responses(client)
-        with patch(
-            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        with (
+            patch(
+                "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+            ),
+            patch(
+                "auto_lorebook.review.OpenRouterClient",
+                return_value=_make_review_client(),
+            ),
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
             assert (
@@ -551,6 +668,7 @@ class TestMultiTargetBundle:
             cfg=cfg_mod.load_config(),
             source_id="yt-abc12345678",
             reviewer=_DropFirstRouteReviewer(),
+            client=_make_review_client(),
         )
 
         # Theron and Second Age stubs exist; Aldara's proposal was dropped.
@@ -820,8 +938,14 @@ class TestInteractiveReviewerUndoIntegration:
 
         client = MagicMock()
         _wire_multi_target_responses(client)
-        with patch(
-            "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+        with (
+            patch(
+                "auto_lorebook.reading_pipeline.OpenRouterClient", return_value=client
+            ),
+            patch(
+                "auto_lorebook.review.OpenRouterClient",
+                return_value=_make_review_client(),
+            ),
         ):
             generate_reading_cmd.run(_args(source_id="yt-abc12345678"))
             assert (

--- a/tests/test_review_cmd.py
+++ b/tests/test_review_cmd.py
@@ -400,6 +400,8 @@ class TestReviewWritesLLMProse:
             wiki_setting: str = "",  # noqa: ARG001
             client: object,
             model: str = "",  # noqa: ARG001
+            context_window: int = 200_000,  # noqa: ARG001
+            budget_fraction: float = 0.25,  # noqa: ARG001
         ) -> list[object]:
             from pathlib import Path as _Path  # noqa: PLC0415
 

--- a/tests/test_stage4.py
+++ b/tests/test_stage4.py
@@ -9,7 +9,11 @@ import pytest
 
 from auto_lorebook import db
 from auto_lorebook.entities import AliasRow, EntityRow
-from auto_lorebook.facts import FactRow, create_fact_with_target
+from auto_lorebook.facts import (
+    FactRow,
+    create_fact_with_target,
+    create_fact_with_targets,
+)
 from auto_lorebook.page_step import run_page_step
 from auto_lorebook.stage4 import (
     Stage4Error,
@@ -509,3 +513,188 @@ class TestRunPageStep:
         md_path = tmp_path / "characters" / "theron.md"
         assert md_path in paths
         assert md_path.exists()
+
+    def test_approving_fact_on_a_regenerates_linked_b(self, tmp_path: Path) -> None:
+        """Integration: touched entity A shares fact with B → B page also written."""
+        conn = _seed_conn()
+        # seed second entity (aldara)
+        conn.execute(
+            "INSERT INTO entities(category, slug, canonical_name, created_at,"
+            " created_by_ingest, updated_at)"
+            " VALUES ('locations', 'aldara', 'Aldara',"
+            " '2026-01-01T00:00:00Z', 'ing-001', '2026-01-01T00:00:00Z')"
+        )
+        # shared fact targeting both theron and aldara
+        create_fact_with_targets(
+            conn,
+            fact_id="f-shared",
+            text="Theron founded Aldara.",
+            raw_transcript_span="raw",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:04:32",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            targets=[
+                ("characters", "theron", "biography"),
+                ("locations", "aldara", "founding"),
+            ],
+            by="tester",
+        )
+        conn.commit()
+
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Generated prose."}')
+
+        # only theron is "touched" — aldara should be regenerated as linked
+        paths = run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+        )
+        aldara_path = tmp_path / "locations" / "aldara.md"
+        assert aldara_path in paths
+        assert aldara_path.exists()
+
+    def test_progress_reports_linked_count(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Progress message includes linked entity info when links exist."""
+        conn = _seed_conn()
+        conn.execute(
+            "INSERT INTO entities(category, slug, canonical_name, created_at,"
+            " created_by_ingest, updated_at)"
+            " VALUES ('locations', 'aldara', 'Aldara',"
+            " '2026-01-01T00:00:00Z', 'ing-001', '2026-01-01T00:00:00Z')"
+        )
+        create_fact_with_targets(
+            conn,
+            fact_id="f-shared",
+            text="Theron founded Aldara.",
+            raw_transcript_span="raw",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:04:32",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            targets=[
+                ("characters", "theron", "biography"),
+                ("locations", "aldara", "founding"),
+            ],
+            by="tester",
+        )
+        conn.commit()
+
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Generated prose."}')
+
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+        )
+        captured = capsys.readouterr()
+        # progress should mention linked count (1 linked)
+        assert "linked" in captured.out.lower() or "1" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# build_prompt — linked_facts parameter
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPromptLinkedFacts:
+    def test_no_linked_block_when_none(self) -> None:
+        entity = _make_entity_row()
+        prompt = build_prompt(
+            entity=entity,
+            aliases=[],
+            facts=[_make_fact_row()],
+            entity_index="",
+            wiki_setting="",
+            linked_facts=None,
+        )
+        assert "Linked entities" not in prompt
+        assert "LINKED" not in prompt
+
+    def test_no_linked_block_when_empty_list(self) -> None:
+        entity = _make_entity_row()
+        prompt = build_prompt(
+            entity=entity,
+            aliases=[],
+            facts=[_make_fact_row()],
+            entity_index="",
+            wiki_setting="",
+            linked_facts=[],
+        )
+        assert "Linked entities" not in prompt
+
+    def test_linked_facts_appear_in_prompt(self) -> None:
+        entity = _make_entity_row()
+        linked_entity = _make_entity_row("Aldara", "locations", "aldara")
+        linked_fact = _make_fact_row(
+            fact_id="f-n01",
+            text="Aldara was founded in the Second Age.",
+            status="authoritative",
+        )
+        prompt = build_prompt(
+            entity=entity,
+            aliases=[],
+            facts=[_make_fact_row()],
+            entity_index="",
+            wiki_setting="",
+            linked_facts=[(linked_entity, [linked_fact])],
+        )
+        assert "Aldara was founded in the Second Age." in prompt
+
+    def test_linked_block_label_present(self) -> None:
+        entity = _make_entity_row()
+        linked_entity = _make_entity_row("Aldara", "locations", "aldara")
+        linked_fact = _make_fact_row(fact_id="f-n01", text="Some linked fact.")
+        prompt = build_prompt(
+            entity=entity,
+            aliases=[],
+            facts=[_make_fact_row()],
+            entity_index="",
+            wiki_setting="",
+            linked_facts=[(linked_entity, [linked_fact])],
+        )
+        assert "Linked" in prompt
+
+    def test_run_forwards_linked_facts(self) -> None:
+        client = MagicMock()
+        client.complete.return_value = MagicMock(
+            text='{"prose": "Theron founded Aldara."}'
+        )
+        entity = _make_entity_row()
+        linked_entity = _make_entity_row("Aldara", "locations", "aldara")
+        linked_fact = _make_fact_row(
+            fact_id="f-n01",
+            text="Aldara is an ancient city.",
+            status="trustworthy",
+        )
+        result = run(
+            entity=entity,
+            aliases=[],
+            facts=[_make_fact_row()],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            linked_facts=[(linked_entity, [linked_fact])],
+        )
+        call_args = client.complete.call_args
+        messages = call_args[0][0] if call_args[0] else call_args[1]["messages"]
+        user_content = " ".join(m["content"] for m in messages if m["role"] == "user")
+        assert "Aldara is an ancient city." in user_content
+        assert result.prose == "Theron founded Aldara."

--- a/tests/test_stage4.py
+++ b/tests/test_stage4.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -17,6 +18,8 @@ from auto_lorebook.facts import (
 from auto_lorebook.page_step import run_page_step
 from auto_lorebook.stage4 import (
     Stage4Error,
+    _resolve_crossref_markers,
+    _resolve_entity_links,
     build_prompt,
     parse_response,
     render_entity_page,
@@ -698,3 +701,195 @@ class TestBuildPromptLinkedFacts:
         user_content = " ".join(m["content"] for m in messages if m["role"] == "user")
         assert "Aldara is an ancient city." in user_content
         assert result.prose == "Theron founded Aldara."
+
+
+# ---------------------------------------------------------------------------
+# TestPerFactAnchors — fact.id-derived stable anchors
+# ---------------------------------------------------------------------------
+
+
+class TestPerFactAnchors:
+    def test_anchor_derived_from_fact_id(self) -> None:
+        """Footnote label uses fact.id, not a counter."""
+        entity = _make_entity_row()
+        fact = _make_fact_row(fact_id="f-001")
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=[fact],
+            prose="Some prose.",
+            conn=None,
+        )
+        assert "[^f-001]:" in result
+
+    def test_anchor_stable_across_fact_set_change(self) -> None:
+        """Adding a second fact does not change the anchor of the first."""
+        entity = _make_entity_row()
+        fact1 = _make_fact_row(fact_id="f-001", text="First fact.")
+        fact2 = _make_fact_row(fact_id="f-002", text="Second fact.", source_id="src-001")
+
+        result_one = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=[fact1],
+            prose="Some prose.",
+            conn=None,
+        )
+        result_two = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=[fact1, fact2],
+            prose="Some prose.",
+            conn=None,
+        )
+        # f-001 anchor must be present in both; not changed by adding f-002
+        assert "[^f-001]:" in result_one
+        assert "[^f-001]:" in result_two
+
+
+# ---------------------------------------------------------------------------
+# TestEntityMarkerResolution — [[category/slug]] → markdown link
+# ---------------------------------------------------------------------------
+
+
+class TestEntityMarkerResolution:
+    def _make_linked_entity(
+        self, name: str, category: str, slug: str
+    ) -> EntityRow:
+        return _make_entity_row(name, category, slug)
+
+    def test_marker_resolves_to_link(self) -> None:
+        """[[characters/aldara]] → [Aldara](../characters/aldara.md) (cross-cat)."""
+        entity = self._make_linked_entity("Aldara", "characters", "aldara")
+        lookup = {("characters", "aldara"): entity}
+        prose = "See [[characters/aldara]] for details."
+        result = _resolve_entity_links(prose, lookup, from_category="locations")
+        assert "[Aldara](../characters/aldara.md)" in result
+        assert "[[characters/aldara]]" not in result
+
+    def test_same_category_bare_path(self) -> None:
+        """Same category → relative path without parent component."""
+        entity = self._make_linked_entity("Aldara", "locations", "aldara")
+        lookup = {("locations", "aldara"): entity}
+        prose = "See [[locations/aldara]] here."
+        result = _resolve_entity_links(prose, lookup, from_category="locations")
+        assert "[Aldara](aldara.md)" in result
+
+    def test_unresolvable_marker_becomes_plain_text(self) -> None:
+        """Unknown marker degrades to raw 'category/slug' text."""
+        lookup: dict[tuple[str, str], EntityRow] = {}
+        prose = "See [[mystery/unknown]] here."
+        result = _resolve_entity_links(prose, lookup, from_category="characters")
+        assert "[[mystery/unknown]]" not in result
+        assert "mystery/unknown" in result
+
+    def test_unresolvable_marker_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Unresolvable marker emits a logged warning."""
+        lookup: dict[tuple[str, str], EntityRow] = {}
+        prose = "See [[mystery/unknown]] here."
+        with caplog.at_level(logging.WARNING, logger="auto_lorebook.stage4"):
+            _resolve_entity_links(prose, lookup, from_category="characters")
+        assert any("mystery/unknown" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# TestCrossReferenceFootnotes — [[fact:<id>]] → footnote + crossref
+# ---------------------------------------------------------------------------
+
+
+class TestCrossReferenceFootnotes:
+    def _make_linked(
+        self, name: str = "Aldara", cat: str = "locations", slug: str = "aldara"
+    ) -> EntityRow:
+        return _make_entity_row(name, cat, slug)
+
+    def test_crossref_marker_emits_footnote(self) -> None:
+        """[[fact:f-n01]] replaced with [^f-n01] ref; footnote def added."""
+        linked_ent = self._make_linked()
+        linked_fact = _make_fact_row(
+            fact_id="f-n01", text="Aldara was built in the Second Age."
+        )
+        linked_fact_index = {"f-n01": (linked_ent, linked_fact)}
+        prose = "Theron lived near [[fact:f-n01]]."
+        new_prose, footnote_defs = _resolve_crossref_markers(
+            prose, linked_fact_index, from_category="characters"
+        )
+        assert "[^f-n01]" in new_prose
+        assert "[[fact:f-n01]]" not in new_prose
+        assert any("f-n01" in d for d in footnote_defs)
+
+    def test_crossref_footnote_quotes_linked_fact(self) -> None:
+        """Footnote def includes the linked fact's text as a quote."""
+        linked_ent = self._make_linked()
+        linked_fact = _make_fact_row(
+            fact_id="f-n01", text="Aldara was built in the Second Age."
+        )
+        linked_fact_index = {"f-n01": (linked_ent, linked_fact)}
+        prose = "Background: [[fact:f-n01]]."
+        _, footnote_defs = _resolve_crossref_markers(
+            prose, linked_fact_index, from_category="characters"
+        )
+        combined = "\n".join(footnote_defs)
+        assert "Aldara was built in the Second Age." in combined
+
+    def test_crossref_footnote_links_to_entity_page(self) -> None:
+        """Footnote def contains link to linked entity's page anchored at fact."""
+        linked_ent = self._make_linked(cat="locations", slug="aldara")
+        linked_fact = _make_fact_row(fact_id="f-n01", text="Some claim.")
+        linked_fact_index = {"f-n01": (linked_ent, linked_fact)}
+        prose = "See [[fact:f-n01]]."
+        _, footnote_defs = _resolve_crossref_markers(
+            prose, linked_fact_index, from_category="characters"
+        )
+        combined = "\n".join(footnote_defs)
+        # link to ../locations/aldara.md#fn:f-n01
+        assert "locations/aldara.md" in combined
+        assert "#fn:f-n01" in combined
+
+    def test_unresolvable_crossref_degrades_to_plain_text(self) -> None:
+        """[[fact:unknown]] → plain text (marker removed), no exception."""
+        linked_fact_index: dict[str, tuple[EntityRow, FactRow]] = {}
+        prose = "See [[fact:unknown]]."
+        new_prose, footnote_defs = _resolve_crossref_markers(
+            prose, linked_fact_index, from_category="characters"
+        )
+        assert "[[fact:unknown]]" not in new_prose
+        assert not footnote_defs
+
+    def test_crossref_only_for_cited_linked_facts(self) -> None:
+        """Only [[fact:…]] markers that appear in prose generate footnotes."""
+        linked_ent = self._make_linked()
+        fact_cited = _make_fact_row(fact_id="f-n01", text="Cited fact.")
+        fact_uncited = _make_fact_row(fact_id="f-n02", text="Uncited fact.")
+        linked_fact_index = {
+            "f-n01": (linked_ent, fact_cited),
+            "f-n02": (linked_ent, fact_uncited),
+        }
+        prose = "Only [[fact:f-n01]] is mentioned."
+        _, footnote_defs = _resolve_crossref_markers(
+            prose, linked_fact_index, from_category="characters"
+        )
+        combined = "\n".join(footnote_defs)
+        assert "f-n01" in combined
+        assert "f-n02" not in combined
+
+    def test_render_entity_page_with_crossref(self) -> None:
+        """render_entity_page passes crossref footnotes through to output."""
+        entity = _make_entity_row()
+        own_fact = _make_fact_row(fact_id="f-001", text="Theron ruled.")
+        linked_ent = _make_entity_row("Aldara", "locations", "aldara")
+        linked_fact = _make_fact_row(fact_id="f-n01", text="Aldara was founded here.")
+        entity_lookup = {("locations", "aldara"): linked_ent}
+        linked_facts = [(linked_ent, [linked_fact])]
+        prose = "Theron ruled. See [[fact:f-n01]]."
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=[own_fact],
+            prose=prose,
+            conn=None,
+            entity_lookup=entity_lookup,
+            linked_facts=linked_facts,
+        )
+        assert "[^f-n01]" in result
+        assert "Aldara was founded here." in result

--- a/tests/test_stage4.py
+++ b/tests/test_stage4.py
@@ -698,3 +698,86 @@ class TestBuildPromptLinkedFacts:
         user_content = " ".join(m["content"] for m in messages if m["role"] == "user")
         assert "Aldara is an ancient city." in user_content
         assert result.prose == "Theron founded Aldara."
+
+
+# ---------------------------------------------------------------------------
+# page_step.run_page_step — linked-context budgeting
+# ---------------------------------------------------------------------------
+
+
+class TestRunPageStepBudget:
+    def _seed_with_linked(self, conn: sqlite3.Connection) -> None:
+        """Add aldara entity sharing a fact with theron."""
+        conn.execute(
+            "INSERT INTO entities(category, slug, canonical_name, created_at,"
+            " created_by_ingest, updated_at)"
+            " VALUES ('locations', 'aldara', 'Aldara',"
+            " '2026-01-01T00:00:00Z', 'ing-001', '2026-01-01T00:00:00Z')"
+        )
+        create_fact_with_targets(
+            conn,
+            fact_id="f-shared",
+            text="Theron founded Aldara.",
+            raw_transcript_span="raw",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:04:32",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            targets=[
+                ("characters", "theron", "biography"),
+                ("locations", "aldara", "founding"),
+            ],
+            by="tester",
+        )
+        conn.commit()
+
+    def test_page_step_caps_linked_context(self, tmp_path: Path) -> None:
+        """run_page_step applies budget_linked_context; large budget passes facts."""
+        conn = _seed_conn()
+        self._seed_with_linked(conn)
+
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Generated prose."}')
+
+        # large budget → linked facts included; LLM called with linked context
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            context_window=200_000,
+            budget_fraction=0.25,
+        )
+        # LLM should have been called (theron has shared fact)
+        assert client.complete.called
+
+    def test_page_step_degrades_on_over_budget(self, tmp_path: Path) -> None:
+        """When linked context too large, page step still summarizes own facts."""
+        conn = _seed_conn()
+        self._seed_with_linked(conn)
+
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Generated prose."}')
+
+        # budget so tiny that fact text ("Theron founded Aldara." = 22 chars → 5 tokens)
+        # exceeds budget → LinkedContextTooLargeError → degrade to empty linked context
+        paths = run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            context_window=4,  # budget = 4 * 0.25 = 1 token; fact text → 5 tokens
+            budget_fraction=0.25,
+        )
+        # entity still summarized even when linked context dropped
+        theron_path = tmp_path / "characters" / "theron.md"
+        assert theron_path in paths
+        assert theron_path.exists()

--- a/tests/test_stage4.py
+++ b/tests/test_stage4.py
@@ -1,0 +1,511 @@
+"""Tests for stage4.py — LLM-prose entity summarizer."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from auto_lorebook import db
+from auto_lorebook.entities import AliasRow, EntityRow
+from auto_lorebook.facts import FactRow, create_fact_with_target
+from auto_lorebook.page_step import run_page_step
+from auto_lorebook.stage4 import (
+    Stage4Error,
+    build_prompt,
+    parse_response,
+    render_entity_page,
+    run,
+    summarize_entity,
+)
+
+if TYPE_CHECKING:
+    import sqlite3
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers / shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_entity_row(
+    name: str = "Theron",
+    category: str = "characters",
+    slug: str = "theron",
+) -> EntityRow:
+    return EntityRow(
+        category=category,
+        slug=slug,
+        canonical_name=name,
+        superseded_by_category=None,
+        superseded_by_slug=None,
+        created_at="2026-01-01T00:00:00Z",
+        created_by_ingest="ing-001",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+
+
+def _make_fact_row(
+    fact_id: str = "f-001",
+    text: str = "Theron founded the city.",
+    status: str = "authoritative",
+    status_reason: str | None = None,
+    source_id: str = "src-001",
+    locator: str = "0:04:32-0:04:41",
+    speaker: str | None = "DM",
+    session_date: str | None = "2026-01-15",
+) -> FactRow:
+    return FactRow(
+        id=fact_id,
+        text=text,
+        raw_transcript_span="raw span",
+        text_corrects_transcript=False,
+        text_source=None,
+        edited_by_human=False,
+        edited_at=None,
+        source_id=source_id,
+        locator=locator,
+        speaker=speaker,
+        status=status,
+        status_reason=status_reason,
+        session_date=session_date,
+        approved_at="2026-01-15T10:00:00Z",
+        created_by_ingest="ing-001",
+        claim_group_id="cg-001",
+        corrections_applied=[],
+        inputs_json=None,
+    )
+
+
+def _make_alias_row(name: str = "King Theron") -> AliasRow:
+    return AliasRow(
+        entity_category="characters",
+        entity_slug="theron",
+        name=name,
+        name_normalized=name.lower(),
+        added_by_ingest="ing-001",
+        added_at="2026-01-01T00:00:00Z",
+        source="stub-creation",
+    )
+
+
+def _seed_conn() -> sqlite3.Connection:
+    """In-memory DB with one entity and one source."""
+    conn = db.open(":memory:")
+    conn.execute(
+        "INSERT INTO sources(source_id, source_type, fetched_at, context_json)"
+        " VALUES ('src-001', 'youtube', '2026-01-01T00:00:00Z', '{}')"
+    )
+    conn.execute(
+        "INSERT INTO ingests(ingest_id, source_id, started_at, state)"
+        " VALUES ('ing-001', 'src-001', '2026-01-01T00:00:00Z', 'done')"
+    )
+    conn.execute(
+        "INSERT INTO entities(category, slug, canonical_name, created_at,"
+        " created_by_ingest, updated_at)"
+        " VALUES ('characters', 'theron', 'Theron',"
+        " '2026-01-01T00:00:00Z', 'ing-001', '2026-01-01T00:00:00Z')"
+    )
+    conn.commit()
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# stage4.build_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPrompt:
+    def test_includes_entity_name(self) -> None:
+        entity = _make_entity_row()
+        prompt = build_prompt(
+            entity=entity,
+            aliases=[],
+            facts=[_make_fact_row()],
+            entity_index="Characters:\n  - Theron",
+            wiki_setting="A fantasy world called Aether.",
+        )
+        assert "Theron" in prompt
+
+    def test_includes_wiki_setting(self) -> None:
+        entity = _make_entity_row()
+        prompt = build_prompt(
+            entity=entity,
+            aliases=[],
+            facts=[_make_fact_row()],
+            entity_index="Characters:\n  - Theron",
+            wiki_setting="Aether is a realm of ancient magic.",
+        )
+        assert "Aether is a realm of ancient magic." in prompt
+
+    def test_includes_fact_text(self) -> None:
+        entity = _make_entity_row()
+        fact = _make_fact_row(text="Theron founded Aldara.")
+        prompt = build_prompt(
+            entity=entity,
+            aliases=[],
+            facts=[fact],
+            entity_index="",
+            wiki_setting="",
+        )
+        assert "Theron founded Aldara." in prompt
+
+    def test_includes_entity_index(self) -> None:
+        entity = _make_entity_row()
+        prompt = build_prompt(
+            entity=entity,
+            aliases=[],
+            facts=[_make_fact_row()],
+            entity_index="Characters:\n  - Aldara\n  - Theron",
+            wiki_setting="",
+        )
+        assert "Aldara" in prompt
+
+    def test_includes_disproven_status(self) -> None:
+        entity = _make_entity_row()
+        fact = _make_fact_row(
+            status="disproven",
+            status_reason="Contradicted by later evidence.",
+        )
+        prompt = build_prompt(
+            entity=entity,
+            aliases=[],
+            facts=[fact],
+            entity_index="",
+            wiki_setting="",
+        )
+        assert "disproven" in prompt.lower()
+
+
+# ---------------------------------------------------------------------------
+# stage4.parse_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseResponse:
+    def test_returns_prose_field(self) -> None:
+        payload = {"prose": "Theron is a legendary king."}
+        result = parse_response(payload)
+        assert result.prose == "Theron is a legendary king."
+
+    def test_empty_prose_treated_as_empty_string(self) -> None:
+        payload = {"prose": ""}
+        result = parse_response(payload)
+        assert not result.prose
+
+    def test_missing_prose_raises(self) -> None:
+        with pytest.raises(Stage4Error, match="prose"):
+            parse_response({})
+
+
+# ---------------------------------------------------------------------------
+# stage4.run (mocked client)
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    def test_calls_client_complete(self) -> None:
+        client = MagicMock()
+        client.complete.return_value = MagicMock(
+            text='{"prose": "Theron is a legendary king."}'
+        )
+        entity = _make_entity_row()
+        result = run(
+            entity=entity,
+            aliases=[],
+            facts=[_make_fact_row()],
+            entity_index="Characters:\n  - Theron",
+            wiki_setting="A fantasy world.",
+            client=client,
+            model="test/model",
+        )
+        assert client.complete.called
+        assert result.prose == "Theron is a legendary king."
+
+    def test_prompt_assembly_passed_to_client(self) -> None:
+        client = MagicMock()
+        client.complete.return_value = MagicMock(
+            text='{"prose": "Theron ruled wisely."}'
+        )
+        entity = _make_entity_row()
+        run(
+            entity=entity,
+            aliases=[],
+            facts=[_make_fact_row(text="Theron ruled wisely.")],
+            entity_index="Characters:\n  - Theron",
+            wiki_setting="A fantasy world.",
+            client=client,
+            model="test/model",
+        )
+        call_args = client.complete.call_args
+        messages = call_args[0][0] if call_args[0] else call_args[1]["messages"]
+        user_content = " ".join(m["content"] for m in messages if m["role"] == "user")
+        assert "Theron ruled wisely." in user_content
+
+
+# ---------------------------------------------------------------------------
+# stage4.render_entity_page — renderer
+# ---------------------------------------------------------------------------
+
+
+class TestRenderEntityPage:
+    def test_heading_is_canonical_name(self) -> None:
+        entity = _make_entity_row()
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=[_make_fact_row()],
+            prose="Theron is a legendary king.",
+            conn=None,
+        )
+        assert result.startswith("# Theron")
+
+    def test_prose_summary_section(self) -> None:
+        entity = _make_entity_row()
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=[_make_fact_row()],
+            prose="Theron is a legendary king.",
+            conn=None,
+        )
+        assert "## Summary" in result
+        assert "Theron is a legendary king." in result
+
+    def test_facts_section_present(self) -> None:
+        entity = _make_entity_row()
+        facts = [_make_fact_row(status="authoritative")]
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=facts,
+            prose="Some prose.",
+            conn=None,
+        )
+        assert "## Facts" in result
+
+    def test_authoritative_subsection(self) -> None:
+        entity = _make_entity_row()
+        facts = [_make_fact_row(status="authoritative")]
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=facts,
+            prose="Some prose.",
+            conn=None,
+        )
+        assert "### Authoritative" in result
+
+    def test_hearsay_subsection(self) -> None:
+        entity = _make_entity_row()
+        facts = [_make_fact_row(status="hearsay")]
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=facts,
+            prose="Some prose.",
+            conn=None,
+        )
+        assert "### Hearsay" in result
+
+    def test_disproven_struck_through(self) -> None:
+        entity = _make_entity_row()
+        facts = [
+            _make_fact_row(
+                status="disproven",
+                text="Theron was evil.",
+                status_reason="Later corrected.",
+            )
+        ]
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=facts,
+            prose="Some prose.",
+            conn=None,
+        )
+        assert "~~Theron was evil.~~" in result
+        assert "Later corrected." in result
+
+    def test_references_section(self) -> None:
+        entity = _make_entity_row()
+        facts = [_make_fact_row(source_id="src-001")]
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=facts,
+            prose="Some prose.",
+            conn=None,
+        )
+        assert "## References" in result
+
+    def test_footnote_includes_quote(self) -> None:
+        entity = _make_entity_row()
+        facts = [_make_fact_row(text="Theron founded Aldara.")]
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=facts,
+            prose="Some prose.",
+            conn=None,
+        )
+        assert "Theron founded Aldara." in result
+
+    def test_aliases_section_when_present(self) -> None:
+        entity = _make_entity_row()
+        aliases = [_make_alias_row("King Theron")]
+        result = render_entity_page(
+            entity=entity,
+            aliases=aliases,
+            facts=[_make_fact_row()],
+            prose="Some prose.",
+            conn=None,
+        )
+        assert "## Aliases" in result
+        assert "King Theron" in result
+
+    def test_zero_fact_stub_no_llm(self) -> None:
+        """Zero-fact entity: mechanical stub only, no prose required."""
+        entity = _make_entity_row()
+        result = render_entity_page(
+            entity=entity,
+            aliases=[],
+            facts=[],
+            prose=None,
+            conn=None,
+        )
+        assert "# Theron" in result
+        assert "## Summary" not in result
+        assert "## Facts" not in result
+
+
+# ---------------------------------------------------------------------------
+# stage4.summarize_entity — zero-fact path skips LLM
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeEntity:
+    def test_zero_fact_entity_skips_llm(self, tmp_path: Path) -> None:
+        conn = _seed_conn()
+        client = MagicMock()
+        path = summarize_entity(
+            conn=conn,
+            wiki_repo=tmp_path,
+            category="characters",
+            slug="theron",
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+        )
+        assert not client.complete.called
+        assert path.exists()
+
+    def test_entity_with_facts_calls_llm(self, tmp_path: Path) -> None:
+        conn = _seed_conn()
+        create_fact_with_target(
+            conn,
+            fact_id="f-001",
+            text="Theron founded the city.",
+            raw_transcript_span="raw",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:04:32",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            entity_category="characters",
+            entity_slug="theron",
+            section="biography",
+            by="tester",
+        )
+        conn.commit()
+
+        client = MagicMock()
+        client.complete.return_value = MagicMock(
+            text='{"prose": "Theron was a great king."}'
+        )
+
+        path = summarize_entity(
+            conn=conn,
+            wiki_repo=tmp_path,
+            category="characters",
+            slug="theron",
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+        )
+        assert client.complete.called
+        assert path.exists()
+        content = path.read_text()
+        assert "Theron was a great king." in content
+
+
+# ---------------------------------------------------------------------------
+# page_step.run_page_step — batched orchestrator
+# ---------------------------------------------------------------------------
+
+
+def _seed_entity_with_fact() -> sqlite3.Connection:
+    """In-memory DB with entity and one fact."""
+    conn = _seed_conn()
+    create_fact_with_target(
+        conn,
+        fact_id="f-001",
+        text="Theron founded the city.",
+        raw_transcript_span="raw",
+        text_corrects_transcript=False,
+        source_id="src-001",
+        locator="0:04:32",
+        status="authoritative",
+        approved_at="2026-01-15T10:00:00Z",
+        created_by_ingest="ing-001",
+        entity_category="characters",
+        entity_slug="theron",
+        section="biography",
+        by="tester",
+    )
+    conn.commit()
+    return conn
+
+
+class TestRunPageStep:
+    def test_reports_progress(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        conn = _seed_entity_with_fact()
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Theron was great."}')
+
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+        )
+        captured = capsys.readouterr()
+        assert "Summarizing" in captured.out or "summariz" in captured.out.lower()
+
+    def test_writes_md_for_touched_entities(self, tmp_path: Path) -> None:
+        conn = _seed_entity_with_fact()
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Theron was great."}')
+
+        paths = run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+        )
+        md_path = tmp_path / "characters" / "theron.md"
+        assert md_path in paths
+        assert md_path.exists()

--- a/tests/test_stage4.py
+++ b/tests/test_stage4.py
@@ -1002,3 +1002,76 @@ class TestRunPageStepBudget:
         theron_path = tmp_path / "characters" / "theron.md"
         assert theron_path in paths
         assert theron_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# page_step.run_page_step — removed_entities param
+# ---------------------------------------------------------------------------
+
+
+class TestRunPageStepRemovedEntities:
+    def test_removed_entity_page_deleted(self, tmp_path: Path) -> None:
+        """Page file for removed entity is deleted; no LLM call for it."""
+        conn = _seed_entity_with_fact()
+        # pre-create the .md so we can assert it gets removed
+        md = tmp_path / "characters" / "theron.md"
+        md.parent.mkdir(parents=True, exist_ok=True)
+        md.write_text("old content", encoding="utf-8")
+
+        client = MagicMock()
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[],
+            removed_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+        )
+        assert not md.exists()
+        client.complete.assert_not_called()
+
+    def test_removed_set_not_resummarized(self, tmp_path: Path) -> None:
+        """Entity in both touched and removed is not re-summarized."""
+        conn = _seed_entity_with_fact()
+        md = tmp_path / "characters" / "theron.md"
+        md.parent.mkdir(parents=True, exist_ok=True)
+        md.write_text("old content", encoding="utf-8")
+
+        client = MagicMock()
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            removed_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+        )
+        # page deleted, NOT re-summarized
+        assert not md.exists()
+        client.complete.assert_not_called()
+
+    def test_only_removed_set_runs(self, tmp_path: Path) -> None:
+        """removed_entities non-empty with empty touched_entities → page deleted."""
+        conn = _seed_entity_with_fact()
+        md = tmp_path / "characters" / "theron.md"
+        md.parent.mkdir(parents=True, exist_ok=True)
+        md.write_text("old content", encoding="utf-8")
+
+        client = MagicMock()
+        paths = run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[],
+            removed_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+        )
+        assert not md.exists()
+        # removed entity is not in the written paths (nothing written)
+        assert ("characters", "theron") not in [(p.parent.name, p.stem) for p in paths]

--- a/tests/test_stage4.py
+++ b/tests/test_stage4.py
@@ -726,7 +726,9 @@ class TestPerFactAnchors:
         """Adding a second fact does not change the anchor of the first."""
         entity = _make_entity_row()
         fact1 = _make_fact_row(fact_id="f-001", text="First fact.")
-        fact2 = _make_fact_row(fact_id="f-002", text="Second fact.", source_id="src-001")
+        fact2 = _make_fact_row(
+            fact_id="f-002", text="Second fact.", source_id="src-001"
+        )
 
         result_one = render_entity_page(
             entity=entity,
@@ -753,9 +755,7 @@ class TestPerFactAnchors:
 
 
 class TestEntityMarkerResolution:
-    def _make_linked_entity(
-        self, name: str, category: str, slug: str
-    ) -> EntityRow:
+    def _make_linked_entity(self, name: str, category: str, slug: str) -> EntityRow:
         return _make_entity_row(name, category, slug)
 
     def test_marker_resolves_to_link(self) -> None:
@@ -783,7 +783,9 @@ class TestEntityMarkerResolution:
         assert "[[mystery/unknown]]" not in result
         assert "mystery/unknown" in result
 
-    def test_unresolvable_marker_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_unresolvable_marker_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """Unresolvable marker emits a logged warning."""
         lookup: dict[tuple[str, str], EntityRow] = {}
         prose = "See [[mystery/unknown]] here."
@@ -855,6 +857,30 @@ class TestCrossReferenceFootnotes:
         )
         assert "[[fact:unknown]]" not in new_prose
         assert not footnote_defs
+
+    def test_unresolvable_crossref_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unresolvable [[fact:unknown]] emits a logged warning."""
+        linked_fact_index: dict[str, tuple[EntityRow, FactRow]] = {}
+        prose = "See [[fact:unknown]]."
+        with caplog.at_level(logging.WARNING, logger="auto_lorebook.stage4"):
+            _resolve_crossref_markers(
+                prose, linked_fact_index, from_category="characters"
+            )
+        assert any("unknown" in r.message for r in caplog.records)
+
+    def test_duplicate_crossref_marker_single_footnote_def(self) -> None:
+        """Same [[fact:f-n01]] twice → exactly one footnote def."""
+        linked_ent = self._make_linked()
+        linked_fact = _make_fact_row(fact_id="f-n01", text="Aldara was built.")
+        linked_fact_index = {"f-n01": (linked_ent, linked_fact)}
+        prose = "First [[fact:f-n01]] and again [[fact:f-n01]]."
+        _, footnote_defs = _resolve_crossref_markers(
+            prose, linked_fact_index, from_category="characters"
+        )
+        assert footnote_defs.count(footnote_defs[0]) == 1
+        assert len([d for d in footnote_defs if "f-n01" in d]) == 1
 
     def test_crossref_only_for_cited_linked_facts(self) -> None:
         """Only [[fact:…]] markers that appear in prose generate footnotes."""

--- a/tests/test_stage4.py
+++ b/tests/test_stage4.py
@@ -1002,3 +1002,159 @@ class TestRunPageStepBudget:
         theron_path = tmp_path / "characters" / "theron.md"
         assert theron_path in paths
         assert theron_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# page_step.run_page_step — staleness-skip behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRunPageStepStaleness:
+    def test_records_hash_after_generation(self, tmp_path: Path) -> None:
+        """run_page_step stores inputs hash in DB after generating a page."""
+        from auto_lorebook.staleness_store import get_page_hash  # noqa: PLC0415
+
+        conn = _seed_entity_with_fact()
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Generated."}')
+
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+        )
+        assert get_page_hash(conn, "characters", "theron") is not None
+
+    def test_skip_unchanged_does_not_call_llm_again(self, tmp_path: Path) -> None:
+        """Second run with skip_unchanged=True skips pages with matching hash."""
+        conn = _seed_entity_with_fact()
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Generated."}')
+
+        # first run populates hash
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            skip_unchanged=True,
+        )
+        first_call_count = client.complete.call_count
+
+        # second run: inputs unchanged → skip
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            skip_unchanged=True,
+        )
+        assert client.complete.call_count == first_call_count
+
+    def test_skip_unchanged_false_regenerates(self, tmp_path: Path) -> None:
+        """skip_unchanged=False always calls LLM."""
+        conn = _seed_entity_with_fact()
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Generated."}')
+
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            skip_unchanged=False,
+        )
+        first_count = client.complete.call_count
+
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            skip_unchanged=False,
+        )
+        assert client.complete.call_count == first_count * 2
+
+    def test_mutated_fact_triggers_regen(self, tmp_path: Path) -> None:
+        """Changing a fact's text causes skip_unchanged=True to regenerate."""
+        from auto_lorebook.facts import update_status  # noqa: PLC0415
+
+        conn = _seed_entity_with_fact()
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Generated."}')
+
+        # first run
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            skip_unchanged=True,
+        )
+        after_first = client.complete.call_count
+
+        # mutate fact status (fact text change would require a new function;
+        # status change is enough to change the inputs hash)
+        update_status(conn, "f-001", "hearsay", reason="changed", by="tester")
+        conn.commit()
+
+        # second run: inputs changed → regenerate
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            skip_unchanged=True,
+        )
+        assert client.complete.call_count > after_first
+
+    def test_second_run_returns_empty_written_paths(self, tmp_path: Path) -> None:
+        """Second skip_unchanged run returns empty written paths list."""
+        conn = _seed_entity_with_fact()
+        client = MagicMock()
+        client.complete.return_value = MagicMock(text='{"prose": "Generated."}')
+
+        run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            skip_unchanged=True,
+        )
+
+        paths = run_page_step(
+            conn=conn,
+            wiki_repo=tmp_path,
+            touched_entities=[("characters", "theron")],
+            entity_index="",
+            wiki_setting="",
+            client=client,
+            model="test/model",
+            skip_unchanged=True,
+        )
+        assert paths == []

--- a/tests/test_staleness_store.py
+++ b/tests/test_staleness_store.py
@@ -1,0 +1,228 @@
+"""Tests for staleness_store: hash computation and DB round-trips."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from auto_lorebook import db
+from auto_lorebook.entities import AliasRow, EntityRow
+from auto_lorebook.facts import FactRow
+from auto_lorebook.staleness_store import (
+    compute_page_inputs_hash,
+    get_page_hash,
+    record_page_hash,
+)
+
+if TYPE_CHECKING:
+    import sqlite3
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_entity(category: str = "characters", slug: str = "theron") -> EntityRow:
+    return EntityRow(
+        category=category,
+        slug=slug,
+        canonical_name="Theron",
+        superseded_by_category=None,
+        superseded_by_slug=None,
+        created_at="2026-01-01T00:00:00Z",
+        created_by_ingest="ing-001",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+
+
+def _make_fact(
+    fact_id: str = "f-001",
+    text: str = "Theron founded the city.",
+    status: str = "authoritative",
+) -> FactRow:
+    return FactRow(
+        id=fact_id,
+        text=text,
+        raw_transcript_span="raw span",
+        text_corrects_transcript=False,
+        text_source=None,
+        edited_by_human=False,
+        edited_at=None,
+        source_id="src-001",
+        locator="0:04:32",
+        speaker="DM",
+        status=status,
+        status_reason=None,
+        session_date="2026-01-15",
+        approved_at="2026-01-15T10:00:00Z",
+        created_by_ingest="ing-001",
+        claim_group_id="cg-001",
+        corrections_applied=[],
+        inputs_json=None,
+    )
+
+
+def _make_alias(name: str = "King Theron") -> AliasRow:
+    return AliasRow(
+        entity_category="characters",
+        entity_slug="theron",
+        name=name,
+        name_normalized=name.lower(),
+        added_by_ingest="ing-001",
+        added_at="2026-01-01T00:00:00Z",
+        source="stub-creation",
+    )
+
+
+def _base_hash(**overrides: object) -> str:
+    kwargs: dict[str, object] = {
+        "entity": _make_entity(),
+        "aliases": [],
+        "facts": [_make_fact()],
+        "linked_facts": [],
+        "entity_index": "Characters:\n  - Theron",
+        "wiki_setting": "A fantasy world.",
+        "model": "test/model",
+        "model_params": {},
+    }
+    kwargs.update(overrides)
+    return compute_page_inputs_hash(**kwargs)  # type: ignore[arg-type]
+
+
+def _mem_conn() -> sqlite3.Connection:
+    conn = db.open(":memory:")
+    conn.execute(
+        "INSERT INTO sources(source_id, source_type, fetched_at, context_json)"
+        " VALUES ('src-001', 'youtube', '2026-01-01T00:00:00Z', '{}')"
+    )
+    conn.execute(
+        "INSERT INTO ingests(ingest_id, source_id, started_at, state)"
+        " VALUES ('ing-001', 'src-001', '2026-01-01T00:00:00Z', 'done')"
+    )
+    conn.execute(
+        "INSERT INTO entities(category, slug, canonical_name, created_at,"
+        " created_by_ingest, updated_at)"
+        " VALUES ('characters', 'theron', 'Theron',"
+        " '2026-01-01T00:00:00Z', 'ing-001', '2026-01-01T00:00:00Z')"
+    )
+    conn.commit()
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# compute_page_inputs_hash — determinism / order-independence
+# ---------------------------------------------------------------------------
+
+
+class TestComputePageInputsHash:
+    def test_deterministic(self) -> None:
+        h1 = _base_hash()
+        h2 = _base_hash()
+        assert h1 == h2
+
+    def test_shuffled_facts_same_hash(self) -> None:
+        f1 = _make_fact("f-001", "First fact.")
+        f2 = _make_fact("f-002", "Second fact.")
+        h1 = _base_hash(facts=[f1, f2])
+        h2 = _base_hash(facts=[f2, f1])
+        assert h1 == h2
+
+    def test_shuffled_linked_entities_same_hash(self) -> None:
+        le1 = _make_entity("locations", "aldara")
+        le2 = _make_entity("factions", "guild")
+        lf1 = _make_fact("f-n01", "Aldara founded.")
+        lf2 = _make_fact("f-n02", "Guild formed.")
+        h1 = _base_hash(linked_facts=[(le1, [lf1]), (le2, [lf2])])
+        h2 = _base_hash(linked_facts=[(le2, [lf2]), (le1, [lf1])])
+        assert h1 == h2
+
+    def test_different_fact_text_different_hash(self) -> None:
+        h1 = _base_hash(facts=[_make_fact(text="Original text.")])
+        h2 = _base_hash(facts=[_make_fact(text="Changed text.")])
+        assert h1 != h2
+
+    def test_different_fact_status_different_hash(self) -> None:
+        h1 = _base_hash(facts=[_make_fact(status="authoritative")])
+        h2 = _base_hash(facts=[_make_fact(status="hearsay")])
+        assert h1 != h2
+
+    def test_different_entity_index_different_hash(self) -> None:
+        h1 = _base_hash(entity_index="Characters:\n  - Theron")
+        h2 = _base_hash(entity_index="Characters:\n  - Theron\n  - Aldara")
+        assert h1 != h2
+
+    def test_different_wiki_setting_different_hash(self) -> None:
+        h1 = _base_hash(wiki_setting="A fantasy world.")
+        h2 = _base_hash(wiki_setting="A sci-fi world.")
+        assert h1 != h2
+
+    def test_different_model_different_hash(self) -> None:
+        h1 = _base_hash(model="model/a")
+        h2 = _base_hash(model="model/b")
+        assert h1 != h2
+
+    def test_different_linked_facts_different_hash(self) -> None:
+        le = _make_entity("locations", "aldara")
+        h1 = _base_hash(linked_facts=[])
+        h2 = _base_hash(linked_facts=[(le, [_make_fact("f-n01", "Linked fact.")])])
+        assert h1 != h2
+
+    def test_returns_hex_string(self) -> None:
+        h = _base_hash()
+        assert len(h) == 64
+        assert all(c in "0123456789abcdef" for c in h)
+
+
+# ---------------------------------------------------------------------------
+# get_page_hash / record_page_hash — DB round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestPageHashRoundTrip:
+    def test_get_returns_none_for_unknown(self) -> None:
+        conn = _mem_conn()
+        result = get_page_hash(conn, "characters", "theron")
+        conn.close()
+        assert result is None
+
+    def test_record_then_get(self) -> None:
+        conn = _mem_conn()
+        record_page_hash(conn, "characters", "theron", "abc123def456")
+        conn.commit()
+        result = get_page_hash(conn, "characters", "theron")
+        conn.close()
+        assert result == "abc123def456"
+
+    def test_upsert_overwrites(self) -> None:
+        conn = _mem_conn()
+        record_page_hash(conn, "characters", "theron", "hash-v1")
+        conn.commit()
+        record_page_hash(conn, "characters", "theron", "hash-v2")
+        conn.commit()
+        result = get_page_hash(conn, "characters", "theron")
+        conn.close()
+        assert result == "hash-v2"
+
+    def test_explicit_generated_at(self) -> None:
+        conn = _mem_conn()
+        ts = "2026-05-01T12:00:00Z"
+        record_page_hash(conn, "characters", "theron", "somehash", generated_at=ts)
+        conn.commit()
+        row = conn.execute(
+            "SELECT generated_at FROM entity_page_staleness"
+            " WHERE category='characters' AND slug='theron'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == ts
+
+    def test_default_generated_at_is_set(self) -> None:
+        conn = _mem_conn()
+        record_page_hash(conn, "characters", "theron", "somehash")
+        conn.commit()
+        row = conn.execute(
+            "SELECT generated_at FROM entity_page_staleness"
+            " WHERE category='characters' AND slug='theron'"
+        ).fetchone()
+        conn.close()
+        assert row[0] is not None
+        assert len(row[0]) > 0

--- a/tests/test_wiki_cmd.py
+++ b/tests/test_wiki_cmd.py
@@ -493,7 +493,7 @@ class TestWikiOverrideFlag:
 
 
 def _make_rebuild_ns(**kwargs: object) -> argparse.Namespace:
-    base: dict[str, object] = {"wiki_action": "rebuild", "wiki": None}
+    base: dict[str, object] = {"wiki_action": "rebuild", "wiki": None, "force": False}
     base.update(kwargs)
     return argparse.Namespace(**base)
 
@@ -694,3 +694,87 @@ class TestRebuild:
 
         assert rc == 1
         assert "wiki" in capsys.readouterr().out.lower()
+
+    def test_rebuild_force_flag_parsed(self) -> None:
+        """Parser sets force=True when --force passed."""
+        from auto_lorebook.cli import create_parser  # noqa: PLC0415
+
+        parser = create_parser()
+        args = parser.parse_args(["wiki", "rebuild", "--force"])
+        assert args.force is True
+
+    def test_rebuild_force_flag_default_false(self) -> None:
+        """Parser sets force=False when --force not passed."""
+        from auto_lorebook.cli import create_parser  # noqa: PLC0415
+
+        parser = create_parser()
+        args = parser.parse_args(["wiki", "rebuild"])
+        assert args.force is False
+
+    def test_rebuild_skip_unchanged_second_run(
+        self,
+        configured_wiki: Path,
+        tmp_home: Path,  # noqa: ARG002
+    ) -> None:
+        """Second rebuild without --force skips unchanged pages (LLM not re-called)."""
+        from unittest.mock import MagicMock, patch  # noqa: PLC0415
+
+        _seed_wiki_db(configured_wiki)
+
+        mock_client = MagicMock()
+        mock_client.complete.return_value = MagicMock(
+            text='{"prose": "Some generated prose."}'
+        )
+
+        patch_client = patch(
+            "auto_lorebook.commands.wiki.OpenRouterClient", return_value=mock_client
+        )
+        patch_key = patch(
+            "auto_lorebook.commands.wiki.cfg_mod.Config.get_api_key",
+            return_value="sk-test",
+        )
+
+        with patch_client, patch_key:
+            rc1 = wiki_cmd.run(_make_rebuild_ns())
+        assert rc1 == 0
+        after_first = mock_client.complete.call_count
+
+        # second rebuild without --force → skip unchanged
+        with patch_client, patch_key:
+            rc2 = wiki_cmd.run(_make_rebuild_ns())
+        assert rc2 == 0
+        # no extra LLM calls on second run
+        assert mock_client.complete.call_count == after_first
+
+    def test_rebuild_force_regenerates_despite_unchanged(
+        self,
+        configured_wiki: Path,
+        tmp_home: Path,  # noqa: ARG002
+    ) -> None:
+        """Second rebuild with --force calls LLM again even if inputs unchanged."""
+        from unittest.mock import MagicMock, patch  # noqa: PLC0415
+
+        _seed_wiki_db(configured_wiki)
+
+        mock_client = MagicMock()
+        mock_client.complete.return_value = MagicMock(
+            text='{"prose": "Some generated prose."}'
+        )
+
+        patch_client = patch(
+            "auto_lorebook.commands.wiki.OpenRouterClient", return_value=mock_client
+        )
+        patch_key = patch(
+            "auto_lorebook.commands.wiki.cfg_mod.Config.get_api_key",
+            return_value="sk-test",
+        )
+
+        with patch_client, patch_key:
+            wiki_cmd.run(_make_rebuild_ns())
+        after_first = mock_client.complete.call_count
+
+        # --force → always regenerate
+        with patch_client, patch_key:
+            rc2 = wiki_cmd.run(_make_rebuild_ns(force=True))
+        assert rc2 == 0
+        assert mock_client.complete.call_count > after_first

--- a/tests/test_wiki_cmd.py
+++ b/tests/test_wiki_cmd.py
@@ -11,7 +11,7 @@ import yaml
 from auto_lorebook import config as cfg_mod
 from auto_lorebook.cli import create_parser
 from auto_lorebook.commands import wiki_cmd
-from auto_lorebook.commands._shared import resolve_wiki  # noqa: PLC2701
+from auto_lorebook.commands._shared import resolve_wiki
 from auto_lorebook.config import ConfigError
 
 if TYPE_CHECKING:

--- a/tests/test_wiki_cmd.py
+++ b/tests/test_wiki_cmd.py
@@ -485,3 +485,212 @@ class TestWikiOverrideFlag:
         resolve_wiki(cfg, args)
         after = yaml.safe_load((tmp_home / "config.yaml").read_text(encoding="utf-8"))
         assert before == after
+
+
+# ---------------------------------------------------------------------------
+# Phase 8 — wiki rebuild
+# ---------------------------------------------------------------------------
+
+
+def _make_rebuild_ns(**kwargs: object) -> argparse.Namespace:
+    base: dict[str, object] = {"wiki_action": "rebuild", "wiki": None}
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+def _seed_wiki_db(wiki_repo: Path) -> None:
+    """Initialise wiki DB with two entities and stub facts."""
+    from auto_lorebook import db, wiki_state  # noqa: PLC0415
+    from auto_lorebook.facts import create_fact_with_target  # noqa: PLC0415
+
+    conn = db.open(wiki_state.wiki_db_path(wiki_repo))
+    try:
+        conn.execute(
+            "INSERT INTO sources(source_id, source_type, fetched_at, context_json)"
+            " VALUES ('src-001', 'youtube', '2026-01-01T00:00:00Z', '{}')"
+        )
+        conn.execute(
+            "INSERT INTO ingests(ingest_id, source_id, started_at, state)"
+            " VALUES ('ing-001', 'src-001', '2026-01-01T00:00:00Z', 'done')"
+        )
+        conn.execute(
+            "INSERT INTO entities(category, slug, canonical_name, created_at,"
+            " created_by_ingest, updated_at)"
+            " VALUES ('characters', 'theron', 'Theron',"
+            " '2026-01-01T00:00:00Z', 'ing-001', '2026-01-01T00:00:00Z')"
+        )
+        conn.execute(
+            "INSERT INTO entities(category, slug, canonical_name, created_at,"
+            " created_by_ingest, updated_at)"
+            " VALUES ('locations', 'aldara', 'Aldara',"
+            " '2026-01-01T00:00:00Z', 'ing-001', '2026-01-01T00:00:00Z')"
+        )
+        create_fact_with_target(
+            conn,
+            fact_id="f-001",
+            text="Theron founded the city.",
+            raw_transcript_span="raw",
+            text_corrects_transcript=False,
+            source_id="src-001",
+            locator="0:04:32",
+            status="authoritative",
+            approved_at="2026-01-15T10:00:00Z",
+            created_by_ingest="ing-001",
+            entity_category="characters",
+            entity_slug="theron",
+            section="biography",
+            by="tester",
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestRebuild:
+    def test_rebuild_subcommand_registered(self) -> None:
+        """Parser accepts `wiki rebuild` and sets func."""
+        parser = create_parser()
+        args = parser.parse_args(["wiki", "rebuild"])
+        assert args.wiki_action == "rebuild"
+        assert args.func is wiki_cmd.run
+
+    def test_rebuild_regenerates_all_pages(
+        self,
+        configured_wiki: Path,
+        tmp_home: Path,  # noqa: ARG002
+    ) -> None:
+        """Rebuild regenerates .md for every entity."""
+        from unittest.mock import MagicMock, patch  # noqa: PLC0415
+
+        _seed_wiki_db(configured_wiki)
+
+        mock_client = MagicMock()
+        mock_client.complete.return_value = MagicMock(
+            text='{"prose": "Some generated prose."}'
+        )
+
+        with (
+            patch(
+                "auto_lorebook.commands.wiki.OpenRouterClient", return_value=mock_client
+            ),
+            patch(
+                "auto_lorebook.commands.wiki.cfg_mod.Config.get_api_key",
+                return_value="sk-test",
+            ),
+        ):
+            rc = wiki_cmd.run(_make_rebuild_ns())
+
+        assert rc == 0
+        assert (configured_wiki / "characters" / "theron.md").exists()
+
+    def test_rebuild_removes_orphan_md(
+        self,
+        configured_wiki: Path,
+        tmp_home: Path,  # noqa: ARG002
+    ) -> None:
+        """Orphan .md with no matching entity is deleted after rebuild."""
+        from unittest.mock import MagicMock, patch  # noqa: PLC0415
+
+        _seed_wiki_db(configured_wiki)
+
+        # pre-create orphan: no matching entity in DB
+        orphan = configured_wiki / "characters" / "ghost.md"
+        orphan.write_text("# Ghost\n", encoding="utf-8")
+        assert orphan.exists()
+
+        mock_client = MagicMock()
+        mock_client.complete.return_value = MagicMock(
+            text='{"prose": "Some generated prose."}'
+        )
+
+        with (
+            patch(
+                "auto_lorebook.commands.wiki.OpenRouterClient", return_value=mock_client
+            ),
+            patch(
+                "auto_lorebook.commands.wiki.cfg_mod.Config.get_api_key",
+                return_value="sk-test",
+            ),
+        ):
+            rc = wiki_cmd.run(_make_rebuild_ns())
+
+        assert rc == 0
+        assert not orphan.exists()
+        assert (configured_wiki / "characters" / "theron.md").exists()
+
+    def test_rebuild_recoverable_after_partial(
+        self,
+        configured_wiki: Path,
+        tmp_home: Path,  # noqa: ARG002
+    ) -> None:
+        """Rebuild succeeds even with a stale/partial .md present."""
+        from unittest.mock import MagicMock, patch  # noqa: PLC0415
+
+        _seed_wiki_db(configured_wiki)
+
+        # partial/stale .md exists with wrong content
+        stale = configured_wiki / "characters" / "theron.md"
+        stale.write_text("# PARTIAL\n", encoding="utf-8")
+
+        mock_client = MagicMock()
+        mock_client.complete.return_value = MagicMock(text='{"prose": "Fresh prose."}')
+
+        with (
+            patch(
+                "auto_lorebook.commands.wiki.OpenRouterClient", return_value=mock_client
+            ),
+            patch(
+                "auto_lorebook.commands.wiki.cfg_mod.Config.get_api_key",
+                return_value="sk-test",
+            ),
+        ):
+            rc = wiki_cmd.run(_make_rebuild_ns())
+
+        assert rc == 0
+        content = stale.read_text(encoding="utf-8")
+        # page was regenerated, not left as stale
+        assert "PARTIAL" not in content
+
+    def test_rebuild_no_api_key_returns_1(
+        self,
+        configured_wiki: Path,
+        tmp_home: Path,  # noqa: ARG002
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Rebuild prints error and returns 1 when no API key."""
+        from unittest.mock import patch  # noqa: PLC0415
+
+        _seed_wiki_db(configured_wiki)
+
+        with patch(
+            "auto_lorebook.commands.wiki.cfg_mod.Config.get_api_key",
+            return_value=None,
+        ):
+            rc = wiki_cmd.run(_make_rebuild_ns())
+
+        assert rc == 1
+        assert "api key" in capsys.readouterr().out.lower()
+
+    def test_rebuild_no_active_wiki_returns_1(
+        self,
+        tmp_home: Path,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Rebuild prints error and returns 1 when no active wiki is set."""
+        # config has a wiki registered but active_wiki is null
+        wiki_dir = tmp_path / "mywiki"
+        wiki_dir.mkdir()
+        data = {
+            "schema_version": 2,
+            "active_wiki": None,
+            "wikis": [{"nickname": "other", "path": str(wiki_dir)}],
+        }
+        (tmp_home / "config.yaml").write_text(
+            yaml.safe_dump(data, sort_keys=False), encoding="utf-8"
+        )
+
+        rc = wiki_cmd.run(_make_rebuild_ns())
+
+        assert rc == 1
+        assert "wiki" in capsys.readouterr().out.lower()


### PR DESCRIPTION
## Summary

Implements Stage 4 — the LLM-prose entity-page summarizer (epic #83) — end to end, as seven vertical slices. Each slice was planned, implemented, code-reviewed, and exercised with a live integration smoke before merging into this branch.

## Slices

- **Slice 1 (#84)** — LLM-prose entity summarizer. Entity `.md` pages generated with LLM prose, status-grouped facts, per-fact footnote citations; review sessions batch page generation for touched entities.
- **Slice 2 (#85)** — Linked-entity propagation. One-hop, non-transitive cross-entity synthesis; entities sharing a fact regenerate together, each prompt carrying a linked-entities context block.
- **Slice 3 (#86)** — Cross-reference citations & entity cross-links. Stable per-fact anchors derived from `fact.id`; `[[fact:<id>]]` markers become crossref footnotes quoting the linked fact; `[[category/slug]]` markers resolve to entity links, degrading to plain text + a warning when unresolvable.
- **Slice 4 (#87)** — Linked-context token budgeter (`linked_budget.py`). Caps the linked-context block to a configurable token budget (`summarizer.linked_context_budget_fraction`); fact-level trimming drops disproven then hearsay first; `LinkedContextTooLargeError` degrades gracefully.
- **Slice 5 (#88)** — `auto-lorebook wiki rebuild`. Regenerates every entity page via the page step and deletes orphan `.md` files with no matching entity.
- **Slice 6 (#90)** — Staleness-aware rebuild skip. New DB migration `006` adds an `entity_page_staleness` table keyed by `(category, slug)` storing an inputs SHA-256 hash; `wiki rebuild` skips pages whose inputs are unchanged, `--force` regenerates unconditionally. Hashes live only in the DB.
- **Slice 7 (#89)** — reject-ingest page reconciliation. `reject-ingest` deletes removed entities' pages and re-summarizes their linked survivors; a survivor that drops to zero facts renders the mechanical stub. `replan` is intentionally unchanged — it only discards unreviewed proposals, so it has nothing to reconcile.

## Validation

Every slice passed `ruff check`, `ruff format --check`, `ty check`, `pytest`, and `mkdocs build --strict`, and got a live integration smoke driving its real code path. On the integrated branch: **1007 tests pass, 5 skipped**. Migration `006` bumps the schema version; docs (`pipeline/summarizer.md`, `architecture/staleness.md`, `reference/audit.md`, `reference/cli.md`, roadmap) are reconciled.

## QA steps for the human

None strictly required — each slice's smoke exercised the live path. Optional spot-checks: run `auto-lorebook wiki rebuild` (then again, to see unchanged pages skipped, and `--force` to override); reject an ingest and confirm removed entities' pages are gone and neighbours re-summarized.

## Notes

- 41 files changed, ~4.9k insertions.
- Closes #83, #86, #87, #88, #89, #90. (#84 and #85 are already closed.)

Closes #83
Closes #86
Closes #87
Closes #88
Closes #89
Closes #90

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5pePA6v63c6JKm5rUPyct)_