### PR TITLE
Refactor pipeline state detection to use segments instead of ingests

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -33,8 +33,9 @@ inside each wiki under `<wiki>/.wiki-state/`. See
 [repository layout](../architecture/repository-layout.md) for the
 full split.
 
-On first invocation of `auto-lorebook ingest`, the tool detects a
-missing `~/.auto-lorebook/config.yaml` and prompts for:
+On the first invocation of `auto-lorebook ingest` or `auto-lorebook
+run`, the tool detects a missing `~/.auto-lorebook/config.yaml` and
+prompts for:
 
 - A nickname for your first wiki.
 - The wiki repo path (registered with that nickname and marked active).

--- a/src/auto_lorebook/commands/_shared.py
+++ b/src/auto_lorebook/commands/_shared.py
@@ -46,6 +46,20 @@ def resolve_wiki(cfg: cfg_mod.Config, args: argparse.Namespace) -> Path:
     return cfg.resolve_active_wiki(override)
 
 
+def load_or_create_config(*, no_interactive: bool) -> cfg_mod.Config:
+    """Load config; run first-run interactive setup when it's missing.
+
+    :raises MissingConfigError: config absent and no_interactive set
+    :raises KeyboardInterrupt: user aborted setup
+    """
+    try:
+        return cfg_mod.load_config()
+    except cfg_mod.MissingConfigError:
+        if no_interactive:
+            raise
+        return cfg_mod.interactive_setup()
+
+
 def finalize_context(
     info: Info,
     info_path: Path,

--- a/src/auto_lorebook/commands/ingest.py
+++ b/src/auto_lorebook/commands/ingest.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from auto_lorebook import config as cfg_mod
 from auto_lorebook import info_yaml, source_store, ytdlp
 from auto_lorebook import source_id as sid_mod
-from auto_lorebook.commands._shared import finalize_context
+from auto_lorebook.commands._shared import finalize_context, load_or_create_config
 from auto_lorebook.timestamps import format_iso_now
 
 if TYPE_CHECKING:
@@ -115,7 +115,7 @@ def add_parser(
 def run(args: argparse.Namespace) -> int:
     """Execute the ingest command."""
     try:
-        cfg = _load_or_create_config(no_interactive=args.no_interactive)
+        cfg = load_or_create_config(no_interactive=args.no_interactive)
     except cfg_mod.ConfigError as e:
         _logger.error("%s", e)
         return 1
@@ -127,15 +127,6 @@ def run(args: argparse.Namespace) -> int:
     if args.url_or_path.startswith(("http://", "https://")):
         return _run_from_url(args, cfg, wiki_repo)
     return _run_from_local(args, cfg, wiki_repo)
-
-
-def _load_or_create_config(*, no_interactive: bool) -> cfg_mod.Config:
-    try:
-        return cfg_mod.load_config()
-    except cfg_mod.MissingConfigError:
-        if no_interactive:
-            raise
-        return cfg_mod.interactive_setup()
 
 
 @dataclass

--- a/src/auto_lorebook/commands/run.py
+++ b/src/auto_lorebook/commands/run.py
@@ -18,6 +18,7 @@ from auto_lorebook.commands import generate_reading as generate_reading_cmd
 from auto_lorebook.commands import ingest as ingest_cmd
 from auto_lorebook.commands import plan as plan_cmd
 from auto_lorebook.commands import review as review_cmd
+from auto_lorebook.commands._shared import load_or_create_config
 from auto_lorebook.interactive import _is_interactive
 from auto_lorebook.pipeline_state import Stage, first_missing_stage
 
@@ -181,10 +182,14 @@ def _build_stage_args(
 def run(args: argparse.Namespace) -> int:
     """Execute the run command: loop through stages until done."""
     try:
-        cfg = cfg_mod.load_config()
+        cfg = load_or_create_config(
+            no_interactive=getattr(args, "no_interactive", False)
+        )
     except cfg_mod.ConfigError as e:
         _logger.error("%s", e)
         return 1
+    except KeyboardInterrupt:
+        return 130
 
     wiki_override: str | None = getattr(args, "wiki", None)
     # url_or_sid = real positional; source_id = --source-id flag override.

--- a/src/auto_lorebook/pipeline_state.py
+++ b/src/auto_lorebook/pipeline_state.py
@@ -34,16 +34,20 @@ def first_missing_stage(
 
     Detector table:
       INGEST           : sources row exists in DB (lazy-backfills from info.yaml)
-      GENERATE_READING : ingests row exists (DB-backed reading state)
+      GENERATE_READING : segments rows exist (Stage 1a structure written)
       APPROVE_READING  : <wiki>/sources/<sid>/reading.md exists
       PLAN             : pending/<sid>/plan.yaml exists
       EXTRACT          : pending/<sid>/proposals/ absent
       REVIEW           : pending/<sid>/proposals/ exists and non-empty
       done             : proposals dir exists and empty
+
+    GENERATE_READING keys off segments, not the ingests row: `ingest`
+    creates a bare ingests row, so its presence cannot distinguish
+    "ingested" from "reading generated".
     """
     from auto_lorebook import db as db_mod  # noqa: PLC0415
     from auto_lorebook import info_yaml as info_yaml_mod  # noqa: PLC0415
-    from auto_lorebook import reading_sidecar as sidecar_mod  # noqa: PLC0415
+    from auto_lorebook import structure_store as structure_store_mod  # noqa: PLC0415
 
     wiki_root: Path = cfg.resolve_active_wiki(wiki_override)
 
@@ -53,8 +57,8 @@ def first_missing_stage(
         if not ingested:
             return Stage.INGEST
 
-        # check DB for reading state
-        has_reading_state = sidecar_mod.exists(conn, source_id)
+        # Stage 1a writes segments; bare ingests row alone is not enough
+        has_reading_state = structure_store_mod.has_structure(conn, source_id)
     finally:
         conn.close()
 

--- a/src/auto_lorebook/structure_store.py
+++ b/src/auto_lorebook/structure_store.py
@@ -312,6 +312,14 @@ def read_bullets(conn: sqlite3.Connection, ingest_id: str) -> ReadingBullets:
 # ---------------------------------------------------------------------------
 
 
+def has_structure(conn: sqlite3.Connection, ingest_id: str) -> bool:
+    """Return True if any segments row exists for ingest_id (Stage 1a output)."""
+    row = conn.execute(
+        "SELECT 1 FROM segments WHERE ingest_id=? LIMIT 1", (ingest_id,)
+    ).fetchone()
+    return row is not None
+
+
 def list_segments(conn: sqlite3.Connection, ingest_id: str) -> list[SegmentRow]:
     """Return all SegmentRows for ingest_id sorted by start."""
     rows = conn.execute(

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -37,7 +37,11 @@ def _mk_info_yaml(wiki: Path, sid: str) -> None:
 
 
 def _mk_reading_sidecar(wiki: Path, sid: str) -> None:
-    """Seed ingests row in wiki DB (DB-backed reading state)."""
+    """Seed bare ingests row in wiki DB — mirrors what `ingest` writes.
+
+    `ingest` creates this row via `record_in_db`; it does NOT mean the
+    reading has been generated. Generate-reading is detected by segments.
+    """
     from auto_lorebook import db as db_mod  # noqa: PLC0415
     from auto_lorebook import wiki_state  # noqa: PLC0415
 
@@ -54,6 +58,24 @@ def _mk_reading_sidecar(wiki: Path, sid: str) -> None:
             " name_corrections_json, session_date) "
             "VALUES (?,?,?,'reading',NULL,'{}',NULL)",
             (sid, sid, "2026-01-01T00:00:00Z"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _mk_structure(wiki: Path, sid: str) -> None:
+    """Seed a segments row (Stage 1a output) — generate-reading done."""
+    from auto_lorebook import db as db_mod  # noqa: PLC0415
+    from auto_lorebook import wiki_state  # noqa: PLC0415
+
+    _mk_reading_sidecar(wiki, sid)
+    conn = db_mod.open(wiki_state.wiki_db_path(wiki))
+    try:
+        conn.execute(
+            "INSERT OR IGNORE INTO segments "
+            "(ingest_id, segment_id, start, end, title) VALUES (?,?,?,?,?)",
+            (sid, "seg-001", "0:00:00", "0:01:00", "Opening"),
         )
         conn.commit()
     finally:
@@ -101,10 +123,12 @@ SID = "yt-abc12345678"
         ([], Stage.INGEST),
         # info.yaml only → GENERATE_READING
         ([_mk_info_yaml], Stage.GENERATE_READING),
-        # info.yaml + reading sidecar → APPROVE_READING
-        ([_mk_info_yaml, _mk_reading_sidecar], Stage.APPROVE_READING),
-        # info.yaml + reading sidecar + wiki reading.md → PLAN
-        ([_mk_info_yaml, _mk_reading_sidecar, _mk_wiki_reading], Stage.PLAN),
+        # info.yaml + bare ingests row (post-ingest) → still GENERATE_READING
+        ([_mk_info_yaml, _mk_reading_sidecar], Stage.GENERATE_READING),
+        # info.yaml + segments (reading generated) → APPROVE_READING
+        ([_mk_info_yaml, _mk_structure], Stage.APPROVE_READING),
+        # info.yaml + segments + wiki reading.md → PLAN
+        ([_mk_info_yaml, _mk_structure, _mk_wiki_reading], Stage.PLAN),
         # info.yaml + wiki reading.md + plan.yaml + absent proposals dir → EXTRACT
         (
             [_mk_info_yaml, _mk_wiki_reading, _mk_plan_yaml],
@@ -124,8 +148,9 @@ SID = "yt-abc12345678"
     ids=[
         "empty→INGEST",
         "info.yaml→GENERATE_READING",
-        "sidecar→APPROVE_READING",
-        "wiki-reading→PLAN",
+        "bare-ingests→GENERATE_READING",
+        "structure→APPROVE_READING",
+        "structure+wiki-reading→PLAN",
         "plan+absent-proposals→EXTRACT",
         "plan+proposals→REVIEW",
         "plan+empty-proposals→None",

--- a/tests/test_run_cmd.py
+++ b/tests/test_run_cmd.py
@@ -24,12 +24,14 @@ def _args(
     *,
     yes: bool = False,
     auto_approve: bool = False,
+    no_interactive: bool = False,
 ) -> argparse.Namespace:
     return argparse.Namespace(
         source_id=source_id,
         wiki=wiki,
         yes=yes,
         auto_approve=auto_approve,
+        no_interactive=no_interactive,
     )
 
 
@@ -256,6 +258,39 @@ def test_config_error_returns_1() -> None:
         result = run_cmd.run(_args())
 
     assert result == 1
+
+
+def test_first_run_triggers_interactive_setup() -> None:
+    """Missing config.yaml invokes interactive_setup when interactive."""
+    setup_mock = MagicMock(return_value=MagicMock())
+    with (
+        patch(
+            "auto_lorebook.commands.run.cfg_mod.load_config",
+            side_effect=cfg_mod.MissingConfigError("not found"),
+        ),
+        patch("auto_lorebook.commands.run.cfg_mod.interactive_setup", setup_mock),
+        patch("auto_lorebook.commands.run.first_missing_stage", return_value=None),
+    ):
+        result = run_cmd.run(_args())
+
+    assert setup_mock.called
+    assert result == 0
+
+
+def test_first_run_no_interactive_returns_1() -> None:
+    """`--no-interactive` surfaces the missing-config error without prompting."""
+    setup_mock = MagicMock()
+    with (
+        patch(
+            "auto_lorebook.commands.run.cfg_mod.load_config",
+            side_effect=cfg_mod.MissingConfigError("not found"),
+        ),
+        patch("auto_lorebook.commands.run.cfg_mod.interactive_setup", setup_mock),
+    ):
+        result = run_cmd.run(_args(no_interactive=True))
+
+    assert result == 1
+    assert not setup_mock.called
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR refactors the pipeline state detection logic to correctly distinguish between the "ingested" and "reading generated" stages by keying off the presence of segments (Stage 1a output) rather than the ingests database row. It also extracts common config-loading logic into a shared utility and adds support for non-interactive mode to the `run` command.

## Key Changes

- **Pipeline state detection**: Changed `first_missing_stage()` to check for segments rows instead of the ingests row when determining if `GENERATE_READING` is complete. The ingests row is created by `ingest` but doesn't indicate whether reading generation has occurred.

- **New `has_structure()` function**: Added to `structure_store.py` to check if any segments exist for a given ingest_id, providing a reliable indicator that Stage 1a has completed.

- **Extracted config loading logic**: Moved `_load_or_create_config()` from `ingest.py` to `_shared.py` as `load_or_create_config()` so it can be reused by both `ingest` and `run` commands.

- **Enhanced `run` command**: Now supports `--no-interactive` flag and uses the shared config-loading utility. Handles `KeyboardInterrupt` during interactive setup by returning exit code 130.

- **Test updates**: Updated `test_pipeline_state.py` to reflect the new semantics:
  - Bare ingests row (post-ingest) now correctly maps to `GENERATE_READING` stage
  - Segments row (post-generate-reading) maps to `APPROVE_READING` stage
  - Added new test helper `_mk_structure()` to seed segments rows

- **Documentation**: Updated installation guide to clarify that both `ingest` and `run` commands trigger interactive setup on first invocation.

## Implementation Details

The key insight is that `ingest` creates a bare ingests row via `record_in_db()`, but this alone doesn't mean reading generation has completed. The presence of segments rows (created by Stage 1a) is the reliable indicator that the reading has been generated and is ready for approval.

https://claude.ai/code/session_01QRyudXHEnvKQGecynZLXyJ