### PR TITLE
ADR: Entity summaries synthesize across linked entities

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,12 @@ Per-route sub-prompt that fires after approve/edit, before any writes, asking wh
 **Ingest**:
 One end-to-end run from source to (possibly partial) approved facts. Identified by `ingest_id`; recorded on every entity stub and alias as `created_by_ingest` / `added_by_ingest`.
 
+### Summarizer-stage terms
+
+**Linked entity**:
+Entity sharing at least one fact with a given entity via `fact_targets`. Symmetric relation. A summary regeneration of an entity propagates to its linked entities.
+_Avoid_: connected entity, related entity, neighbour.
+
 ## Relationships
 
 - A **Reading** produces zero or more **Plans** (one per replan).
@@ -71,6 +77,7 @@ One end-to-end run from source to (possibly partial) approved facts. Identified 
 - Extraction emits one **Proposal** per **Route**.
 - A **Bundle** is the runtime view of one **Claim group** during review.
 - Approving a **Bundle** creates one **Fact** plus N **Fact targets** (one per checked route) in a single DB transaction.
+- Two entities are **linked** when a **Fact** targets both; regenerating one entity's summary propagates to its **linked entities**.
 
 ## Invariants
 

--- a/docs/adr/0005-summaries-synthesize-across-linked-entities.md
+++ b/docs/adr/0005-summaries-synthesize-across-linked-entities.md
@@ -1,0 +1,30 @@
+# Entity summaries synthesize across linked entities
+
+Stage 4 generates an entity's summary prose with an LLM that receives,
+alongside the entity's own facts, the facts of every *linked* entity —
+any entity co-targeted by a shared fact. The summary prose may
+therefore state and cite a claim drawn from a linked entity's facts
+even though that fact does not target this entity, so a new fact on one
+entity propagates to re-summarize its linked entities (one hop).
+
+## Considered Options
+
+- **Self-only.** Each summary uses only its own entity's facts.
+  Rejected: cross-entity context is impossible, and a neighbour's page
+  goes silently stale once a relevant fact lands on a linked entity.
+- **Pulled-in facts.** An entity page renders the facts of its linked
+  entities directly. Rejected: redefines "entity page = its own
+  approved facts", double-counts facts across pages, and bloats every
+  page with its neighbourhood.
+
+## Consequences
+
+- The `## Facts` section still lists only the entity's own
+  `fact_targets`. A summary sentence drawn from a linked fact renders a
+  cross-reference footnote pointing at the linked entity's page
+  (anchored to that fact), not a duplicated citation.
+- The entity-page staleness hash must include linked entities' facts,
+  not just the entity's own — see `docs/architecture/staleness.md`.
+- One new fact on a well-connected hub entity can force LLM
+  re-summarization of every linked entity. Propagation is capped at one
+  hop (no transitive cascade) to bound this cost.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,3 +80,4 @@ nav:
       - adr/0002-status-edit-audit-asymmetry.md
       - adr/0003-wiki-state-lives-inside-the-wiki.md
       - adr/0004-sqlite-replaces-yaml-wiki-store.md
+      - adr/0005-summaries-synthesize-across-linked-entities.md


### PR DESCRIPTION
## Summary

Documents the architectural decision that entity summaries are generated with context from linked entities (those sharing facts), enabling cross-entity awareness in summary prose while maintaining a one-hop propagation boundary to control re-summarization costs.

## Changes

- **New ADR 0005**: Establishes that Stage 4 summary generation receives facts from all linked entities, not just the entity's own facts. Documents the rejected alternatives (self-only summaries and pulled-in facts) and key consequences including staleness hash requirements and propagation scope.

- **Updated CONTEXT.md**: 
  - Added "Linked entity" definition to the Summarizer-stage terms section, clarifying it as a symmetric relation between entities sharing at least one fact
  - Added relationship invariant documenting that linked entities trigger summary regeneration propagation

- **Updated mkdocs.yml**: Registered the new ADR in the documentation navigation

## Notable Details

The ADR clarifies important implementation constraints:
- The `## Facts` section still lists only the entity's own facts; cross-references to linked facts render as footnotes
- Entity staleness hashing must include linked entities' facts to prevent stale summaries
- Propagation is intentionally capped at one hop to prevent transitive cascades that could force re-summarization of entire entity graphs

https://claude.ai/code/session_017bVHJbuDmQC89pSYXEmMDn