### PR TITLE
Show transcript window behind claims in approve-reading

### DIFF
--- a/docs/pipeline/reading.md
+++ b/docs/pipeline/reading.md
@@ -336,7 +336,14 @@ Below the segment list, any persisted gap-check warnings are rendered as
 ⚠ Possible coverage gap: blocks (one per stretch, transcript order).
 
 **Per-segment prompt** — shows segment body (up to 60 lines) and current /
-pending status:
+pending status. Each claim bullet is followed by the verbatim transcript
+cues behind it — the cues overlapping that bullet's `locator_hint` window —
+so the reviewer can compare the claim against what was actually said and
+against the clickable source timestamp without leaving the terminal. The
+transcript shown is the raw (globally-corrected) transcript, not the
+reading's `name_corrections`-applied text, so mishearings stay visible.
+Plain-text sources (no cue timing) and missing transcripts fall back to
+plain bullets:
 
 | Key | Action |
 |-----|--------|

--- a/src/auto_lorebook/commands/approve_reading.py
+++ b/src/auto_lorebook/commands/approve_reading.py
@@ -292,8 +292,14 @@ def _load_segment_body(
     segment_id: str,
     wiki_override: str | None = None,
 ) -> str:
-    """Render segment body from DB for interactive display."""
+    """Render segment body from DB for interactive display.
+
+    Each claim bullet is annotated with the verbatim transcript window behind
+    it so the reviewer can compare the claim against what was said.
+    """
+    from auto_lorebook import corrections as corrections_mod  # noqa: PLC0415
     from auto_lorebook import reading_assembly as assembly_mod  # noqa: PLC0415
+    from auto_lorebook import transcript as transcript_mod  # noqa: PLC0415
 
     wiki_repo = cfg.resolve_active_wiki(wiki_override)
     conn = db_mod.open(wiki_state_mod.wiki_db_path(wiki_repo))
