### PR TITLE
Switch default model from Claude Sonnet to GLM 5.1

### DIFF
--- a/docs/architecture/repository-layout.md
+++ b/docs/architecture/repository-layout.md
@@ -88,7 +88,7 @@ wikis:
 openrouter:
   api_key_env: OPENROUTER_API_KEY
 models:
-  primary: anthropic/claude-sonnet-4-5
+  primary: z-ai/glm-5.1
   primary_context_window: 200000
 preamble:
   budget_fraction: 0.8

--- a/docs/architecture/staleness.md
+++ b/docs/architecture/staleness.md
@@ -20,7 +20,7 @@ inputs:
   corrections_sha256: jk0lm1...          # .transcription-corrections.yaml
   entity_index_sha256: n2o3p4...         # canonical serialization of the in-memory index
   preamble_sha256: q5r6s7...             # the fully-assembled preamble string
-  model: anthropic/claude-sonnet-4-5
+  model: z-ai/glm-5.1
   model_params_sha256: t8u9v0...         # temperature, max_tokens, etc.
 generated_at: 2026-04-20T14:32:00Z
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -64,8 +64,8 @@ wikis:
 openrouter:
   api_key_env: OPENROUTER_API_KEY
 models:
-  primary: anthropic/claude-sonnet-4-5
-  extractor: anthropic/claude-sonnet-4-5   # accepted but unused in Phase 1
+  primary: z-ai/glm-5.1
+  extractor: z-ai/glm-5.1   # accepted but unused in Phase 1
   primary_context_window: 200000
 preamble:
   budget_fraction: 0.8

--- a/src/auto_lorebook/config.py
+++ b/src/auto_lorebook/config.py
@@ -34,7 +34,7 @@ class OpenRouterConfig:
 class ModelsConfig:
     """Models section of config.yaml."""
 
-    primary: str = "anthropic/claude-sonnet-4-5"
+    primary: str = "z-ai/glm-5.1"
     primary_context_window: int = 200_000
     extractor: str | None = None
     planner: str | None = None
@@ -179,7 +179,7 @@ def load_config(home: Path | None = None) -> Config:
         api_key_env=or_raw.get("api_key_env", "OPENROUTER_API_KEY"),
     )
     models = ModelsConfig(
-        primary=models_raw.get("primary", "anthropic/claude-sonnet-4-5"),
+        primary=models_raw.get("primary", "z-ai/glm-5.1"),
         primary_context_window=int(models_raw.get("primary_context_window", 200_000)),
         extractor=models_raw.get("extractor"),
         planner=models_raw.get("planner"),
@@ -259,7 +259,7 @@ def save_last_context(
 
 
 _DEFAULT_API_KEY_ENV = "OPENROUTER_API_KEY"
-_DEFAULT_MODEL = "anthropic/claude-sonnet-4-5"
+_DEFAULT_MODEL = "z-ai/glm-5.1"
 _CREDENTIALS_FILE = "credentials"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -286,7 +286,7 @@ def test_interactive_setup_writes_config_and_skeleton(
     assert raw["wikis"][0] == {"nickname": nick, "path": str(wiki.resolve())}
     assert cfg.resolve_active_wiki(None) == wiki.resolve()
     assert cfg.openrouter.api_key_env == "OPENROUTER_API_KEY"
-    assert cfg.models.primary == "anthropic/claude-sonnet-4-5"
+    assert cfg.models.primary == "z-ai/glm-5.1"
     # wiki skeleton created
     assert (wiki / "characters").is_dir()
     assert (wiki / "concepts").is_dir()


### PR DESCRIPTION
## Summary
Updates the default AI model used throughout the application from `anthropic/claude-sonnet-4-5` to `z-ai/glm-5.1`.

## Changes
- Updated default model constant in `config.py` (3 locations):
  - `ModelsConfig.primary` class default
  - `load_config()` function default
  - `_DEFAULT_MODEL` module constant
- Updated documentation examples in:
  - `docs/getting-started/installation.md` (config examples)
  - `docs/architecture/repository-layout.md` (config example)
  - `docs/architecture/staleness.md` (metadata example)
- Updated test assertion in `tests/test_config.py` to expect the new default model

## Notes
This change affects the default model selection when no explicit model is configured. Users with existing configurations specifying `anthropic/claude-sonnet-4-5` will not be affected.

https://claude.ai/code/session_01UEnoXvxLBS4hYVzetiB6KA