### PR TITLE
Add html skill for building and previewing static pages

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -12,3 +12,4 @@ Skills I use daily for code work.
 - **[to-prd](./to-prd/SKILL.md)** — Turn the current conversation context into a PRD and submit it as a GitHub issue.
 - **[zoom-out](./zoom-out/SKILL.md)** — Tell the agent to zoom out and give broader context or a higher-level perspective on an unfamiliar section of code.
 - **[prototype](./prototype/SKILL.md)** — Build a throwaway prototype to flesh out a design — either a runnable terminal app for state/business-logic questions, or several radically different UI variations toggleable from one route.
+- **[html](./html/SKILL.md)** — Build a single static HTML page and publish it to a throwaway `html-previews` branch, returning a temporary browser URL.

--- a/.claude/skills/html/SKILL.md
+++ b/.claude/skills/html/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: html
+description: Build a single static HTML page and give the user a temporary URL to view it in their browser. Use whenever the user asks to "show", "preview", "mock up", "demo", or "build" a webpage, landing page, or one-file HTML design.
+---
+
+# HTML Preview (single, temporary)
+
+Previews live on a dedicated `html-previews` branch that holds **only** preview
+`.html` files — never any other repo content. Each preview is its own
+uniquely-named file. Never merge this branch into or out of your working branch.
+
+When invoked:
+
+1. Pick a unique filename: `preview-<random>.html`, where `<random>` is a short
+   random string (e.g. `preview-7f3a9c2e.html`). Build the page as that single
+   file — inline all CSS and JS, no build step.
+
+2. Publish it to `html-previews` without disturbing your current branch or
+   working tree, using a separate worktree:
+
+   ```sh
+   git fetch origin html-previews 2>/dev/null
+   if [ ! -d ../html-previews-wt ]; then
+     if git ls-remote --exit-code --heads origin html-previews >/dev/null 2>&1; then
+       git worktree add ../html-previews-wt html-previews
+     else
+       # First time: orphan branch with no history and no other repo files
+       git worktree add --detach ../html-previews-wt
+       git -C ../html-previews-wt checkout --orphan html-previews
+       git -C ../html-previews-wt rm -rf . >/dev/null 2>&1 || true
+     fi
+   fi
+   ```
+
+3. Write the HTML into `../html-previews-wt/preview-<random>.html`, then commit
+   and push:
+
+   ```sh
+   git -C ../html-previews-wt add preview-<random>.html
+   git -C ../html-previews-wt commit -m "Add preview-<random>.html"
+   git -C ../html-previews-wt push -u origin html-previews
+   ```
+
+4. Give the user this URL (substitute owner, repo, filename):
+
+   `http://htmlpreview.github.io/?http://raw.githubusercontent.com/<owner>/<repo>/html-previews/preview-<random>.html`
+
+5. For revisions: edit that same file in `../html-previews-wt/`, commit, and push
+   again. The URL stays the same; they just refresh. For a brand-new preview,
+   generate a fresh filename and repeat steps 1–4.
+
+Notes:
+- For private repos, the user needs to be signed into GitHub in the same browser
+  for htmlpreview to fetch it.
+- Don't try to spin up a local server — the cloud sandbox isn't reachable from
+  the user's browser.
+- The `html-previews` branch is throwaway and only ever contains preview `.html`
+  files. To clean up, delete individual files or the whole branch.


### PR DESCRIPTION
## Summary
Adds a new `html` skill that enables building single static HTML pages and publishing them to a temporary `html-previews` branch for browser preview via htmlpreview.github.io.

## Changes
- **New skill documentation** (`.claude/skills/html/SKILL.md`): Comprehensive guide for the html skill including:
  - Purpose: Build and preview single-file HTML designs on demand
  - Workflow: Uses a dedicated `html-previews` branch with git worktrees to isolate preview files from the working branch
  - Step-by-step instructions for generating unique preview filenames, publishing via separate worktree, and sharing temporary URLs
  - Notes on private repo access and cleanup procedures

- **Updated skills index** (`.claude/skills/README.md`): Added entry linking to the new html skill

## Implementation Details
The skill leverages git worktrees to safely publish HTML previews to an orphan `html-previews` branch without affecting the current working branch or tree. Previews are served via htmlpreview.github.io, which fetches raw files from GitHub. Each preview gets a unique filename (`preview-<random>.html`) to support multiple concurrent previews and easy revisions.

https://claude.ai/code/session_01KfgpNt661eBb5L5mPSPMUD