@@ -306,11 +312,20 @@ def _load_segment_body(
         bullets_map = structure_store_mod.read_bullets(conn, source_id)
         seg_bullets = bullets_map.segments.get(segment_id, [])
         flags = list(seg_row.flags)
-        return assembly_mod.build_segment_body(
+        # transcript powers the claim-vs-transcript comparison; missing or
+        # plain-text transcripts degrade to plain bullets.
+        loaded: transcript_mod.LoadedTranscript | None = None
+        try:
+            cors = corrections_mod.read(conn, wiki_repo=wiki_repo)
+            loaded = transcript_mod.load(wiki_repo, info, cors)
+        except transcript_mod.TranscriptError:
+            loaded = None
+        return assembly_mod.build_segment_review_body(
             seg_bullets=seg_bullets,
             flags=flags,
             source_url=info.source_url,
             name_corrections=sc.name_corrections,
+            transcript=loaded,
         )
     finally:
         conn.close()

--- a/src/auto_lorebook/reading_assembly.py
+++ b/src/auto_lorebook/reading_assembly.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 
     from auto_lorebook.info_yaml import Info
     from auto_lorebook.reading_sidecar import IngestState
+    from auto_lorebook.srt import Cue
+    from auto_lorebook.transcript import LoadedTranscript
 
 _EMPTY_MARKER = "_No claims extracted from this segment._"
 
@@ -105,6 +107,70 @@ def build_segment_body(
             else:
                 parts.append(f"- {text} [{anchor_ts}]")
     return "\n\n".join(parts) + "\n"
+
+
+def build_segment_review_body(
+    *,
+    seg_bullets: list,
+    flags: list[dict],
+    source_url: str | None,
+    name_corrections: dict[str, str],
+    transcript: LoadedTranscript | None,
+) -> str:
+    """Per-segment review body for `approve-reading`.
+
+    Each claim bullet is followed by the verbatim transcript cues behind it —
+    cues overlapping the bullet's `locator_hint` window. Interactive-display
+    only; never written to `reading.md`.
+
+    Falls back to plain `build_segment_body` output when `transcript` is None
+    or has no cues (plain-text source).
+    """
+    cues = transcript.cues if transcript is not None else None
+    if not cues:
+        return build_segment_body(
+            seg_bullets=seg_bullets,
+            flags=flags,
+            source_url=source_url,
+            name_corrections=name_corrections,
+        )
+
+    parts: list[str] = []
+    for flag in flags:
+        locator = parse_timestamp(str(flag.get("locator") or "0:00:00"))
+        ts = format_timestamp(locator)
+        kind = flag.get("kind", "other")
+        span = flag.get("span", "")
+        note = flag.get("note")
+        note_str = f"; {note}" if note else ""
+        parts.append(f"- [{ts}] uncertain {kind}: {span}{note_str}")
+    if not seg_bullets:
+        parts.append(_EMPTY_MARKER)
+    else:
+        for b in seg_bullets:
+            text = apply_name_corrections(b.text, name_corrections)
+            anchor_ts = format_timestamp(b.anchor)
+            link = linkify_timestamp(source_url, b.anchor)
+            bullet = (
+                f"- {text} [[{anchor_ts}]]({link})"
+                if link
+                else f"- {text} [{anchor_ts}]"
+            )
+            window = _transcript_window_block(
+                cues, b.locator_hint_start, b.locator_hint_end
+            )
+            parts.append(f"{bullet}\n{window}")
+    return "\n\n".join(parts) + "\n"
+
+
+def _transcript_window_block(cues: tuple[Cue, ...], start: float, end: float) -> str:
+    """Indented verbatim transcript lines for cues overlapping `[start, end)`."""
+    kept = [c for c in cues if c.end > start and c.start < end]
+    label = f"    transcript {format_timestamp(start)}-{format_timestamp(end)}:"
+    if not kept:
+        return f"{label} (no transcript lines in window)"
+    lines = "\n".join(f"      [{format_timestamp(c.start)}] {c.text}" for c in kept)
+    return f"{label}\n{lines}"
 
 
 def _render_frontmatter(info: Info, sidecar: IngestState) -> str:

--- a/tests/test_reading_assembly.py
+++ b/tests/test_reading_assembly.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from auto_lorebook.reading_assembly import assemble, build_segment_body
+from auto_lorebook.reading_assembly import (
+    assemble,
+    build_segment_body,
+    build_segment_review_body,
+)
+from auto_lorebook.srt import Cue
+from auto_lorebook.stage1b import Bullet
+from auto_lorebook.transcript import LoadedTranscript
 from tests._reading_fixtures import (
     _bullets,
     _info,
@@ -171,6 +178,138 @@ class TestPureNoFilesystem:
             sidecar=_sidecar(),
         )
         assert isinstance(result, str)
+
+
+def _bullet(text: str, anchor: float, hint_start: float, hint_end: float) -> Bullet:
+    return Bullet(
+        text=text,
+        anchor=anchor,
+        locator_hint_start=hint_start,
+        locator_hint_end=hint_end,
+    )
+
+
+def _loaded(cues: list[Cue]) -> LoadedTranscript:
+    return LoadedTranscript(text_for_llm="", total_duration=0.0, cues=tuple(cues))
+
+
+class TestBuildSegmentReviewBody:
+    """approve-reading per-segment body: claim bullets vs. transcript window."""
+
+    def test_transcript_lines_follow_each_bullet(self) -> None:
+        bullets = [_bullet("Theron founded Aldara", 150.0, 135.0, 165.0)]
+        cues = [
+            Cue(index=1, start=120.0, end=160.0, text="Theron founded Aldara then."),
+            Cue(index=2, start=200.0, end=210.0, text="Unrelated later cue."),
+        ]
+        body = build_segment_review_body(
+            seg_bullets=bullets,
+            flags=[],
+            source_url=None,
+            name_corrections={},
+            transcript=_loaded(cues),
+        )
+        assert "- Theron founded Aldara [0:02:30]" in body
+        assert "transcript 0:02:15-0:02:45:" in body
+        assert "[0:02:00] Theron founded Aldara then." in body
+        assert "Unrelated later cue." not in body
+
+    def test_overlapping_cue_starting_before_window_included(self) -> None:
+        # cue starts before the window but spans into it (coarse manual SRT)
+        cues = [Cue(index=1, start=60.0, end=200.0, text="Long spanning cue.")]
+        bullets = [_bullet("claim", 150.0, 135.0, 165.0)]
+        body = build_segment_review_body(
+            seg_bullets=bullets,
+            flags=[],
+            source_url=None,
+            name_corrections={},
+            transcript=_loaded(cues),
+        )
+        assert "Long spanning cue." in body
+
+    def test_empty_window_shows_marker(self) -> None:
+        cues = [Cue(index=1, start=500.0, end=510.0, text="far away cue")]
+        bullets = [_bullet("claim", 150.0, 135.0, 165.0)]
+        body = build_segment_review_body(
+            seg_bullets=bullets,
+            flags=[],
+            source_url=None,
+            name_corrections={},
+            transcript=_loaded(cues),
+        )
+        assert "(no transcript lines in window)" in body
+        assert "far away cue" not in body
+
+    def test_none_transcript_falls_back_to_plain(self) -> None:
+        bullets = [_bullet("claim", 150.0, 135.0, 165.0)]
+        plain = build_segment_body(
+            seg_bullets=bullets, flags=[], source_url=None, name_corrections={}
+        )
+        review = build_segment_review_body(
+            seg_bullets=bullets,
+            flags=[],
+            source_url=None,
+            name_corrections={},
+            transcript=None,
+        )
+        assert review == plain
+        assert "transcript" not in review
+
+    def test_plain_text_transcript_falls_back_to_plain(self) -> None:
+        bullets = [_bullet("claim", 150.0, 135.0, 165.0)]
+        plain = build_segment_body(
+            seg_bullets=bullets, flags=[], source_url=None, name_corrections={}
+        )
+        lt = LoadedTranscript(text_for_llm="raw", total_duration=0.0, cues=None)
+        review = build_segment_review_body(
+            seg_bullets=bullets,
+            flags=[],
+            source_url=None,
+            name_corrections={},
+            transcript=lt,
+        )
+        assert review == plain
+
+    def test_anchor_link_preserved_with_source_url(self) -> None:
+        bullets = [_bullet("claim", 150.0, 135.0, 165.0)]
+        cues = [Cue(index=1, start=140.0, end=150.0, text="said it here")]
+        body = build_segment_review_body(
+            seg_bullets=bullets,
+            flags=[],
+            source_url="https://youtube.com/watch?v=abc",
+            name_corrections={},
+            transcript=_loaded(cues),
+        )
+        assert "[[0:02:30]](https://youtube.com/watch?v=abc&t=150)" in body
+        assert "[0:02:20] said it here" in body
+
+    def test_flags_still_rendered(self) -> None:
+        flags = [
+            {
+                "locator": "0:05:47",
+                "span": "a place name",
+                "kind": "name",
+                "note": "unclear",
+            }
+        ]
+        body = build_segment_review_body(
+            seg_bullets=[],
+            flags=flags,
+            source_url=None,
+            name_corrections={},
+            transcript=_loaded([Cue(index=1, start=0.0, end=5.0, text="hi")]),
+        )
+        assert "uncertain name: a place name; unclear" in body
+
+    def test_empty_bullets_with_transcript_shows_marker(self) -> None:
+        body = build_segment_review_body(
+            seg_bullets=[],
+            flags=[],
+            source_url=None,
+            name_corrections={},
+            transcript=_loaded([Cue(index=1, start=0.0, end=5.0, text="hi")]),
+        )
+        assert "_No claims extracted from this segment._" in body
 
 
 class TestFixtureMatchesPipeline:

--- a/tests/test_reading_commands.py
+++ b/tests/test_reading_commands.py
@@ -735,6 +735,30 @@ class TestApproveReadingInteractive:
         out = capsys.readouterr().out
         assert "Approved" in out
 
+    def test_per_segment_view_shows_transcript(
+        self,
+        tmp_home: Path,
+        ingested_wiki: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Opening a segment shows the transcript window behind each claim."""
+        _write_user_config(tmp_home, ingested_wiki)
+        self._force_tty(monkeypatch)
+        # open seg-002 (has the Theron claim), back to outer, quit
+        self._patch_inputs(monkeypatch, ["2", "b", "q"])
+        self._generate(monkeypatch)
+
+        rc = approve_reading_cmd.run(_args(source_id="yt-abc12345678", yes=False))
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        # claim bullet text
+        assert "King Theron founded Aldara" in out
+        # transcript window label + verbatim cue behind the claim
+        assert "transcript" in out
+        assert "in the Second Age" in out
+
     def test_ctrl_c_in_outer_writes_nothing(
         self,
         tmp_home: Path,


### PR DESCRIPTION
## Summary
Enhance the `approve-reading` interactive command to display the verbatim transcript cues behind each claim bullet, allowing reviewers to compare claims against what was actually said without leaving the terminal.

## Key Changes
- **New function `build_segment_review_body()`** in `reading_assembly.py`: Renders segment bodies with transcript context for interactive review. Each claim bullet is followed by the verbatim transcript cues that overlap its `locator_hint` window.
- **Helper function `_transcript_window_block()`**: Formats the transcript cues for a given time window, showing timestamps and text. Displays a marker when no cues exist in the window.
- **Updated `_load_segment_body()`** in `approve_reading.py`: Now loads the transcript and passes it to `build_segment_review_body()` instead of the plain `build_segment_body()`. Gracefully degrades to plain bullets if transcript loading fails or transcript is plain-text (no cues).
- **Comprehensive test coverage** in `test_reading_assembly.py`: New `TestBuildSegmentReviewBody` class with 8 tests covering:
  - Transcript lines following bullets
  - Overlapping cues starting before the window
  - Empty windows with fallback marker
  - Fallback to plain output when transcript is None or plain-text
  - Anchor link preservation with source URLs
  - Flag rendering alongside transcript
  - Empty bullets marker with transcript present
- **Integration test** in `test_reading_commands.py`: Verifies the per-segment view displays both claim text and transcript content.
- **Documentation update** in `docs/pipeline/reading.md`: Explains the new per-segment transcript display feature and fallback behavior.

## Implementation Details
- The transcript shown is the raw (globally-corrected) transcript, not the reading's `name_corrections`-applied text, so mishearings remain visible for review.
- Cues are filtered to those overlapping the bullet's `locator_hint_start` and `locator_hint_end` window.
- Graceful degradation: missing transcripts or plain-text sources (no cue timing) fall back to the original plain bullet output.
- Timestamps are formatted consistently and linked to source URLs when available.

https://claude.ai/code/session_016ZxvdTatyZE8vz5oRCijVK